### PR TITLE
allow passing infuraProjectId to getConfig

### DIFF
--- a/src/utils/ConfigHelper.ts
+++ b/src/utils/ConfigHelper.ts
@@ -19,16 +19,16 @@ const configs = [
     },
     {
         network: 'rinkeby',
-        url: 'https://rinkeby.infura.io/v3/YOUR-PROJECT-ID',
+        url: 'https://rinkeby.infura.io/v3',
         factoryAddress: '0xcDfEe5D80041224cDCe9AE2334E85B3236385EA3',
         oceanTokenAddress: '0x8967BCF84170c91B0d24D4302C2376283b0B3a07',
-        metadataStoreUri: 'https://aquarius.rinkeby.v3.dev-ocean.com/',
-        providerUri: 'https://provider.rinkeby.v3.dev-ocean.com/',
+        metadataStoreUri: 'https://aquarius.rinkeby.v3.dev-ocean.com',
+        providerUri: 'https://provider.rinkeby.v3.dev-ocean.com',
         poolFactoryAddress: '0xA4531C624A3D88323a1e178DABe1233AF178701B'
     },
     {
         network: 'mainnet',
-        url: 'https://mainnet.infura.io/v3/YOUR-PROJECT-ID',
+        url: 'https://mainnet.infura.io/v3',
         factoryAddress: '0x1234',
         oceanTokenAddress: '0x985dd3d42de1e256d09e1c10f112bccb8015ad41',
         metadataStoreUri: null,
@@ -38,7 +38,7 @@ const configs = [
 ]
 
 export class ConfigHelper {
-    public getConfig(network: string): ConfigHelper {
+    public getConfig(network: string, infuraProjectId?: string): ConfigHelper {
         const confighelp = new ConfigHelper()
         // fill unknown values
         confighelp.factoryAddress = null
@@ -48,16 +48,19 @@ export class ConfigHelper {
         confighelp.metadataStoreUri = null
         confighelp.providerUri = null
         confighelp.poolFactoryAddress = null
+
         const knownconfig = configs.find((c) => c.network === network)
+
         if (knownconfig) {
             confighelp.factoryAddress = knownconfig.factoryAddress
             confighelp.oceanTokenAddress = knownconfig.oceanTokenAddress
-            confighelp.url = knownconfig.url
+            confighelp.url = `${knownconfig.url}/${infuraProjectId}`
             confighelp.network = knownconfig.network
             confighelp.metadataStoreUri = knownconfig.metadataStoreUri
             confighelp.providerUri = knownconfig.providerUri
             confighelp.poolFactoryAddress = knownconfig.poolFactoryAddress
         }
+
         return confighelp
     }
 }


### PR DESCRIPTION
Makes it possible so clients do not have to overwrite the `url` when accessing the config.

```js
const oceanConfig = new ConfigHelper().getConfig('rinkeby', 'xyz')
```