### PR TITLE
set versioning-strategy for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,8 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: '/'
+    versioning-strategy: increase
     schedule:
       interval: daily
       time: '03:00'
       timezone: Europe/Berlin
-      versioning-strategy: increase


### PR DESCRIPTION
Try no. 2 as addendum to #1040. Cause I can't do proper indentation for YAML, and GitHub only complained about it after merge into `main`