### PR TITLE
exporting common JS library

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.14.5",
   "description": "JavaScript client library for Ocean Protocol",
   "main": "./dist/node/lib.js",
-  "exports": "./dist/node/lib.module.js",
+  "exports": "./dist/node/lib.js",
   "module": "./dist/node/lib.module.js",
   "typings": "./dist/node/lib.d.ts",
   "umd:main": "dist/node/lib.umd.js",


### PR DESCRIPTION
Closes: https://github.com/oceanprotocol/ocean.js/issues/753

Changes proposed in this PR:
- Exporting common JS bundle rather than ESM module
 