### PR TITLE
refactor config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ npm install @oceanprotocol/lib
 
 ## 🏄 Quick Start
 
-```js
-import { Ocean, ConfigHelper } from '@oceanprotocol/lib'
+```ts
+import { Ocean, Config, ConfigHelper } from '@oceanprotocol/lib'
 
-const defaultConfig = new ConfigHelper().getConfig('rinkeby', 'YOUR_INFURA_PROJECT_ID')
+const defaultConfig: Config = new ConfigHelper().getConfig(
+  'rinkeby',
+  'YOUR_INFURA_PROJECT_ID'
+)
 
 const config = {
   ...defaultConfig,

--- a/src/utils/ConfigHelper.ts
+++ b/src/utils/ConfigHelper.ts
@@ -53,7 +53,7 @@ export class ConfigHelper {
   public getConfig(
     network: ConfigHelperNetworkName | ConfigHelperNetworkId,
     infuraProjectId?: string
-  ): ConfigHelperConfig {
+  ): Config {
     const filterBy = typeof network === 'string' ? 'network' : 'chainId'
     const config = configs.find((c) => c[filterBy] === network)
 

--- a/test/unit/utils/ConfigHelper.test.ts
+++ b/test/unit/utils/ConfigHelper.test.ts
@@ -5,7 +5,7 @@ describe('ConfigHelper', () => {
   it('should get config based on network name', () => {
     const network = 'rinkeby'
     const config = new ConfigHelper().getConfig(network)
-    assert(config.network === network)
+    assert(config.nodeUri.includes(network))
   })
 
   it('should get config based on network name, and add passed Infura ID', () => {
@@ -18,7 +18,7 @@ describe('ConfigHelper', () => {
   it('should get config based on chain ID', () => {
     const network = 4
     const config = new ConfigHelper().getConfig(network)
-    assert(config.chainId === network)
+    assert(config.nodeUri.includes('rinkeby'))
   })
 
   it('should return nothing with unknown network', () => {


### PR DESCRIPTION
Seemed very repetitive to just get an object from an array. And has lots of potential for user-friendly configuration.

So:

- simplify into one small method where passed `network` can be either the network name or the chainID
- unify global config and config helper typings
- add 100% test coverage for `ConfigHelper`
- present as preferred way of setting config in main README

Closes #181