### PR TITLE
Solve all typing warnings

### DIFF
--- a/src/pools/fixedRate/FixedRateExchange.ts
+++ b/src/pools/fixedRate/FixedRateExchange.ts
@@ -1,6 +1,4 @@
 import defaultFixedRateExchangeAbi from '@oceanprotocol/contracts/artifacts/contracts/pools/fixedRate/FixedRateExchange.sol/FixedRateExchange.json'
-import defaultErc20Abi from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template.sol/ERC20Template.json'
-import BigNumber from 'bignumber.js'
 import { TransactionReceipt } from 'web3-core'
 import { Contract } from 'web3-eth-contract'
 import { AbiItem } from 'web3-utils/types'
@@ -48,10 +46,12 @@ export interface FixedPriceSwap {
   datatokenAmount: string
 }
 
+/* eslint-disable no-unused-vars */
 export enum FixedRateCreateProgressStep {
   CreatingExchange,
   ApprovingDatatoken
 }
+/* eslint-enable no-unused-vars */
 
 export class FixedRateExchange {
   public GASLIMIT_DEFAULT = 1000000
@@ -457,7 +457,6 @@ export class FixedRateExchange {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) return null
     if (exchange.active === true) return null
-    const gasLimitDefault = this.GASLIMIT_DEFAULT
 
     const estGas = await this.estActivate(address, exchangeId)
     const trxReceipt = await this.contract.methods.toggleExchangeState(exchangeId).send({
@@ -743,7 +742,6 @@ export class FixedRateExchange {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) return null
     if (exchange.withMint === true) return null
-    const gasLimitDefault = this.GASLIMIT_DEFAULT
 
     const estGas = await this.estActivateMint(address, exchangeId)
     const trxReceipt = await this.contract.methods

--- a/src/pools/ssContracts/SideStaking.ts
+++ b/src/pools/ssContracts/SideStaking.ts
@@ -2,12 +2,7 @@ import Web3 from 'web3'
 import { AbiItem } from 'web3-utils/types'
 import { TransactionReceipt } from 'web3-core'
 import { Contract } from 'web3-eth-contract'
-import {
-  LoggerInstance,
-  getFairGasPrice,
-  ConfigHelper,
-  configHelperNetworks
-} from '../../utils'
+import { LoggerInstance, getFairGasPrice, configHelperNetworks } from '../../utils'
 import BigNumber from 'bignumber.js'
 import SideStakingTemplate from '@oceanprotocol/contracts/artifacts/contracts/pools/ssContracts/SideStaking.sol/SideStaking.json'
 import defaultErc20Abi from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template.sol/ERC20Template.json'

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 export enum LogLevel {
   None = -1,
   Error = 0,
@@ -5,6 +6,7 @@ export enum LogLevel {
   Log = 2,
   Verbose = 3
 }
+/* eslint-enable no-unused-vars */
 
 export class Logger {
   constructor(private logLevel: LogLevel = LogLevel.Error) {}


### PR DESCRIPTION
Cause it's a pain having to constantly see them on every PR review.

Please keep warnings clean in the future, never a need to keep unused imports or define unused variables