### PR TITLE
skip coverage job for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     needs: [test_unit, test_integration]
-    if: success()
+    if: ${{ success() && github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Workaround as there is not really a need for coverage change checks on dependency updates.

Fixes #862