### PR TITLE
Fix compute status

### DIFF
--- a/src/provider/Provider.ts
+++ b/src/provider/Provider.ts
@@ -528,26 +528,21 @@ export class Provider {
     }
   }
 
-  /** Get status for a specific jobId/documentId/owner.
-   * @param {string} did
-   * @param {string} consumerAddress
-   * @param {string} providerUri
-   * @param {Web3} web3
+  /** Get compute status for a specific jobId/documentId/owner.
+   * @param {string} providerUri The URI of the provider we want to query
+   * @param {string} consumerAddress The consumer ethereum address
+   * @param {string} jobId The ID of a compute job.
+   * @param {string} did The ID of the asset
    * @param {AbortSignal} signal abort signal
-   * @param {string} jobId
    * @return {Promise<ComputeJob | ComputeJob[]>}
    */
   public async computeStatus(
     providerUri: string,
-    signal?: AbortSignal,
+    consumerAddress: string,
     jobId?: string,
     did?: string,
-    consumerAddress?: string
+    signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    if (!jobId && !did && !consumerAddress) {
-      throw new Error('You need at least one of jobId, did, consumerAddress')
-    }
-
     const providerEndpoints = await this.getEndpoints(providerUri)
     const serviceEndpoints = await this.getServiceEndpoints(
       providerUri,
@@ -557,8 +552,8 @@ export class Provider {
       ? this.getEndpointURL(serviceEndpoints, 'computeStatus').urlPath
       : null
 
-    let url = '?documentId=' + noZeroX(did)
-    url += (consumerAddress && `&consumerAddress=${consumerAddress}`) || ''
+    let url = `?consumerAddress=${consumerAddress}`
+    url += (did && `&documentId=${noZeroX(did)}`) || ''
     url += (jobId && `&jobId=${jobId}`) || ''
 
     if (!computeStatusUrl) return null

--- a/test/integration/ComputeFlow.test.ts
+++ b/test/integration/ComputeFlow.test.ts
@@ -337,10 +337,9 @@ describe('Simple compute tests', async () => {
     assert(computeJobs, 'Cannot start compute job')
     const jobStatus = await ProviderInstance.computeStatus(
       providerUrl,
-      null,
+      consumerAccount,
       computeJobs[0].jobId,
-      resolvedDDOAsset.id,
-      consumerAccount
+      resolvedDDOAsset.id
     )
     assert(jobStatus)
   })


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

Based on this https://github.com/oceanprotocol/provider/blob/v4main/ocean_provider/routes/compute.py#L202 the consumerAddres is required and jobId and asset id are optional. In our case the documentId was required
- update compute status query
- update methods jsdoc
