### PR TITLE
Clean up transferOwnership

### DIFF
--- a/src/metadatacache/MetadataCache.ts
+++ b/src/metadatacache/MetadataCache.ts
@@ -233,47 +233,6 @@ export class MetadataCache {
     return this.retrieveDDO(undefined, metadataServiceEndpoint)
   }
 
-  /**
-   * Transfer ownership of a DDO
-   * @param  {DID | string} did DID of the asset to update.
-   * @param  {String} newOwner New owner of the DDO
-   * @param  {String} updated Updated field of the DDO
-   * @param  {String} signature Signature using updated field to verify that the consumer has rights
-   * @return {Promise<String>} Result.
-   */
-  public async transferOwnership(
-    did: DID | string,
-    newOwner: string,
-    updated: string,
-    signature: string
-  ): Promise<string> {
-    did = did && DID.parse(did)
-    const fullUrl = `${this.url}${apiPath}/owner/update/${did.getDid()}`
-    const result = await this.fetch
-      .put(
-        fullUrl,
-        JSON.stringify({
-          signature: signature,
-          updated: updated,
-          newOwner: newOwner
-        })
-      )
-      .then((response: Response) => {
-        if (response.ok) {
-          return response.text
-        }
-        this.logger.log('transferownership failed:', response.status, response.statusText)
-        return null
-      })
-
-      .catch((error) => {
-        this.logger.error('Error transfering ownership metadata: ', error)
-        return null
-      })
-
-    return result
-  }
-
   public async getOwnerAssets(owner: string): Promise<QueryResult> {
     const q = {
       page: 1,

--- a/src/metadatacache/MetadataCache.ts
+++ b/src/metadatacache/MetadataCache.ts
@@ -1,6 +1,5 @@
 import { DDO } from '../ddo/DDO'
 import DID from '../ocean/DID'
-import { EditableMetadata } from '../ddo/interfaces/EditableMetadata'
 import { Logger, isDdo } from '../utils'
 import { WebServiceConnector } from '../ocean/utils/WebServiceConnector'
 import { Response } from 'node-fetch'

--- a/src/metadatacache/OnChainMetaData.ts
+++ b/src/metadatacache/OnChainMetaData.ts
@@ -230,23 +230,30 @@ export class OnChainMetadata {
 
   /**
    * Transfer Ownership of a DDO
-   * @param {String} did
+   * @param {String} ddo
    * @param {String} newOwner
-   * @param {String} consumerAccount
-   * @return {Promise<TransactionReceipt>} exchangeId
+   * @param {String} existingOwner
+   * @return {Promise<TransactionReceipt>} TransactionReceipt
    */
   public async transferOwnership(
-    did: string,
+    ddo: DDO,
     newOwner: string,
-    consumerAccount: string
+    existingOwner: string
   ): Promise<TransactionReceipt> {
-    if (!this.DDOContract) return null
+    if (!ddo) return null
+
+    const newDdo = new DDO({
+      ...ddo,
+      publicKey: [
+        {
+          ...ddo.publicKey[0],
+          owner: newOwner
+        }
+      ]
+    })
+
     try {
-      const trxReceipt = await this.DDOContract.methods
-        .transferOwnership(didZeroX(did), newOwner)
-        .send({
-          from: consumerAccount
-        })
+      const trxReceipt = await this.update(ddo.id, newDdo, existingOwner)
       return trxReceipt
     } catch (e) {
       this.logger.error(`ERROR: Failed to transfer DDO ownership : ${e.message}`)

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -783,4 +783,25 @@ export class Assets extends Instantiable {
     */
     return { status, message, result }
   }
+
+  /**
+   * Transfer Ownership of a DDO
+   * @param {String} ddo
+   * @param {String} newOwner
+   * @param {String} existingOwner
+   * @return {Promise<TransactionReceipt>} TransactionReceipt
+   */
+  public async transferOwnership(
+    ddo: DDO,
+    newOwner: string,
+    existingOwner: string
+  ): Promise<TransactionReceipt> {
+    if (!ddo) return null
+
+    return await this.ocean.onChainMetadata.transferOwnership(
+      ddo,
+      newOwner,
+      existingOwner
+    )
+  }
 }

--- a/src/ocean/Assets.ts
+++ b/src/ocean/Assets.ts
@@ -798,10 +798,12 @@ export class Assets extends Instantiable {
   ): Promise<TransactionReceipt> {
     if (!ddo) return null
 
-    return await this.ocean.onChainMetadata.transferOwnership(
+    const tx = await this.ocean.onChainMetadata.transferOwnership(
       ddo,
       newOwner,
       existingOwner
     )
+
+    return tx
   }
 }

--- a/test/integration/Marketplaceflow.test.ts
+++ b/test/integration/Marketplaceflow.test.ts
@@ -18,30 +18,10 @@ import { Ocean } from '../../src/ocean/Ocean'
 import { ConfigHelper } from '../../src/utils/ConfigHelper'
 import { TestContractHandler } from '../TestContractHandler'
 import { LoggerInstance } from '../../src/utils'
-const fetch = require('cross-fetch')
+import { sleep, waitForAqua } from './utils'
+
 const web3 = new Web3('http://127.0.0.1:8545')
 
-function sleep(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
-async function waitForAqua(ocean, did) {
-  const apiPath = '/api/v1/aquarius/assets/ddo'
-  let tries = 0
-  do {
-    try {
-      const result = await fetch(ocean.metadataCache.url + apiPath + '/' + did)
-      if (result.ok) {
-        break
-      }
-    } catch (e) {
-      // do nothing
-    }
-    await sleep(1500)
-    tries++
-  } while (tries < 100)
-}
 use(spies)
 
 describe('Marketplace flow', () => {

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -1,0 +1,25 @@
+import { Ocean } from '../../src/ocean/Ocean'
+const fetch = require('cross-fetch')
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export async function waitForAqua(ocean: Ocean, did: string) {
+  const apiPath = '/api/v1/aquarius/assets/ddo'
+  let tries = 0
+  do {
+    try {
+      const result = await fetch(ocean.metadataCache.getURI() + apiPath + '/' + did)
+      if (result.ok) {
+        break
+      }
+    } catch (e) {
+      // do nothing
+    }
+    await sleep(1500)
+    tries++
+  } while (tries < 100)
+}


### PR DESCRIPTION
Reduce all `transferOwnership` methods to a single one.

- `ocean.assets.transferOwnership` as main interface
- shortcut to `ocean.OnChainMetadata.transferOwnership` which updates the owner field in DDO on-chain, creating a `MetadataUpdate` event in the process
- add an integration test for the whole thing (WIP)
- based on findings in https://github.com/oceanprotocol/privateissues/issues/36