### PR TITLE
Feature/contracts alpha 23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@oceanprotocol/lib",
-      "version": "1.0.0-next.27",
+      "version": "1.0.0-next.28",
       "license": "Apache-2.0",
       "dependencies": {
-        "@oceanprotocol/contracts": "^1.0.0-alpha.22",
+        "@oceanprotocol/contracts": "^1.0.0-alpha.23",
         "bignumber.js": "^9.0.2",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
@@ -3071,9 +3071,9 @@
       }
     },
     "node_modules/@oceanprotocol/contracts": {
-      "version": "1.0.0-alpha.22",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.0.0-alpha.22.tgz",
-      "integrity": "sha512-+m0E2WgH9x66DCtoHB3aaJ69ep3sp/x+jjae50HVgvpw0I0fvatXn5jfHrBxRIBvu0ZIbj6Ct0En3N6h5Yi1vw==",
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-4y0CjXHGoDqv05q9ulLkEC81DRYj0mysOpffiRisxI7iy+MEJ5MzMEI6H50sCD/Du+lT/8W21mvkngKvOQbIHw==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.3.3",
         "@openzeppelin/test-helpers": "^0.5.15",
@@ -23457,9 +23457,9 @@
       }
     },
     "@oceanprotocol/contracts": {
-      "version": "1.0.0-alpha.22",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.0.0-alpha.22.tgz",
-      "integrity": "sha512-+m0E2WgH9x66DCtoHB3aaJ69ep3sp/x+jjae50HVgvpw0I0fvatXn5jfHrBxRIBvu0ZIbj6Ct0En3N6h5Yi1vw==",
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-4y0CjXHGoDqv05q9ulLkEC81DRYj0mysOpffiRisxI7iy+MEJ5MzMEI6H50sCD/Du+lT/8W21mvkngKvOQbIHw==",
       "requires": {
         "@openzeppelin/contracts": "^4.3.3",
         "@openzeppelin/test-helpers": "^0.5.15",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "web3": "^1.7.1"
   },
   "dependencies": {
-    "@oceanprotocol/contracts": "1.0.0-alpha.22",
+    "@oceanprotocol/contracts": "^1.0.0-alpha.23",
     "bignumber.js": "^9.0.2",
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",

--- a/test/unit/pools/dispenser/Dispenser.test.ts
+++ b/test/unit/pools/dispenser/Dispenser.test.ts
@@ -173,11 +173,7 @@ describe('Dispenser flow', () => {
     assert(tx, 'user3 failed to get 1DT')
   })
 
-  it('tries to withdraw all datatokens', async () => {
-    const tx = await DispenserClass.ownerWithdraw(dtAddress, user3)
-    assert(tx === null, 'Request should fail')
-  })
-
+  
   it('user2 withdraws all datatokens', async () => {
     const tx = await DispenserClass.ownerWithdraw(dtAddress, contracts.accounts[0])
     assert(tx, 'user2 failed to withdraw all her tokens')


### PR DESCRIPTION
Breaking changes:
 - fixedrate collectBT & collectDT are expecting amount as well
 - fixedrate collectBT & collectDT are sending funds to erc20.getPaymentCollector() instead of owner
 - fixedrate generateExchangeId takes only 2 params (basetoken, datatoken) , the 3rd param (owner) was removed
 - dispenser :  anyone can call collect, datatokens are always sent to erc20.getPaymentCollector()
 - For ERC20Enterprise, OPC will not take 0.03DT as fee