### PR TITLE
fix pool pricing

### DIFF
--- a/src/balancer/OceanPool.ts
+++ b/src/balancer/OceanPool.ts
@@ -70,6 +70,7 @@ export class OceanPool extends Pool {
      * @param {String} token  DataToken address
      * @param {String} amount DataToken amount
      * @param {String} weight DataToken weight
+     * @param {String} oceanAmount Ocean amount
      * @param {String} fee Swap fee. E.g. to get a 0.1% swapFee use `0.001`. The maximum allowed swapFee is `0.1` (10%).
      * @return {String}
      */
@@ -78,6 +79,7 @@ export class OceanPool extends Pool {
     token: string,
     amount: string,
     weight: string,
+    oceanAmount: string,
     fee: string
   ): SubscribablePromise<PoolCreateProgressStep, TransactionReceipt> {
     if (this.oceanAddress == null) {
@@ -101,7 +103,6 @@ export class OceanPool extends Pool {
       }
       const address = createTxid.events.BPoolRegistered.returnValues[0]
       const oceanWeight = 10 - parseFloat(weight)
-      const oceanAmount = (parseFloat(amount) * oceanWeight) / parseFloat(weight)
       this.dtAddress = token
       observer.next(PoolCreateProgressStep.ApprovingDatatoken)
       let txid

--- a/test/unit/balancer/Balancer.test.ts
+++ b/test/unit/balancer/Balancer.test.ts
@@ -125,7 +125,19 @@ describe('Balancer flow', () => {
   })
   it('Alice creates a new OceanPool pool', async () => {
     /// new pool with total DT = 45 , dt weight=90% with swap fee 2%
-    const createTx = await Pool.create(alice, tokenAddress, '45', '9', '0.02')
+    const dtAmount = '45'
+    const dtWeight = '9'
+    const oceanAmount =
+      (parseFloat(dtAmount) * (10 - parseFloat(dtWeight))) / parseFloat(dtWeight)
+    const fee = '0.02'
+    const createTx = await Pool.create(
+      alice,
+      tokenAddress,
+      dtAmount,
+      dtWeight,
+      String(oceanAmount),
+      fee
+    )
     alicePoolAddress = createTx.events.BPoolRegistered.returnValues[0]
     const s = await Pool.getPoolSharesTotalSupply(alicePoolAddress)
     assert(String(s) === '100', 'totalSupply does not match: ' + s)


### PR DESCRIPTION
Breaking Change when creating a balancer pool !

Instead of computing the oceanAmount using a rate of 1 DT = 1 Ocean, now the publisher must fill the desired oceanAmount