### PR TITLE
Feature/more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_script:
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
   - export ADDRESS_FILE="${HOME}/.ocean/ocean-contracts/artifacts/address.json"
-  - export AQUARIUS_VERSION=v2.2.5
   - mkdir "${HOME}/.ocean/"
   - mkdir "${HOME}/.ocean/ocean-contracts/"
   - mkdir "${HOME}/.ocean/ocean-contracts/artifacts"

--- a/src/ddo/interfaces/BestPrice.ts
+++ b/src/ddo/interfaces/BestPrice.ts
@@ -5,5 +5,7 @@ export interface BestPrice {
   isConsumable?: 'true' | 'false' | ''
   ocean?: number
   datatoken?: number
+  // eslint-disable-next-line camelcase
+  exchange_id?: string
   pools: string[]
 }

--- a/test/integration/ComputeFlow.test.ts
+++ b/test/integration/ComputeFlow.test.ts
@@ -66,6 +66,7 @@ describe('Compute flow', () => {
   let datasetWithTrustedAlgo: DDO
   let datasetWithBogusProvider: DDO
   let algorithmAsset: DDO
+  let algorithmAssetwithCompute: DDO
   let algorithmAssetRemoteProvider: DDO
   let contracts: TestContractHandler
   let datatoken: DataTokens
@@ -74,6 +75,7 @@ describe('Compute flow', () => {
   let tokenAddressWithTrustedAlgo: string
   let tokenAddressWithBogusProvider: string
   let tokenAddressAlgorithm: string
+  let tokenAddressAlgorithmwithCompute: string
   let tokenAddressAlgorithmRemoteProvider: string
   let tokenAddressAdditional1: string
   let tokenAddressAdditional2: string
@@ -182,6 +184,15 @@ describe('Compute flow', () => {
       '10000000000',
       'AlgoDT',
       'ALGDT'
+    )
+    assert(tokenAddressAlgorithm != null, 'Creation of tokenAddressAlgorithm failed')
+
+    tokenAddressAlgorithmwithCompute = await datatoken.create(
+      blob,
+      alice.getId(),
+      '10000000000',
+      'AlgoDTwCompute',
+      'ALGwC'
     )
     assert(tokenAddressAlgorithm != null, 'Creation of tokenAddressAlgorithm failed')
 
@@ -506,6 +517,67 @@ describe('Compute flow', () => {
     await waitForAqua(ocean, algorithmAsset.id)
   })
 
+  it('should publish an algorithm with a compute service', async () => {
+    const algoAssetwithCompute: Metadata = {
+      main: {
+        type: 'algorithm',
+        name: 'Test Algo with Compute',
+        dateCreated: dateCreated,
+        author: 'DevOps',
+        license: 'CC-BY',
+        files: [
+          {
+            url:
+              'https://raw.githubusercontent.com/oceanprotocol/test-algorithm/master/javascript/algo.js',
+            contentType: 'text/js',
+            encoding: 'UTF-8'
+          }
+        ],
+        algorithm: {
+          language: 'js',
+          format: 'docker-image',
+          version: '0.1',
+          container: {
+            entrypoint: 'node $ALGO',
+            image: 'node',
+            tag: '10'
+          }
+        }
+      }
+    }
+    const origComputePrivacy = {
+      allowRawAlgorithm: false,
+      allowNetworkAccess: false,
+      allowAllPublishedAlgorithms: false,
+      publisherTrustedAlgorithms: []
+    }
+    const service1 = ocean.compute.createComputeService(
+      alice,
+      '1',
+      dateCreated,
+      providerAttributes,
+      origComputePrivacy as ServiceComputePrivacy
+    )
+
+    algorithmAssetwithCompute = await ocean.assets.create(
+      algoAssetwithCompute,
+      alice,
+      [service1],
+      tokenAddressAlgorithmwithCompute
+    )
+    assert(
+      algorithmAssetwithCompute.dataToken === tokenAddressAlgorithmwithCompute,
+      'algorithmAssetwithCompute.dataToken !== tokenAddressAlgorithm'
+    )
+    const storeTx = await ocean.onChainMetadata.publish(
+      algorithmAssetwithCompute.id,
+      algorithmAssetwithCompute,
+      alice.getId()
+    )
+    assert(storeTx)
+    await waitForAqua(ocean, algorithmAssetwithCompute.id)
+  })
+
   it('should publish an algorithm using the 2nd provider', async () => {
     const remoteProviderUri = 'http://172.15.0.7:8030'
     const algoAssetRemoteProvider: Metadata = {
@@ -577,6 +649,7 @@ describe('Compute flow', () => {
     await datatoken.mint(tokenAddressWithTrustedAlgo, alice.getId(), tokenAmount)
     await datatoken.mint(tokenAddressWithBogusProvider, alice.getId(), tokenAmount)
     await datatoken.mint(tokenAddressAlgorithm, alice.getId(), tokenAmount)
+    await datatoken.mint(tokenAddressAlgorithmwithCompute, alice.getId(), tokenAmount)
     await datatoken.mint(tokenAddressAlgorithmRemoteProvider, alice.getId(), tokenAmount)
     await datatoken.mint(tokenAddressAdditional1, alice.getId(), tokenAmount)
     await datatoken.mint(tokenAddressAdditional2, alice.getId(), tokenAmount)
@@ -616,6 +689,15 @@ describe('Compute flow', () => {
       .transfer(tokenAddressAlgorithm, bob.getId(), dTamount, alice.getId())
       .then(async () => {
         const balance = await datatoken.balance(tokenAddressAlgorithm, bob.getId())
+        assert(balance.toString() === dTamount.toString())
+      })
+    await datatoken
+      .transfer(tokenAddressAlgorithmwithCompute, bob.getId(), dTamount, alice.getId())
+      .then(async () => {
+        const balance = await datatoken.balance(
+          tokenAddressAlgorithmwithCompute,
+          bob.getId()
+        )
         assert(balance.toString() === dTamount.toString())
       })
     await datatoken
@@ -858,6 +940,63 @@ describe('Compute flow', () => {
       'allowNetworkAccess does not match'
     )
   })
+  it('should start a compute job with a published algo that has a compute service', async () => {
+    const output = {}
+    const computeService = ddo.findServiceByType('compute')
+    // get the compute address first
+    computeAddress = await ocean.compute.getComputeAddress(ddo.id, computeService.index)
+    assert(ddo != null, 'ddo should not be null')
+
+    // check if asset is orderable. otherwise, you might pay for it, but it has some algo restrictions
+    const allowed = await ocean.compute.isOrderable(
+      ddo.id,
+      computeService.index,
+      algorithmAssetwithCompute.id,
+      undefined
+    )
+    assert(allowed === true)
+    const order = await ocean.compute.orderAsset(
+      bob.getId(),
+      ddo.id,
+      computeService.index,
+      algorithmAssetwithCompute.id,
+      undefined,
+      null, // no marketplace fee
+      computeAddress // CtD is the consumer of the dataset
+    )
+    assert(order != null, 'Order should not be null')
+    // order the algorithm
+    assert(algorithmAsset != null, 'algorithmAsset should not be null')
+    const serviceAlgo = algorithmAssetwithCompute.findServiceByType('compute')
+    const orderalgo = await ocean.compute.orderAlgorithm(
+      algorithmAssetwithCompute.id,
+      serviceAlgo.type,
+      bob.getId(),
+      serviceAlgo.index,
+      null, // no marketplace fee
+      computeAddress // CtD is the consumer of the dataset
+    )
+    assert(orderalgo != null, 'Order should not be null')
+
+    const response = await ocean.compute.start(
+      ddo.id,
+      order,
+      tokenAddress,
+      bob,
+      algorithmAssetwithCompute.id,
+      undefined,
+      output,
+      `${computeService.index}`,
+      computeService.type,
+      orderalgo,
+      algorithmAssetwithCompute.dataToken
+    )
+    assert(response, 'Compute error')
+    jobId = response.jobId
+    assert(response.status >= 1, 'Invalid response status')
+    assert(response.jobId, 'Invalid jobId')
+  })
+
   it('should start a compute job with a published algo', async () => {
     const output = {}
     const computeService = ddo.findServiceByType('compute')

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -380,7 +380,7 @@ describe('Marketplace flow', () => {
     const assets = await ocean.assets.ownerAssets(alice.getId())
     assert(assets.results.length > 0)
   })
-  /*
+
   it('Alice updates metadata and removes sample links', async () => {
     const newMetaData: EditableMetadata = {
       description: 'new description no links',
@@ -454,7 +454,7 @@ describe('Marketplace flow', () => {
     assert(response[0].contentLength === '1161')
     assert(response[0].contentType === 'application/json')
   })
-  */
+  
   it('Alice should create a FRE pricing for her asset', async () => {
     const trxReceipt = await ocean.fixedRateExchange.create(
       tokenAddress,

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -509,7 +509,7 @@ describe('Marketplace flow', () => {
   })
 
   it('Alice should update the POOL pricing for her asset by buying a DT', async () => {
-    const poolAddress=await ocean.pool.searchPoolforDT(tokenAddressWithPool)
+    const poolAddress = await ocean.pool.searchPoolforDT(tokenAddressWithPool)
     const buyTx = await ocean.pool.buyDT(alice.getId(), poolAddress[0], '1', '999')
     assert(buyTx)
     await sleep(aquaSleep)

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -454,7 +454,7 @@ describe('Marketplace flow', () => {
     assert(response[0].contentLength === '1161')
     assert(response[0].contentType === 'application/json')
   })
-  
+
   it('Alice should create a FRE pricing for her asset', async () => {
     const trxReceipt = await ocean.fixedRateExchange.create(
       tokenAddress,

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -462,7 +462,6 @@ describe('Marketplace flow', () => {
       alice.getId()
     )
     assert(trxReceipt)
-    console.error(trxReceipt)
     await sleep(aquaSleep)
     const exchangeDetails = await ocean.fixedRateExchange.searchforDT(tokenAddress, '0')
     const resolvedDDO = await ocean.assets.resolve(ddo.id)

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -507,6 +507,7 @@ describe('Marketplace flow', () => {
     assert(resolvedDDO.price.value)
     assert(resolvedDDO.price.pools.includes(alicePoolAddress))
   })
+
   it('Alice should update the POOL pricing for her asset by buying a DT', async () => {
     const poolAddress=await ocean.pool.searchPoolforDT(tokenAddressWithPool)
     const buyTx = await ocean.pool.buyDT(alice.getId(), poolAddress[0], '1', '999')

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -406,6 +406,33 @@ describe('Marketplace flow', () => {
     assert(response[0].contentType === 'application/json')
   })
 
+  it('Alice should create a FRE pricing for her asset', async () => {
+    const trxReceipt = await ocean.fixedRateExchange.create(
+      tokenAddress,
+      '1',
+      alice.getId()
+    )
+    assert(trxReceipt)
+    await sleep(aquaSleep)
+    const resolvedDDO = await ocean.assets.resolve(ddo.id)
+    assert(resolvedDDO.price.type === 'exchange')
+    assert(resolvedDDO.price.value === 1)
+  })
+  it('Alice should update the FRE pricing for her asset', async () => {
+    const exchangeDetails = await ocean.fixedRateExchange.searchforDT(tokenAddress, '0')
+    assert(exchangeDetails)
+    const trxReceipt = await ocean.fixedRateExchange.setRate(
+      exchangeDetails[0].exchangeID,
+      2,
+      alice.getId()
+    )
+    assert(trxReceipt)
+    await sleep(aquaSleep)
+    const resolvedDDO = await ocean.assets.resolve(ddo.id)
+    assert(resolvedDDO.price.type === 'exchange')
+    assert(resolvedDDO.price.value === 2)
+  })
+
   it('Alice publishes a dataset but passed data token is invalid', async () => {
     price = '10' // in datatoken
     const publishedDate = new Date(Date.now()).toISOString().split('.')[0] + 'Z'


### PR DESCRIPTION
- add compute job with compute dataset/compute algo published by the same provider (requires provider v0.4.9)
- add FRE create/update integration tests (check that aqua behaves as expected)  (requires aquarius v2.2.8)
- add Pool create/swaps integration tests (check that aqua behaves as expected) 