### PR TITLE
Optimize compute job status calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3778,9 +3778,9 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.2.tgz",
-      "integrity": "sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.3.tgz",
+      "integrity": "sha512-2i6v88DTqVBNODyjD9U6Ycn/uSZNvyHe25cIbo2fFnAACAsaLTJsd23miRWiR5NuiGXR9wpJ9d40/9WAhjDIrw==",
       "requires": {
         "node-fetch": "2.6.1"
       }

--- a/src/ocean/Compute.ts
+++ b/src/ocean/Compute.ts
@@ -193,14 +193,18 @@ export class Compute extends Instantiable {
    * Returns information about the status of all compute jobs, or a single compute job.
    * @param  {Account} consumerAccount The account of the consumer ordering the service.
    * @param  {string} did Decentralized identifier.
-   * @param  {string} jobId The jobId of the compute job
+   * @param  {DDO} ddo If undefined then the ddo will be fetched by did, this is just to optimize network calls
+   * @param  {ServiceCompute} service If undefined then we get the service from the ddo
    * @param  {string} jobId The Order transaction id
+   * @param  {string} txId The transaction id
    * @param  {boolean} sign If the provider request is going to be signed(default) (full status) or not (short status)
    * @return {Promise<ComputeJob[]>} Returns the status
    */
   public async status(
     consumerAccount: Account,
     did?: string,
+    ddo?: DDO,
+    service?: ServiceCompute,
     jobId?: string,
     txId?: string,
     sign = true
@@ -208,14 +212,22 @@ export class Compute extends Instantiable {
     let provider: Provider
 
     if (did) {
-      const ddo = await this.ocean.assets.resolve(did)
-      const service = ddo.findServiceByType('compute')
+      if (!service) {
+        if (!ddo) {
+          ddo = await this.ocean.assets.resolve(did)
+          if (!ddo) return null
+        }
+        service = ddo.findServiceByType('compute')
+        if (!service) return null
+      }
+
       const { serviceEndpoint } = service
       provider = await Provider.getInstance(this.instanceConfig)
       await provider.setBaseUrl(serviceEndpoint)
     } else {
       provider = this.ocean.provider
     }
+
     const computeJobsList = await provider.computeStatus(
       did,
       consumerAccount,
@@ -223,6 +235,7 @@ export class Compute extends Instantiable {
       txId,
       sign
     )
+
     return computeJobsList as ComputeJob[]
   }
 

--- a/src/ocean/Compute.ts
+++ b/src/ocean/Compute.ts
@@ -215,10 +215,11 @@ export class Compute extends Instantiable {
       if (!service) {
         if (!ddo) {
           ddo = await this.ocean.assets.resolve(did)
-          if (!ddo) return null
+          if (!ddo) throw new Error(`Couldn't resolve the did ${did}`)
         }
         service = ddo.findServiceByType('compute')
-        if (!service) return null
+        if (!service)
+          throw new Error(`Couldn't find a compute service on the asset with did ${did}`)
       }
 
       const { serviceEndpoint } = service

--- a/src/ocean/interfaces/ComputeJob.ts
+++ b/src/ocean/interfaces/ComputeJob.ts
@@ -2,7 +2,7 @@ import DID from '../DID'
 
 export interface ComputeJob {
   owner: string
-  did: string
+  dids: string[]
   jobId: string
   dateCreated: string
   dateFinished: string

--- a/src/ocean/interfaces/ComputeJob.ts
+++ b/src/ocean/interfaces/ComputeJob.ts
@@ -2,7 +2,6 @@ import DID from '../DID'
 
 export interface ComputeJob {
   owner: string
-  dids: string[]
   jobId: string
   dateCreated: string
   dateFinished: string
@@ -11,4 +10,6 @@ export interface ComputeJob {
   algorithmLogUrl: string
   resultsUrl: string[]
   resultsDid?: DID
+  input?: string[]
+  algoDID?: string
 }

--- a/src/ocean/interfaces/ComputeJob.ts
+++ b/src/ocean/interfaces/ComputeJob.ts
@@ -10,6 +10,6 @@ export interface ComputeJob {
   algorithmLogUrl: string
   resultsUrl: string[]
   resultsDid?: DID
-  input?: string[]
+  inputDID?: string[]
   algoDID?: string
 }

--- a/test/integration/ComputeFlow.test.ts
+++ b/test/integration/ComputeFlow.test.ts
@@ -690,8 +690,8 @@ describe('Compute flow', () => {
       undefined,
       undefined,
       undefined,
-      computeOrderId,
       undefined,
+      computeOrderId,
       true
     )
     assert(response.length > 0, "Response.length is's not >0")

--- a/test/integration/ComputeFlow.test.ts
+++ b/test/integration/ComputeFlow.test.ts
@@ -689,14 +689,24 @@ describe('Compute flow', () => {
       bob,
       undefined,
       undefined,
+      undefined,
       computeOrderId,
+      undefined,
       true
     )
     assert(response.length > 0, "Response.length is's not >0")
   })
   it('Bob should get status of a compute job without signing', async () => {
     assert(jobId != null, 'Jobid is null')
-    const response = await ocean.compute.status(bob, ddo.id, jobId, undefined, false)
+    const response = await ocean.compute.status(
+      bob,
+      ddo.id,
+      undefined,
+      undefined,
+      jobId,
+      undefined,
+      false
+    )
     assert(response[0].jobId === jobId, 'response[0].jobId !== jobId')
   })
 
@@ -706,13 +716,15 @@ describe('Compute flow', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
+      undefined,
       false
     )
     assert(response.length > 0, 'Invalid response length')
   })
   it('Bob should get status of a compute job', async () => {
     assert(jobId != null, 'Jobid is null')
-    const response = await ocean.compute.status(bob, ddo.id, jobId)
+    const response = await ocean.compute.status(bob, ddo.id, undefined, undefined, jobId)
     assert(response[0].jobId === jobId, 'response[0].jobId !== jobId')
   })
 
@@ -723,7 +735,7 @@ describe('Compute flow', () => {
   it('Bob should stop compute job', async () => {
     assert(jobId != null, 'Jobid is null')
     await ocean.compute.stop(bob, ddo.id, jobId)
-    const response = await ocean.compute.status(bob, ddo.id, jobId)
+    const response = await ocean.compute.status(bob, ddo.id, undefined, undefined, jobId)
     // TODO: typings say that `stopreq` does not exist
     assert((response[0] as any).stopreq === 1, 'Response.stopreq is invalid')
   })
@@ -1282,6 +1294,8 @@ describe('Compute flow', () => {
     const response = await ocean.compute.status(
       bob,
       datasetWithBogusProvider.id,
+      undefined,
+      undefined,
       undefined,
       undefined,
       false


### PR DESCRIPTION
- optimize status calls by passing ddo or service so ddo is not fetched multiple times.
- includes a small update needed after https://github.com/oceanprotocol/provider/issues/126  ( so this pr is blocked until )
