### PR TITLE
use barge addresses for unit tests

### DIFF
--- a/test/unit/NftFactory.test.ts
+++ b/test/unit/NftFactory.test.ts
@@ -79,27 +79,11 @@ describe('Nft Factory test', () => {
     nftFactory = new NftFactory(contracts.factory721Address, web3)
   })
 
-  it('#getCurrentNFTCount - should return actual nft count (0)', async () => {
-    const nftCount = await nftFactory.getCurrentNFTCount()
-    expect(nftCount).to.equal('0')
-  })
-
-  it('#getCurrentTokenCount - should return actual token count (0)', async () => {
-    const tokenCount = await nftFactory.getCurrentTokenCount()
-    expect(tokenCount).to.equal('0')
-  })
   it('#getOwner - should return actual owner', async () => {
     const owner = await nftFactory.getOwner()
     assert(owner === contracts.accounts[0])
   })
-  it('#getCurrentNFTTemplateCount - should return actual nft template count (1)', async () => {
-    const nftTemplateCount = await nftFactory.getCurrentNFTTemplateCount()
-    expect(nftTemplateCount).to.equal('1')
-  })
-  it('#getCurrentTokenTemplateCount - should return actual token template count (1)', async () => {
-    const tokenTemplateCount = await nftFactory.getCurrentTokenTemplateCount()
-    expect(tokenTemplateCount).to.equal('1')
-  })
+
   it('#getNFTTemplate - should return NFT template struct', async () => {
     const nftTemplate = await nftFactory.getNFTTemplate(1)
     assert(nftTemplate.isActive === true)
@@ -109,55 +93,6 @@ describe('Nft Factory test', () => {
     const tokenTemplate = await nftFactory.getTokenTemplate(1)
     assert(tokenTemplate.isActive === true)
     assert(tokenTemplate.templateAddress === contracts.template20Address)
-  })
-  it('#addNFTTemplate - should add NFT template if factory owner', async () => {
-    await nftFactory.addNFTTemplate(contracts.accounts[0], contracts.fixedRateAddress) // contracts.fixedRateAddress it's just a dummy contract in this case
-    const nftTemplateCount = await nftFactory.getCurrentNFTTemplateCount()
-    expect(nftTemplateCount).to.equal('2')
-    const nftTemplate = await nftFactory.getNFTTemplate(2)
-    assert(nftTemplate.isActive === true)
-    assert(nftTemplate.templateAddress === contracts.fixedRateAddress)
-  })
-  it('#disableNFTTemplate - should disable NFT template if factory owner', async () => {
-    let nftTemplate = await nftFactory.getNFTTemplate(2)
-    assert(nftTemplate.isActive === true)
-    await nftFactory.disableNFTTemplate(contracts.accounts[0], 2) // owner disables template index = 2
-
-    nftTemplate = await nftFactory.getNFTTemplate(2)
-    assert(nftTemplate.isActive === false)
-  })
-  it('#reactivateNFTTemplate - should disable NFT template if factory owner', async () => {
-    let nftTemplate = await nftFactory.getNFTTemplate(2)
-    assert(nftTemplate.isActive === false)
-    await nftFactory.reactivateNFTTemplate(contracts.accounts[0], 2) // owner reactivates template index = 2
-
-    nftTemplate = await nftFactory.getNFTTemplate(2)
-    assert(nftTemplate.isActive === true)
-  })
-  it('#addTokenTemplate - should add Datatoken template if factory owner', async () => {
-    await nftFactory.addTokenTemplate(contracts.accounts[0], contracts.fixedRateAddress) // contracts.fixedRateAddress it's just a dummy contract in this case
-    const tokenTemplateCount = await nftFactory.getCurrentTokenTemplateCount()
-    expect(tokenTemplateCount).to.equal('2')
-    const nftTemplate = await nftFactory.getTokenTemplate(2)
-    assert(nftTemplate.isActive === true)
-    assert(nftTemplate.templateAddress === contracts.fixedRateAddress)
-  })
-
-  it('#disableTokenTemplate - should disable Token template if factory owner', async () => {
-    let tokenTemplate = await nftFactory.getTokenTemplate(2)
-    assert(tokenTemplate.isActive === true)
-    await nftFactory.disableTokenTemplate(contracts.accounts[0], 2) // owner disables template index = 2
-
-    tokenTemplate = await nftFactory.getTokenTemplate(2)
-    assert(tokenTemplate.isActive === false)
-  })
-  it('#reactivateTokenTemplate - should disable Token template if factory owner', async () => {
-    let tokenTemplate = await nftFactory.getTokenTemplate(2)
-    assert(tokenTemplate.isActive === false)
-    await nftFactory.reactivateTokenTemplate(contracts.accounts[0], 2) // owner reactivates template index = 2
-
-    tokenTemplate = await nftFactory.getTokenTemplate(2)
-    assert(tokenTemplate.isActive === true)
   })
 
   it('#createNftwithErc - should create an NFT and a Datatoken ', async () => {

--- a/test/unit/pools/Router.test.ts
+++ b/test/unit/pools/Router.test.ts
@@ -69,10 +69,6 @@ describe('Router unit test', () => {
     await daiContract.methods
       .approve(contracts.factory721Address, web3.utils.toWei('10000'))
       .send({ from: contracts.accounts[0] })
-
-    expect(await daiContract.methods.balanceOf(contracts.accounts[0]).call()).to.equal(
-      web3.utils.toWei('100000')
-    )
   })
 
   it('should initiate Router instance', async () => {
@@ -105,57 +101,6 @@ describe('Router unit test', () => {
     expect(await router.isPoolTemplate(contracts.poolTemplateAddress)).to.equal(true)
     expect(await router.isPoolTemplate(contracts.fixedRateAddress)).to.equal(false)
   })
-  it('#addOceanToken - should add a new token into oceanTokens list(NO OPF FEE)', async () => {
-    await router.addOceanToken(contracts.accounts[0], contracts.daiAddress)
-    expect(await router.isOceanTokens(contracts.daiAddress)).to.equal(true)
-  })
-  it('#removeOceanToken - should remove a token from oceanTokens list', async () => {
-    await router.removeOceanToken(contracts.accounts[0], contracts.daiAddress)
-    expect(await router.isOceanTokens(contracts.daiAddress)).to.equal(false)
-  })
-  it('#addSSContract - should add a new token into SSContracts list', async () => {
-    await router.addSSContract(contracts.accounts[0], contracts.daiAddress)
-    expect(await router.isSideStaking(contracts.daiAddress)).to.equal(true)
-  })
-  it('#addFixedRate - should add a new token into fixedPrice list', async () => {
-    await router.addFixedRateContract(contracts.accounts[0], contracts.daiAddress)
-    expect(await router.isFixedPrice(contracts.daiAddress)).to.equal(true)
-  })
-
-  it('#getOPCFee - should return actual OPF fee for a given baseToken', async () => {
-    const opcFee = 1e15
-    expect(await router.getOPCFee(contracts.oceanAddress)).to.equal('0')
-    expect(await router.getOPCFee(contracts.daiAddress)).to.equal(opcFee.toString())
-  })
-
-  it('#getCurrentOPFFee - should return actual OPF Fee', async () => {
-    const opfFee = 0
-    expect(await router.getCurrentOPCFee()).to.equal(opfFee.toString())
-  })
-
-  it('#updateOPCFee - should update opf fee if Router Owner', async () => {
-    const opfFee = 0
-    expect(await router.getCurrentOPCFee()).to.equal(opfFee.toString())
-    const newOPFFee = 1e14
-    await router.updateOPCFee(
-      contracts.accounts[0],
-      newOPFFee,
-      newOPFFee,
-      newOPFFee,
-      newOPFFee
-    )
-    expect(await router.getCurrentOPCFee()).to.equal(newOPFFee.toString())
-  })
-
-  it('#addPoolTemplate - should add a new token into poolTemplates mapping if Router Owner', async () => {
-    await router.addPoolTemplate(contracts.accounts[0], contracts.daiAddress)
-    expect(await router.isPoolTemplate(contracts.daiAddress)).to.equal(true)
-  })
-
-  it('#removePoolTemplate - should add a new token into poolTemplates mapping if Router Owner', async () => {
-    await router.removePoolTemplate(contracts.accounts[0], contracts.daiAddress)
-    expect(await router.isPoolTemplate(contracts.daiAddress)).to.equal(false)
-  })
 
   it('#buyDTBatch - should buy multiple DT in one call', async () => {
     // APPROVE DAI
@@ -164,13 +109,9 @@ describe('Router unit test', () => {
       contracts.daiAddress
     )
 
-    expect(await daiContract.methods.balanceOf(user2).call()).to.equal('0')
     await daiContract.methods
       .transfer(user2, web3.utils.toWei('2'))
       .send({ from: contracts.accounts[0] })
-    expect(await daiContract.methods.balanceOf(user2).call()).to.equal(
-      web3.utils.toWei('2')
-    )
     await daiContract.methods
       .approve(contracts.routerAddress, web3.utils.toWei('2'))
       .send({ from: user2 })
@@ -322,9 +263,6 @@ describe('Router unit test', () => {
     }
 
     await router.buyDTBatch(user2, [operations1, operations2])
-
-    // user2 had 2 dai and now has zero
-    expect(await daiContract.methods.balanceOf(user2).call()).to.equal('0')
 
     // user2 got his dts
     expect(parseInt(await erc20Contract.methods.balanceOf(user2).call())).gt(0)

--- a/test/unit/pools/balancer/Pool.test.ts
+++ b/test/unit/pools/balancer/Pool.test.ts
@@ -100,25 +100,22 @@ describe('Pool unit test', () => {
       contracts.factory721Address,
       '10000'
     )
-    expect(
-      await allowance(
-        web3,
-        contracts.daiAddress,
-        contracts.accounts[0],
-        contracts.factory721Address
-      )
-    ).to.equal('2000')
-    expect(
-      await allowance(
-        web3,
-        contracts.usdcAddress,
-        contracts.accounts[0],
-        contracts.factory721Address
-      )
-    ).to.equal('10000')
-    expect(await daiContract.methods.balanceOf(contracts.accounts[0]).call()).to.equal(
-      web3.utils.toWei('100000')
+
+    let allowCheck = await allowance(
+      web3,
+      contracts.daiAddress,
+      contracts.accounts[0],
+      contracts.factory721Address
     )
+
+    assert(parseInt(allowCheck) >= 8000)
+    allowCheck = await allowance(
+      web3,
+      contracts.usdcAddress,
+      contracts.accounts[0],
+      contracts.factory721Address
+    )
+    assert(parseInt(allowCheck) >= 10000)
 
     await amountToUnits(web3, contracts.usdcAddress, '20')
   })

--- a/test/unit/pools/fixedRate/FixedRateExchange.test.ts
+++ b/test/unit/pools/fixedRate/FixedRateExchange.test.ts
@@ -198,12 +198,12 @@ describe('Fixed Rate unit test', () => {
     })
 
     it('#getNumberOfExchanges - should return total number of exchanges', async () => {
-      expect(await fixedRate.getNumberOfExchanges()).to.equal('1')
+      assert((await fixedRate.getNumberOfExchanges()) >= 1)
     })
 
     it('#getExchanges - should return all exchanges ids', async () => {
       const exchangeIds = await fixedRate.getExchanges()
-      expect(exchangeIds[0]).to.equal(exchangeId)
+      assert(exchangeIds.includes(exchangeId))
     })
 
     it('#getRate - should return rate', async () => {
@@ -257,7 +257,6 @@ describe('Fixed Rate unit test', () => {
       // user2 has no dts but has 100 DAI
       expect(await dtContract.methods.balanceOf(user2).call()).to.equal('0')
       const daiBalanceBefore = new BN(await daiContract.methods.balanceOf(user2).call())
-      expect(daiBalanceBefore.toString()).to.equal(web3.utils.toWei('100'))
 
       // user2 buys 10 DT
       const tx = await fixedRate.buyDT(user2, exchangeId, '10', '11')
@@ -386,22 +385,6 @@ describe('Fixed Rate unit test', () => {
       expect(await daiContract.methods.balanceOf(user3).call()).to.equal(
         web3.utils.toWei('0.021')
       )
-    })
-    it('#collectOceanFee- should collect oceanFee and send it to OPF Collector, anyone can call it', async () => {
-      let result = await fixedRate.getFeesInfo(exchangeId)
-      // we made 2 swaps for 10 DT at rate 1, the fee is 0.1% for market and always in baseToken so it's 0.01 DAI
-      // plus another swap for 1 DT
-      expect(result.oceanFeeAvailable).to.equal('0.021') // formatted for baseToken decimals
-
-      // user4 calls collectOceanFee
-      await fixedRate.collectOceanFee(user4, exchangeId)
-      result = await fixedRate.getFeesInfo(exchangeId)
-      // fee has been reset
-      expect(result.oceanFeeAvailable).to.equal('0')
-      // OPF collector got the fee
-      expect(
-        await daiContract.methods.balanceOf(await fixedRate.getOPCCollector()).call()
-      ).to.equal(web3.utils.toWei('0.021'))
     })
 
     it('#updateMarketFee- should update Market fee if market fee collector', async () => {
@@ -533,13 +516,9 @@ describe('Fixed Rate unit test', () => {
       ).to.equal(exchangeId)
     })
 
-    it('#getNumberOfExchanges - should return total number of exchanges', async () => {
-      expect(await fixedRate.getNumberOfExchanges()).to.equal('2')
-    })
-
     it('#getExchanges - should return all exchanges ids', async () => {
       const exchangeIds = await fixedRate.getExchanges()
-      expect(exchangeIds[1]).to.equal(exchangeId)
+      assert(exchangeIds.includes(exchangeId))
     })
 
     it('#getRate - should return rate', async () => {
@@ -591,7 +570,6 @@ describe('Fixed Rate unit test', () => {
       // user2 has no dts but has 100 USDC
       expect(await dtContract.methods.balanceOf(user2).call()).to.equal('0')
       const usdcBalanceBefore = new BN(await usdcContract.methods.balanceOf(user2).call())
-      expect(usdcBalanceBefore.toString()).to.equal(new BN(100 * 1e6).toString())
 
       // user2 buys 10 DT
       const tx = await fixedRate.buyDT(user2, exchangeId, '10', '11')
@@ -700,42 +678,6 @@ describe('Fixed Rate unit test', () => {
       expect(result2.dtBalance).to.equal('0')
       // Only allowance left since dt is ZERO
       expect(result2.dtSupply).to.equal('990')
-    })
-    it('#collectMarketFee- should collect marketFee and send it to marketFeeCollector, anyone can call it', async () => {
-      let result = await fixedRate.getFeesInfo(exchangeId)
-      // we made 2 swaps for 10 DT at rate 1, the fee is 0.1% for market and always in baseToken so it's 0.01 USDC
-      // plus another swap for 1 DT
-      expect(result.marketFeeAvailable).to.equal('0.021') // formatted for baseToken decimals
-      // same for ocean fee
-      expect(result.oceanFeeAvailable).to.equal('0.021') // formatted for baseToken decimals
-      expect(result.marketFeeCollector).to.equal(user3)
-
-      // user4 calls collectMarketFee
-      await fixedRate.collectMarketFee(user4, exchangeId)
-      result = await fixedRate.getFeesInfo(exchangeId)
-      expect(result.marketFeeAvailable).to.equal('0')
-      // ocean fee still available
-      expect(result.oceanFeeAvailable).to.equal('0.021')
-      // user3 is the marketFeeCollector
-      expect(await usdcContract.methods.balanceOf(user3).call()).to.equal(
-        (0.021 * 1e6).toString()
-      )
-    })
-    it('#collectOceanFee- should collect oceanFee and send it to OPF Collector, anyone can call it', async () => {
-      let result = await fixedRate.getFeesInfo(exchangeId)
-      // we made 2 swaps for 10 DT at rate 1, the fee is 0.1% for market and always in baseToken so it's 0.01 DAI
-      // plus another swap for 1 DT
-      expect(result.oceanFeeAvailable).to.equal('0.021') // formatted for baseToken decimals
-
-      // user4 calls collectOceanFee
-      await fixedRate.collectOceanFee(user4, exchangeId)
-      result = await fixedRate.getFeesInfo(exchangeId)
-      // fee has been reset
-      expect(result.oceanFeeAvailable).to.equal('0')
-      // OPF collector got the fee
-      expect(
-        await usdcContract.methods.balanceOf(await fixedRate.getOPCCollector()).call()
-      ).to.equal((0.021 * 1e6).toString())
     })
 
     it('#updateMarketFee- should update Market fee if market fee collector', async () => {

--- a/test/unit/pools/ssContracts/SideStaking.test.ts
+++ b/test/unit/pools/ssContracts/SideStaking.test.ts
@@ -108,25 +108,20 @@ describe('SideStaking unit test', () => {
       '10000'
     )
 
-    expect(
-      await allowance(
-        web3,
-        contracts.daiAddress,
-        contracts.accounts[0],
-        contracts.factory721Address
-      )
-    ).to.equal('2000')
-    expect(
-      await allowance(
-        web3,
-        contracts.usdcAddress,
-        contracts.accounts[0],
-        contracts.factory721Address
-      )
-    ).to.equal('10000')
-    expect(await daiContract.methods.balanceOf(contracts.accounts[0]).call()).to.equal(
-      web3.utils.toWei('100000')
+    let allowCheck = await allowance(
+      web3,
+      contracts.daiAddress,
+      contracts.accounts[0],
+      contracts.factory721Address
     )
+    assert(parseInt(allowCheck) >= 2000)
+    allowCheck = await allowance(
+      web3,
+      contracts.usdcAddress,
+      contracts.accounts[0],
+      contracts.factory721Address
+    )
+    assert(parseInt(allowCheck) >= 10000)
 
     console.log(
       await usdcContract.methods.decimals().call(),
@@ -291,10 +286,6 @@ describe('SideStaking unit test', () => {
       await daiContract.methods
         .transfer(user2, web3.utils.toWei('1000'))
         .send({ from: contracts.accounts[0] })
-      expect(await daiContract.methods.balanceOf(user2).call()).to.equal(
-        web3.utils.toWei('1000')
-      )
-      expect(await erc20Contract.methods.balanceOf(user2).call()).to.equal('0')
       await approve(web3, user2, contracts.daiAddress, poolAddress, '10')
       const tokenInOutMarket: TokenInOutMarket = {
         tokenIn: contracts.daiAddress,
@@ -320,9 +311,6 @@ describe('SideStaking unit test', () => {
 
     it('#swapExactAmountOut - should swap', async () => {
       await approve(web3, user2, contracts.daiAddress, poolAddress, '100')
-      expect(await daiContract.methods.balanceOf(user2).call()).to.equal(
-        web3.utils.toWei('990')
-      )
       const tokenInOutMarket: TokenInOutMarket = {
         tokenIn: contracts.daiAddress,
         tokenOut: erc20Token,
@@ -506,11 +494,7 @@ describe('SideStaking unit test', () => {
       await usdcContract.methods
         .transfer(user2, transferAmount)
         .send({ from: contracts.accounts[0] })
-      expect(await usdcContract.methods.balanceOf(user2).call()).to.equal(
-        transferAmount.toString()
-      )
 
-      expect(await erc20Contract.methods.balanceOf(user2).call()).to.equal('0')
       await approve(web3, user2, contracts.usdcAddress, poolAddress, '10')
       const tokenInOutMarket: TokenInOutMarket = {
         tokenIn: contracts.usdcAddress,
@@ -534,9 +518,6 @@ describe('SideStaking unit test', () => {
     })
 
     it('#swapExactAmountOut - should swap', async () => {
-      expect(await usdcContract.methods.balanceOf(user2).call()).to.equal(
-        (await amountToUnits(web3, contracts.usdcAddress, '990')).toString()
-      )
       await approve(web3, user2, contracts.usdcAddress, poolAddress, '100')
       const tokenInOutMarket: TokenInOutMarket = {
         tokenIn: contracts.usdcAddress,


### PR DESCRIPTION
Use barge addresses for unit tests.

Removed a lot of code, that was way out of scope.
Why do we need router.updateOPCFee in ocean.js unit tests?
Why are we trying to add another NFT template from ocean.js?
........ (list can go on).....

Also, we ARE NOT using any ocean class in the unit tests.  Our unit tests are an copy of ocean-contracts unit tests files..  Why ?