### PR TITLE
Feature/use decimal in pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@ethereum-navigator/navigator": "^0.5.2",
-    "@oceanprotocol/contracts": "^0.5.16",
+    "@oceanprotocol/contracts": "0.5.16",
     "@types/crypto-js": "^4.0.1",
     "cross-fetch": "^3.1.2",
     "crypto-js": "^4.0.0",

--- a/src/balancer/PoolFactory.ts
+++ b/src/balancer/PoolFactory.ts
@@ -45,10 +45,19 @@ export class PoolFactory {
       from: account
     })
     let txid = null
+    const gasLimitDefault = this.GASLIMIT_DEFAULT
+    let estGas
     try {
-      txid = await factory.methods
+      estGas = await factory.methods
         .newBPool()
-        .send({ from: account, gas: this.GASLIMIT_DEFAULT })
+        .estimateGas({ from: account }, (err, estGas) => (err ? gasLimitDefault : estGas))
+    } catch (e) {
+      this.logger.log('Error estimate gas newBPool')
+      this.logger.log(e)
+      estGas = gasLimitDefault
+    }
+    try {
+      txid = await factory.methods.newBPool().send({ from: account, gas: estGas + 1 })
       // pooladdress = transactiondata.events.BPoolRegistered.returnValues[0]
     } catch (e) {
       this.logger.error(`ERROR: Failed to create new pool: ${e.message}`)

--- a/src/utils/GasUtils.ts
+++ b/src/utils/GasUtils.ts
@@ -3,5 +3,5 @@ import Web3 from 'web3'
 
 export async function getFairGasPrice(web3: Web3): Promise<string> {
   const x = new BigNumber(await web3.eth.getGasPrice())
-  return x.multipliedBy(1.25).integerValue(BigNumber.ROUND_DOWN).toString(10)
+  return x.multipliedBy(1.05).integerValue(BigNumber.ROUND_DOWN).toString(10)
 }


### PR DESCRIPTION
Closes #766
Closes #779 

Non breaking changes proposed in this PR:

- use a lower default gas value
- fix gas estimate in remove liquidity
- approve will check allowance
- use Decimal instead of simple js math functions
- use gas estimate when creating new pool
