### PR TITLE
remove barge defaults overwrites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_script:
   - touch $ADDRESS_FILE
   - echo "{}" >> $ADDRESS_FILE
   - export AQUARIUS_URI="http://172.15.0.5:5000"
-  - export DEPLOY_CONTRACTS="true"
-  - export CONTRACTS_VERSION=v0.5.7
   - bash -x start_ocean.sh --no-dashboard 2>&1 > start_ocean.log &
   - cd ..
   - ./scripts/waitforcontracts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - touch $ADDRESS_FILE
   - echo "{}" >> $ADDRESS_FILE
   - export AQUARIUS_URI="http://172.15.0.5:5000"
+  - export DEPLOY_CONTRACTS="true"
   - bash -x start_ocean.sh --no-dashboard 2>&1 > start_ocean.log &
   - cd ..
   - ./scripts/waitforcontracts.sh


### PR DESCRIPTION
Run CI against latest defaults of Barge. In Barge, `DEPLOY_CONTRACTS` is `true` by default and CI should run against whatever is defined in Barge for the contracts