### PR TITLE
test barge version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'oceanprotocol/barge'
+          ref: 'featuree/version-bumps'
           path: 'barge'
 
       - name: Login to Docker Hub


### PR DESCRIPTION
Testing https://github.com/oceanprotocol/barge/pull/257 against our CI here.