### PR TITLE
Make metadataProofs optional in setMetadataAndTokenURI

### DIFF
--- a/src/@types/Erc721.ts
+++ b/src/@types/Erc721.ts
@@ -9,5 +9,5 @@ export interface MetadataAndTokenURI {
   metaDataHash: string
   tokenId: number
   tokenURI: string
-  metadataProofs: MetadataProof[]
+  metadataProofs?: MetadataProof[]
 }

--- a/src/tokens/NFT.ts
+++ b/src/tokens/NFT.ts
@@ -1119,9 +1119,13 @@ export class Nft {
       )
     const gasLimitDefault = this.GASLIMIT_DEFAULT
     let estGas
+    const sanitizedMetadataAndTokenURI = {
+      ...metadataAndTokenURI,
+      metadataProofs: metadataAndTokenURI.metadataProofs || []
+    }
     try {
       estGas = await nftContract.methods
-        .setMetaDataAndTokenURI(metadataAndTokenURI)
+        .setMetaDataAndTokenURI(sanitizedMetadataAndTokenURI)
         .estimateGas({ from: metadataUpdater }, (err, estGas) =>
           err ? gasLimitDefault : estGas
         )
@@ -1157,8 +1161,12 @@ export class Nft {
       metadataAndTokenURI,
       nftContract
     )
+    const sanitizedMetadataAndTokenURI = {
+      ...metadataAndTokenURI,
+      metadataProofs: metadataAndTokenURI.metadataProofs || []
+    }
     const trxReceipt = await nftContract.methods
-      .setMetaDataAndTokenURI(metadataAndTokenURI)
+      .setMetaDataAndTokenURI(sanitizedMetadataAndTokenURI)
       .send({
         from: metadataUpdater,
         gas: estGas + 1,


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes #1307 .

Changes proposed in this PR:

- Make metadataProofs optional in setMetadataAndTokenURI