### PR TITLE
speed up previous order

### DIFF
--- a/src/ocean/Ocean.ts
+++ b/src/ocean/Ocean.ts
@@ -51,7 +51,8 @@ export class Ocean extends Instantiable {
       instanceConfig.config.factoryABI,
       instanceConfig.config.datatokensABI,
       instanceConfig.config.web3Provider,
-      instanceConfig.logger
+      instanceConfig.logger,
+      instanceConfig.config.startBlock
     )
     instance.pool = new OceanPool(
       instanceConfig.config.web3Provider,


### PR DESCRIPTION
Some code refactor:
 - if there is a timeout, no need to check beyond lastBlock - timeout (and this is generous, because we are assuming 1 block/sec)
 - if timeout = 0 , no need to check beyond startBlock


closes #602 