### PR TITLE
revert fetch require

### DIFF
--- a/src/ocean/utils/WebServiceConnector.ts
+++ b/src/ocean/utils/WebServiceConnector.ts
@@ -1,7 +1,9 @@
-import fetch, { BodyInit, RequestInit, Response } from 'node-fetch'
+import { BodyInit, RequestInit, Response } from 'node-fetch'
 import fs from 'fs'
 import { Logger } from '../../utils'
 import save from 'save-file'
+
+const fetch = require('node-fetch')
 
 /**
  * Provides a common interface to web services.


### PR DESCRIPTION
Not sure what the right solution is to have browsers use `window.fetch`, either by solving it with build tool or using e.g. `axios` within WebServiceConnector, but for now we can simply try reverting that change from https://github.com/oceanprotocol/ocean-lib-js/pull/165