### PR TITLE
add encrypt ddo support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
   - export ADDRESS_FILE="${HOME}/.ocean/ocean-contracts/artifacts/address.json"
+  - export AQUARIUS_VERSION=v2.2.5
   - mkdir "${HOME}/.ocean/"
   - mkdir "${HOME}/.ocean/ocean-contracts/"
   - mkdir "${HOME}/.ocean/ocean-contracts/artifacts"

--- a/src/metadatacache/MetadataCache.ts
+++ b/src/metadatacache/MetadataCache.ts
@@ -95,7 +95,6 @@ export class MetadataCache {
    * @return {Promise<QueryResult>}
    */
   public async queryMetadata(query: SearchQuery): Promise<QueryResult> {
-    if (!query.query.nativeSearch) query.query.nativeSearch = 1
     const result: QueryResult = await this.fetch
       .post(`${this.url}${apiPath}/query`, JSON.stringify(query))
       .then((response: Response) => {
@@ -245,16 +244,15 @@ export class MetadataCache {
 
   public async getOwnerAssets(owner: string): Promise<QueryResult> {
     const q = {
-      offset: 100,
       page: 1,
+      offset: 100,
       query: {
-        nativeSearch: 1,
         query_string: {
-          query: `(publicKey.owner:${owner})`
+          query: `publicKey.owner:${owner}`
         }
       },
       sort: {
-        value: 1
+        created: 1
       }
     } as SearchQuery
 

--- a/src/metadatacache/MetadataCache.ts
+++ b/src/metadatacache/MetadataCache.ts
@@ -15,7 +15,6 @@ export interface QueryResult {
 }
 
 export interface SearchQuery {
-  text?: string
   offset?: number
   page?: number
   query: {

--- a/src/metadatacache/MetadataCache.ts
+++ b/src/metadatacache/MetadataCache.ts
@@ -19,7 +19,6 @@ export interface SearchQuery {
   offset?: number
   page?: number
   query: {
-    nativeSearch?: number
     match?: {
       [property: string]:
         | string

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -275,10 +275,25 @@ export class Assets extends Instantiable {
   }
 
   /**
+   * Publish DDO on chain.
+   * @param  {ddo} DDO
+   * @param {String} consumerAccount
+   * @param {boolean} encrypt
+   * @return {Promise<TransactionReceipt>} transaction
+   */
+  public async publishDdo(
+    ddo: DDO,
+    consumerAccount: string,
+    encrypt: boolean = false
+  ): Promise<TransactionReceipt> {
+    return await this.ocean.onChainMetadata.publish(ddo.id, ddo, consumerAccount, encrypt)
+  }
+
+  /**
    * Update Metadata on chain.
    * @param  {ddo} DDO
    * @param {String} consumerAccount
-   * @return {Promise<TransactionReceipt>} exchangeId
+   * @return {Promise<TransactionReceipt>} transaction
    */
   public async updateMetadata(
     ddo: DDO,
@@ -351,7 +366,7 @@ export class Assets extends Instantiable {
         }
       },
       sort: {
-        value: 1
+        created: -1
       }
     } as SearchQuery)
   }

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -232,7 +232,6 @@ export class Assets extends Instantiable {
       offset: offset || 100,
       page: page || 1,
       query: {
-        nativeSearch: 1,
         query_string: {
           query: `dataToken:${dtAddress}`
         }
@@ -347,7 +346,6 @@ export class Assets extends Instantiable {
       page: 1,
       offset: 100,
       query: {
-        nativeSearch: 1,
         query_string: {
           query: text
         }

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -55,7 +55,7 @@ export class Assets extends Instantiable {
   }
 
   /**
-   * Creates a new DDO and publishes it
+   * Creates a new DDO. After this, Call ocean.onChainMetadata.to publish
    * @param  {Metadata} metadata DDO metadata.
    * @param  {Account}  publisher Publisher account.
    * @param  {list} services list of Service description documents

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -186,9 +186,11 @@ export class Assets extends Instantiable {
         address: dtAddress,
         cap: parseFloat(await datatokens.getCap(dtAddress))
       }
+      return ddo
+      /* Remeber to call ocean.onChainMetadata.publish after creating the DDO.
+      
       this.logger.log('Storing DDO')
       observer.next(CreateProgressStep.StoringDdo)
-      // const storedDdo = await this.ocean.metadataCache.storeDDO(ddo)
       const storeTx = await this.ocean.onChainMetadata.publish(
         ddo.id,
         ddo,
@@ -198,6 +200,7 @@ export class Assets extends Instantiable {
       observer.next(CreateProgressStep.DdoStored)
       if (storeTx) return ddo
       else return null
+      */
     })
   }
 
@@ -229,7 +232,10 @@ export class Assets extends Instantiable {
       offset: offset || 100,
       page: page || 1,
       query: {
-        dataToken: [dtAddress]
+        nativeSearch: 1,
+        query_string: {
+          query: `dataToken:${dtAddress}`
+        }
       },
       sort: {
         value: sort || 1
@@ -338,11 +344,13 @@ export class Assets extends Instantiable {
    */
   public async search(text: string): Promise<QueryResult> {
     return this.ocean.metadataCache.queryMetadata({
-      text,
       page: 1,
       offset: 100,
       query: {
-        value: 1
+        nativeSearch: 1,
+        query_string: {
+          query: text
+        }
       },
       sort: {
         value: 1

--- a/src/ocean/Ocean.ts
+++ b/src/ocean/Ocean.ts
@@ -76,7 +76,8 @@ export class Ocean extends Instantiable {
       instanceConfig.config.web3Provider,
       instanceConfig.logger,
       instanceConfig.config.metadataContractAddress,
-      instanceConfig.config.metadataContractABI
+      instanceConfig.config.metadataContractABI,
+      instance.metadataCache
     )
     instance.versions = await Versions.getInstance(instanceConfig)
     instance.network = new Network()

--- a/src/ocean/utils/WebServiceConnector.ts
+++ b/src/ocean/utils/WebServiceConnector.ts
@@ -34,6 +34,24 @@ export class WebServiceConnector {
     }
   }
 
+  public postWithOctet(url: string, payload: BodyInit): Promise<Response> {
+    if (payload != null) {
+      return this.fetch(url, {
+        method: 'POST',
+        body: payload,
+        headers: {
+          'Content-type': 'application/octet-stream'
+        },
+        timeout: 5000
+      })
+    } else {
+      return this.fetch(url, {
+        method: 'POST',
+        timeout: 5000
+      })
+    }
+  }
+
   public get(url: string): Promise<Response> {
     return this.fetch(url, {
       method: 'GET',

--- a/src/ocean/utils/WebServiceConnector.ts
+++ b/src/ocean/utils/WebServiceConnector.ts
@@ -17,31 +17,29 @@ export class WebServiceConnector {
   }
 
   public post(url: string, payload: BodyInit): Promise<Response> {
-    if (payload != null) {
-      return this.fetch(url, {
-        method: 'POST',
-        body: payload,
-        headers: {
-          'Content-type': 'application/json'
-        },
-        timeout: 5000
-      })
-    } else {
-      return this.fetch(url, {
-        method: 'POST',
-        timeout: 5000
-      })
+    const headers = {
+      'Content-type': 'application/json'
     }
+    return this.postWithHeaders(url, payload, headers)
   }
 
   public postWithOctet(url: string, payload: BodyInit): Promise<Response> {
+    const headers = {
+      'Content-type': 'application/octet-stream'
+    }
+    return this.postWithHeaders(url, payload, headers)
+  }
+
+  public postWithHeaders(
+    url: string,
+    payload: BodyInit,
+    headers: any
+  ): Promise<Response> {
     if (payload != null) {
       return this.fetch(url, {
         method: 'POST',
         body: payload,
-        headers: {
-          'Content-type': 'application/octet-stream'
-        },
+        headers,
         timeout: 5000
       })
     } else {

--- a/test/integration/ComputeFlow.test.ts
+++ b/test/integration/ComputeFlow.test.ts
@@ -264,6 +264,8 @@ describe('Compute flow', () => {
     )
     ddo = await ocean.assets.create(asset, alice, [computeService], tokenAddress)
     assert(ddo.dataToken === tokenAddress, 'ddo.dataToken !== tokenAddress')
+    const storeTx = await ocean.onChainMetadata.publish(ddo.id, ddo, alice.getId())
+    assert(storeTx)
     await sleep(aquaSleep)
   })
   it('Alice publishes a 2nd dataset with a compute service that allows Raw Algo', async () => {
@@ -320,6 +322,12 @@ describe('Compute flow', () => {
       ddoAdditional1.dataToken === tokenAddressAdditional1,
       'ddoAdditional1.dataToken !== tokenAddressAdditional1'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      ddoAdditional1.id,
+      ddoAdditional1,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
   })
 
@@ -342,6 +350,12 @@ describe('Compute flow', () => {
       ddoAdditional2.dataToken === tokenAddressAdditional2,
       'ddoAdditional2.dataToken !== tokenAddressAdditional2'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      ddoAdditional2.id,
+      ddoAdditional2,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
   })
 
@@ -369,6 +383,12 @@ describe('Compute flow', () => {
       datasetNoRawAlgo.dataToken === tokenAddressNoRawAlgo,
       'datasetNoRawAlgo.dataToken !== tokenAddressNoRawAlgo'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      datasetNoRawAlgo.id,
+      datasetNoRawAlgo,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
   })
 
@@ -402,6 +422,12 @@ describe('Compute flow', () => {
       datasetWithTrustedAlgo.dataToken === tokenAddressWithTrustedAlgo,
       'datasetWithTrustedAlgo.dataToken !== tokenAddressWithTrustedAlgo'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      datasetWithTrustedAlgo.id,
+      datasetWithTrustedAlgo,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
   })
 
@@ -449,6 +475,12 @@ describe('Compute flow', () => {
       algorithmAsset.dataToken === tokenAddressAlgorithm,
       'algorithmAsset.dataToken !== tokenAddressAlgorithm'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      algorithmAsset.id,
+      algorithmAsset,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
   })
 
@@ -502,6 +534,12 @@ describe('Compute flow', () => {
       algorithmAssetRemoteProvider.dataToken === tokenAddressAlgorithmRemoteProvider,
       'algorithmAssetRemoteProvider.dataToken !== tokenAddressAlgorithmRemoteProvider'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      algorithmAssetRemoteProvider.id,
+      algorithmAssetRemoteProvider,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
     const checkDDO = await ocean.assets.resolve(algorithmAssetRemoteProvider.id)
     const checkService = checkDDO.findServiceByType('access')
@@ -1122,6 +1160,12 @@ describe('Compute flow', () => {
       datasetWithBogusProvider.dataToken === tokenAddressWithBogusProvider,
       'datasetWithBogusProvider.dataToken !== tokenAddressWithBogusProvider'
     )
+    const storeTx = await ocean.onChainMetadata.publish(
+      datasetWithBogusProvider.id,
+      datasetWithBogusProvider,
+      alice.getId()
+    )
+    assert(storeTx)
     await sleep(aquaSleep)
   })
   it('Bob should fail to start a compute job for a bogus provider with a raw Algo', async () => {

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -27,14 +27,17 @@ describe('Marketplace flow', () => {
   let bob: Account
   let ddo
   let ddoWithBadUrl
+  let ddoEncrypted
   let alice: Account
   let asset
   let assetWithBadUrl
+  let assetWithEncrypt
   let marketplace: Account
   let contracts: TestContractHandler
   let datatoken: DataTokens
   let tokenAddress: string
   let tokenAddressForBadUrlAsset: string
+  let tokenAddressEncrypted: string
   let service1: ServiceAccess
   let price: string
   let ocean: Ocean
@@ -90,6 +93,13 @@ describe('Marketplace flow', () => {
       'DTA'
     )
     assert(tokenAddressForBadUrlAsset != null)
+    tokenAddressEncrypted = await datatoken.create(
+      blob,
+      alice.getId(),
+      '10000000000',
+      'AliceDT',
+      'DTA'
+    )
   })
 
   it('Generates metadata', async () => {
@@ -112,10 +122,29 @@ describe('Marketplace flow', () => {
         ]
       }
     }
+    assetWithEncrypt = {
+      main: {
+        type: 'dataset encrypted',
+        name: 'test-dataset-encrypted',
+        dateCreated: new Date(Date.now()).toISOString().split('.')[0] + 'Z', // remove milliseconds
+        author: 'oceanprotocol-team',
+        license: 'MIT',
+        files: [
+          {
+            url: 'https://s3.amazonaws.com/testfiles.oceanprotocol.com/info.0.json',
+            checksum: 'efb2c764274b745f5fc37f97c6b0e761',
+            contentLength: '4535431',
+            contentType: 'text/csv',
+            encoding: 'UTF-8',
+            compression: 'zip'
+          }
+        ]
+      }
+    }
     assetWithBadUrl = {
       main: {
-        type: 'dataset',
-        name: 'test-dataset',
+        type: 'datasetWithBadUrl',
+        name: 'test-dataset-withBadUrl',
         dateCreated: new Date(Date.now()).toISOString().split('.')[0] + 'Z', // remove milliseconds
         author: 'oceanprotocol-team',
         license: 'MIT',
@@ -145,6 +174,8 @@ describe('Marketplace flow', () => {
     )
     ddo = await ocean.assets.create(asset, alice, [service1], tokenAddress)
     assert(ddo.dataToken === tokenAddress)
+    const storeTx = await ocean.onChainMetadata.publish(ddo.id, ddo, alice.getId())
+    assert(storeTx)
     await sleep(1000)
     ddoWithBadUrl = await ocean.assets.create(
       assetWithBadUrl,
@@ -153,12 +184,51 @@ describe('Marketplace flow', () => {
       tokenAddressForBadUrlAsset
     )
     assert(ddoWithBadUrl.dataToken === tokenAddressForBadUrlAsset)
-    await sleep(aquaSleep)
+    const storeTxWithBadUrl = await ocean.onChainMetadata.publish(
+      ddoWithBadUrl.id,
+      ddoWithBadUrl,
+      alice.getId()
+    )
+    assert(storeTxWithBadUrl)
+    await sleep(1000)
   })
 
+  it('Alice publishes an encrypted dataset', async () => {
+    ddoEncrypted = await ocean.assets.create(
+      assetWithEncrypt,
+      alice,
+      [service1],
+      tokenAddressEncrypted
+    )
+    assert(ddoEncrypted.dataToken === tokenAddressEncrypted)
+    const storeTx = await ocean.onChainMetadata.publish(
+      ddoEncrypted.id,
+      ddoEncrypted,
+      alice.getId(),
+      true
+    )
+    assert(storeTx)
+    await sleep(aquaSleep)
+  })
+  it('Marketplace should resolve asset using DID', async () => {
+    await ocean.assets.resolve(ddo.id).then((newDDO) => {
+      assert(newDDO.id === ddo.id)
+    })
+  })
+  it('Marketplace should resolve asset with bad URL using DID', async () => {
+    await ocean.assets.resolve(ddoWithBadUrl.id).then((newDDO) => {
+      assert(newDDO.id === ddoWithBadUrl.id)
+    })
+  })
+  it('Marketplace should resolve the encrypted asset using DID', async () => {
+    await ocean.assets.resolve(ddoEncrypted.id).then((newDDO) => {
+      assert(newDDO.id === ddoEncrypted.id)
+    })
+  })
   it('Alice mints 100 tokens', async () => {
     await datatoken.mint(tokenAddress, alice.getId(), tokenAmount)
     await datatoken.mint(tokenAddressForBadUrlAsset, alice.getId(), tokenAmount)
+    await datatoken.mint(tokenAddressEncrypted, alice.getId(), tokenAmount)
   })
 
   it('Alice allows marketplace to sell her datatokens', async () => {
@@ -189,11 +259,6 @@ describe('Marketplace flow', () => {
         )
         assert(marketplaceBalance.toString() === marketplaceAllowance.toString())
       })
-  })
-  it('Marketplace should resolve asset using DID', async () => {
-    await ocean.assets.resolve(ddo.id).then((newDDO) => {
-      assert(newDDO.id === ddo.id)
-    })
   })
 
   it('Marketplace posts asset for sale', async () => {
@@ -263,6 +328,25 @@ describe('Marketplace flow', () => {
     assert(txid !== null)
     await sleep(60000)
     const metaData = await ocean.assets.getServiceByType(ddo.id, 'metadata')
+    assert.deepEqual(metaData.attributes.additionalInformation.links, [])
+  })
+
+  it('Alice updates metadata and removes sample links with encrypted ddo', async () => {
+    const newMetaData: EditableMetadata = {
+      description: 'new description no links',
+      title: 'new title no links'
+    }
+    const newDdo = await ocean.assets.editMetadata(ddoEncrypted, newMetaData)
+    assert(newDdo !== null)
+    const txid = await ocean.onChainMetadata.update(
+      newDdo.id,
+      newDdo,
+      alice.getId(),
+      true
+    )
+    assert(txid !== null)
+    await sleep(60000)
+    const metaData = await ocean.assets.getServiceByType(ddoEncrypted.id, 'metadata')
     assert.deepEqual(metaData.attributes.additionalInformation.links, [])
   })
 

--- a/test/unit/metadatacache/MetadataCache.test.ts
+++ b/test/unit/metadatacache/MetadataCache.test.ts
@@ -28,12 +28,13 @@ describe('MetadataCache', () => {
       offset: 100,
       page: 1,
       query: {
-        value: 1
+        query_string: {
+          query: 'Office'
+        }
       },
       sort: {
         value: 1
-      },
-      text: 'Office'
+      }
     } as SearchQuery
 
     it('should query metadata', async () => {

--- a/test/unit/ocean/Assets.test.ts
+++ b/test/unit/ocean/Assets.test.ts
@@ -28,7 +28,6 @@ describe('Assets', () => {
         offset: 100,
         page: 1,
         query: {
-          nativeSearch: 1,
           query_string: {
             query: 'Office'
           }

--- a/test/unit/ocean/Assets.test.ts
+++ b/test/unit/ocean/Assets.test.ts
@@ -28,7 +28,10 @@ describe('Assets', () => {
         offset: 100,
         page: 1,
         query: {
-          text: 'Office'
+          nativeSearch: 1,
+          query_string: {
+            query: 'Office'
+          }
         },
         sort: {
           created: -1


### PR DESCRIPTION
Breaking changes:
  - ocean.assets.create is not calling ocean.onChainMetadata.publish anymore. It will just return the DDO and you have to call it after to publish your asset

Fixes:
 - query support for aquarius 2.2.5
 - add encrypted ddo support (siloed market)
