### PR TITLE
Add ocean.assets.isConsumable function

### DIFF
--- a/src/ddo/DDO.ts
+++ b/src/ddo/DDO.ts
@@ -58,8 +58,6 @@ export class DDO {
 
   public isInPurgatory: 'false' | 'true'
 
-  public isDisable?: boolean
-
   public purgatoryData?: PurgatoryData
 
   public dataTokenInfo?: DataTokenInfo

--- a/src/ddo/DDO.ts
+++ b/src/ddo/DDO.ts
@@ -58,6 +58,8 @@ export class DDO {
 
   public isInPurgatory: 'false' | 'true'
 
+  public isDisable?: boolean
+
   public purgatoryData?: PurgatoryData
 
   public dataTokenInfo?: DataTokenInfo

--- a/src/ddo/interfaces/Consumable.ts
+++ b/src/ddo/interfaces/Consumable.ts
@@ -1,0 +1,4 @@
+export interface Consumable {
+  status: string
+  message: string
+}

--- a/src/ddo/interfaces/Consumable.ts
+++ b/src/ddo/interfaces/Consumable.ts
@@ -1,4 +1,4 @@
 export interface Consumable {
-  status: string
+  status: number
   message: string
 }

--- a/src/ddo/interfaces/EditableMetadata.ts
+++ b/src/ddo/interfaces/EditableMetadata.ts
@@ -1,8 +1,9 @@
 import { EditableMetadataLinks } from './EditableMetadataLinks'
+import { Status } from './Status'
 
 export interface EditableMetadata {
   description?: string
   title?: string
   links?: EditableMetadataLinks[]
-  isDisable?: boolean
+  status?: Status
 }

--- a/src/ddo/interfaces/EditableMetadata.ts
+++ b/src/ddo/interfaces/EditableMetadata.ts
@@ -4,4 +4,5 @@ export interface EditableMetadata {
   description?: string
   title?: string
   links?: EditableMetadataLinks[]
+  isDisable?: boolean
 }

--- a/src/ddo/interfaces/Metadata.ts
+++ b/src/ddo/interfaces/Metadata.ts
@@ -1,10 +1,12 @@
 import { MetadataMain } from './MetadataMain'
 import { AdditionalInformation } from './AdditionalInformation'
 import { Curation } from './Curation'
+import { Status } from './Status'
 
 export interface Metadata {
   main: MetadataMain
   encryptedFiles?: string
   additionalInformation?: AdditionalInformation
   curation?: Curation
+  status?: Status
 }

--- a/src/ddo/interfaces/Service.ts
+++ b/src/ddo/interfaces/Service.ts
@@ -1,10 +1,12 @@
 import { Metadata } from './Metadata'
+import { Status } from './Status'
 
 export type ServiceType = 'authorization' | 'metadata' | 'access' | 'compute'
 
 export interface ServiceCommonAttributes {
   main: { [key: string]: any }
   additionalInformation?: { [key: string]: any }
+  status?: Status
 }
 
 export interface ServiceCommon {

--- a/src/ddo/interfaces/Status.ts
+++ b/src/ddo/interfaces/Status.ts
@@ -1,0 +1,26 @@
+/**
+ * Status attributes of Assets Metadata.
+ * @see https://github.com/oceanprotocol/OEPs/tree/master/8
+ */
+export interface Status {
+  /**
+   * Use to flag unsuitable content. True by default. If it's false, the content must not be returned.
+   * @type {boolean}
+   * @example true
+   */
+  isListed?: boolean
+
+  /**
+   * Flag retired content. False by default. If it's true, the content may either not be returned, or returned with a note about retirement.
+   * @type {boolean}
+   * @example false
+   */
+  isRetired?: boolean
+
+  /**
+   * For temporarily disabling ordering assets, e.g. when file host is in maintenance. False by default. If it's true, no ordering of assets for download or compute should be allowed.
+   * @type {boolean}
+   * @example false
+   */
+  isOrderDisabled?: boolean
+}

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -644,7 +644,6 @@ export class Assets extends Instantiable {
   /**
    *
    * @param {String} did
-   * @param {String} consumerAddress // Optional, to check allow/deny list
    * @return {Promise<Consumable>}
    */
   public async isConsumable(did: string, consumerAddress?: string): Promise<Consumable> {
@@ -657,18 +656,9 @@ export class Assets extends Instantiable {
       }
 
     /*
-    // To do: check credentials using consumerAddress
-    if (ddo.credential.allow.length > 0) {
-      if (consumerAddress) {
-        // call method check consumerAddress with allow list
-        // return: 2, Credential missing from allow list
-      }
-    } else if (ddo.credential.deny.length > 0) {
-      if (consumerAddress) {
-        // call method check consumerAddress with deny list
-        // return: 3, Credential found on deny list
-      }
-    }
+    // To do: call helper method check credential
+    // return: 4, Credential missing from allow list
+    // return: 5, Credential found on deny list
     */
     return {
       status: '0',

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -273,7 +273,7 @@ export class Assets extends Instantiable {
         ddo.service[i].attributes.additionalInformation.links = []
       }
 
-      if (newMetadata.status.isOrderDisabled !== undefined) {
+      if (newMetadata.status?.isOrderDisabled !== undefined) {
         !ddo.service[i].attributes.status
           ? (ddo.service[i].attributes.status = {
               isOrderDisabled: newMetadata.status.isOrderDisabled

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -474,7 +474,8 @@ export class Assets extends Instantiable {
   ): Promise<string> {
     let service: Service
 
-    const consumable = await this.isConsumable(did)
+    const ddo = await this.resolve(did)
+    const consumable = await this.isConsumable(ddo)
     if (consumable.status > 0) return null
 
     if (!consumerAddress) consumerAddress = payerAddress
@@ -646,17 +647,16 @@ export class Assets extends Instantiable {
 
   /**
    *
-   * @param {String} did
+   * @param {DDO} ddo
    * @return {Promise<Consumable>}
    */
-  public async isConsumable(did: string): Promise<Consumable> {
-    const ddo = await this.resolve(did)
+  public async isConsumable(ddo: DDO): Promise<Consumable> {
     if (!ddo) return null
 
     if (ddo.isDisable)
       return {
         status: 1,
-        message: 'Asset is disabled'
+        message: 'Ordering this asset has been temporarily disabled by the publisher.'
       }
 
     /*

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -644,7 +644,7 @@ export class Assets extends Instantiable {
   /**
    *
    * @param {String} did
-   * @param {String} consumerAddress
+   * @param {String} consumerAddress // Optional, to check allow/deny list
    * @return {Promise<Consumable>}
    */
   public async isConsumable(did: string, consumerAddress?: string): Promise<Consumable> {
@@ -656,13 +656,20 @@ export class Assets extends Instantiable {
         message: 'Asset is disabled'
       }
 
-    // To do: Check if ddo have allow/deny list
-    if (consumerAddress) {
-      // To do: check credentials using consumerAddress
-      // return: 4, Credential missing from allow list
-      // return: 5, Credential found on deny list
+    /*
+    // To do: check credentials using consumerAddress
+    if (ddo.credential.allow.length > 0) {
+      if (consumerAddress) {
+        // call method check consumerAddress with allow list
+        // return: 2, Credential missing from allow list
+      }
+    } else if (ddo.credential.deny.length > 0) {
+      if (consumerAddress) {
+        // call method check consumerAddress with deny list
+        // return: 3, Credential found on deny list
+      }
     }
-
+    */
     return {
       status: '0',
       message: 'All good'

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -474,6 +474,9 @@ export class Assets extends Instantiable {
   ): Promise<string> {
     let service: Service
 
+    const consumable = await this.isConsumable(did)
+    if (consumable.status > 0) return null
+
     if (!consumerAddress) consumerAddress = payerAddress
     if (serviceIndex === -1) {
       service = await this.getServiceByType(did, serviceType)
@@ -651,7 +654,7 @@ export class Assets extends Instantiable {
 
     if (ddo.isDisable)
       return {
-        status: '1',
+        status: 1,
         message: 'Asset is disabled'
       }
 
@@ -661,7 +664,7 @@ export class Assets extends Instantiable {
     // return: 5, Credential found on deny list
     */
     return {
-      status: '0',
+      status: 0,
       message: 'All good'
     }
   }

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -649,8 +649,9 @@ export class Assets extends Instantiable {
    * @param {String} did
    * @return {Promise<Consumable>}
    */
-  public async isConsumable(did: string, consumerAddress?: string): Promise<Consumable> {
+  public async isConsumable(did: string): Promise<Consumable> {
     const ddo = await this.resolve(did)
+    if (!ddo) return null
 
     if (ddo.isDisable)
       return {

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -13,6 +13,7 @@ import { Provider } from '../provider/Provider'
 import { isAddress } from 'web3-utils'
 import { MetadataMain } from '../ddo/interfaces'
 import { TransactionReceipt } from 'web3-core'
+import { Consumable } from '../ddo/interfaces/Consumable'
 
 export enum CreateProgressStep {
   CreatingDataToken,
@@ -270,6 +271,7 @@ export class Assets extends Instantiable {
       } else {
         ddo.service[i].attributes.additionalInformation.links = []
       }
+      if (newMetadata.isDisable) ddo.isDisable = newMetadata.isDisable
     }
     return ddo
   }
@@ -637,5 +639,33 @@ export class Assets extends Instantiable {
       } catch (e) {}
     }
     return results
+  }
+
+  /**
+   *
+   * @param {String} did
+   * @param {String} consumerAddress
+   * @return {Promise<Consumable>}
+   */
+  public async isConsumable(did: string, consumerAddress?: string): Promise<Consumable> {
+    const ddo = await this.resolve(did)
+
+    if (ddo.isDisable)
+      return {
+        status: '1',
+        message: 'Asset is disabled'
+      }
+
+    // To do: Check if ddo have allow/deny list
+    if (consumerAddress) {
+      // To do: check credentials using consumerAddress
+      // return: 4, Credential missing from allow list
+      // return: 5, Credential found on deny list
+    }
+
+    return {
+      status: '0',
+      message: 'All good'
+    }
   }
 }

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -148,9 +148,10 @@ export class Assets extends Instantiable {
             type: 'metadata',
             attributes: {
               // Default values
-              curation: {
-                rating: 0,
-                numVotes: 0
+              status: {
+                isListed: true,
+                isRetired: false,
+                isOrderDisabled: false
               },
               // Overwrites defaults
               ...metadata,
@@ -271,7 +272,15 @@ export class Assets extends Instantiable {
       } else {
         ddo.service[i].attributes.additionalInformation.links = []
       }
-      if (newMetadata.isDisable) ddo.isDisable = newMetadata.isDisable
+
+      if (newMetadata.status.isOrderDisabled !== undefined) {
+        !ddo.service[i].attributes.status
+          ? (ddo.service[i].attributes.status = {
+              isOrderDisabled: newMetadata.status.isOrderDisabled
+            })
+          : (ddo.service[i].attributes.status.isOrderDisabled =
+              newMetadata.status.isOrderDisabled)
+      }
     }
     return ddo
   }
@@ -652,8 +661,9 @@ export class Assets extends Instantiable {
    */
   public async isConsumable(ddo: DDO): Promise<Consumable> {
     if (!ddo) return null
+    const metadata = ddo.findServiceByType('metadata')
 
-    if (ddo.isDisable)
+    if (metadata.attributes.status?.isOrderDisabled)
       return {
         status: 1,
         message: 'Ordering this asset has been temporarily disabled by the publisher.'

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -458,9 +458,29 @@ describe('Marketplace flow', () => {
   })
 
   it('Alice should check if her asset is disable', async () => {
-    const response = await ocean.assets.isConsumable(ddo.id)
+    const response = await ocean.assets.isConsumable(ddo)
     assert(response !== null)
     assert(response.status === 0)
+  })
+
+  it('Alice should update her asset and set isDisable = true', async () => {
+    const newMetaData: EditableMetadata = {
+      isDisable: true
+    }
+    const newDdo = await ocean.assets.editMetadata(ddo, newMetaData)
+    assert(newDdo !== null)
+    const txid = await ocean.onChainMetadata.update(newDdo.id, newDdo, alice.getId())
+    assert(txid !== null)
+    await sleep(60000)
+    const resolvedDDO = await ocean.assets.resolve(ddo.id)
+    assert(resolvedDDO !== null)
+    asset(resolvedDDO.isDisable === true)
+  })
+
+  it('Bob should not be able to consume Alice dataset after disable', async () => {
+    const response = await ocean.assets.isConsumable(ddo)
+    assert(response !== null)
+    assert(response.status === 1)
   })
 
   it('Alice should create a FRE pricing for her asset', async () => {

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -463,9 +463,11 @@ describe('Marketplace flow', () => {
     assert(response.status === 0)
   })
 
-  it('Alice should update her asset and set isDisable = true', async () => {
+  it('Alice should update her asset and set isOrderDisabled = true', async () => {
     const newMetaData: EditableMetadata = {
-      isDisable: true
+      status: {
+        isOrderDisabled: true
+      }
     }
     const newDdo = await ocean.assets.editMetadata(ddo, newMetaData)
     assert(newDdo !== null)
@@ -474,7 +476,8 @@ describe('Marketplace flow', () => {
     await sleep(60000)
     const resolvedDDO = await ocean.assets.resolve(ddo.id)
     assert(resolvedDDO !== null)
-    assert(resolvedDDO.isDisable === true)
+    const metaData = await ocean.assets.getServiceByType(resolvedDDO.id, 'metadata')
+    assert.deepEqual(metaData.attributes.status.isOrderDisabled, true)
   })
 
   it('Bob should not be able to consume Alice dataset after disable', async () => {

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -457,6 +457,12 @@ describe('Marketplace flow', () => {
     assert(response === true)
   })
 
+  it('Alice should check if her asset is disable', async () => {
+    const response = await ocean.assets.isConsumable(ddo.id)
+    assert(response !== null)
+    assert(response.status === 0)
+  })
+
   it('Alice should create a FRE pricing for her asset', async () => {
     const trxReceipt = await ocean.fixedRateExchange.create(
       tokenAddress,

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -474,7 +474,7 @@ describe('Marketplace flow', () => {
     await sleep(60000)
     const resolvedDDO = await ocean.assets.resolve(ddo.id)
     assert(resolvedDDO !== null)
-    asset(resolvedDDO.isDisable === true)
+    assert(resolvedDDO.isDisable === true)
   })
 
   it('Bob should not be able to consume Alice dataset after disable', async () => {

--- a/test/unit/__fixtures__/ddo.json
+++ b/test/unit/__fixtures__/ddo.json
@@ -137,10 +137,10 @@
             }
           ]
         },
-        "curation": {
-          "rating": 0.93,
-          "numVotes": 123,
-          "schema": "Binary Voting"
+        "status": {
+          "isListed": true,
+          "isRetired": false,
+          "isOrderDisabled": false
         },
         "additionalInformation": {
           "description": "Weather information of UK including temperature and humidity",

--- a/test/unit/ddo/DDO.test.ts
+++ b/test/unit/ddo/DDO.test.ts
@@ -116,10 +116,10 @@ describe('DDO', () => {
               }
             ]
           },
-          curation: {
-            rating: 0.93,
-            numVotes: 123,
-            schema: 'Binary Voting'
+          status: {
+            isListed: true,
+            isRetired: false,
+            isOrderDisabled: false
           },
           additionalInformation: {
             description: 'Weather information of UK including temperature and humidity',


### PR DESCRIPTION
Fixes #759 

The function should check the data asset ddo if is consumable by:

- check isOrderDisabled flag in `status` object of ddo (if exists & true -> asset is not consumable)

Return is an interface, containing a status and a status_message: Eg
- 0, All good
- 1, Ordering this asset has been temporarily disabled by the publisher.