### PR TITLE
Add agreementId in ComputeJob interface

### DIFF
--- a/src/ocean/interfaces/Compute.ts
+++ b/src/ocean/interfaces/Compute.ts
@@ -15,6 +15,7 @@ export interface ComputeJob {
   resultsDid?: DID
   inputDID?: string[]
   algoDID?: string
+  agreementId?: string
 }
 
 export interface ComputeOutput {


### PR DESCRIPTION
Changes proposed in this PR:
- Add `agreementId` in the interface as exist for market usage

example of returned `ComputeJob` data: 

```
{
    "agreementId": "0x77e22e055264e1fa017078b5a0356f8c90cbdf103e0c6d8374f7acff3e5f3a31",
    "algoDID": "did:op:013815DCD034d452019D3809b0C8Eb57A20C0CCe",
    "dateCreated": 1624842644.1359,
    "dateFinished": 1624842721.980891,
    "inputDID": [
        "did:op:38D1Fc21e9231b29E7bD836eb8E44DcA88Cd1F91"
    ],
    "jobId": "b9fcef93a584487ab218e39109d0f391",
    "removed": 0,
    "status": 70,
    "statusText": "Job finished",
    "stopreq": 0
}
```