### PR TITLE
remove redundant build on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,6 @@ jobs:
           node-version: '16'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Cut publish time in half, as `prepublishOnly` npm script will result in a build when `npm publish` is called. Right now this resulted in 2 builds one after another but we only need 1