### PR TITLE
set versioning-strategy for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '03:00'
-    timezone: Europe/Berlin
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: Europe/Berlin
+      versioning-strategy: increase


### PR DESCRIPTION
Problem: dependabot just updates the `package-lock.json`, but not `package.json`, creating an unexpected mismatch when checking out versions used.

Solution: from here https://github.com/dependabot/dependabot-core/issues/3891