### PR TITLE
Issue-#1367: Fix error in `NftFactory.disableTokenTemplate()` and `NftFactory.reactivateTokenTemplate()`

### DIFF
--- a/src/factories/NFTFactory.ts
+++ b/src/factories/NFTFactory.ts
@@ -492,14 +492,14 @@ export class NftFactory {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Factory Owner`)
     }
-    if (templateIndex > (await this.getCurrentNFTTemplateCount())) {
+    if (templateIndex > (await this.getCurrentTokenTemplateCount())) {
       throw new Error(`Template index doesnt exist`)
     }
 
     if (templateIndex === 0) {
       throw new Error(`Template index cannot be ZERO`)
     }
-    if ((await this.getNFTTemplate(templateIndex)).isActive === false) {
+    if ((await this.getTokenTemplate(templateIndex)).isActive === false) {
       throw new Error(`Template is already disabled`)
     }
     const estGas = await this.estGasDisableTokenTemplate(address, templateIndex)
@@ -551,7 +551,7 @@ export class NftFactory {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Factory Owner`)
     }
-    if (templateIndex > (await this.getCurrentNFTTemplateCount())) {
+    if (templateIndex > (await this.getCurrentTokenTemplateCount())) {
       throw new Error(`Template index doesnt exist`)
     }
 

--- a/test/unit/NftFactory.test.ts
+++ b/test/unit/NftFactory.test.ts
@@ -374,4 +374,72 @@ describe('Nft Factory test', () => {
     )
     assert((await nftFactory.checkNFT(nftAddress)) === nftAddress)
   })
+
+  it('#addNFTTemplate - should add a new erc721 token template', async () => {
+    const currentNFTTemplateCount = await nftFactory.getCurrentNFTTemplateCount()
+
+    await nftFactory.addNFTTemplate(factoryOwner, contracts.template721Address)
+
+    expect(
+      (await nftFactory.getCurrentNFTTemplateCount()) === currentNFTTemplateCount + 1
+    )
+  })
+
+  it('#disableNFTTemplate - should disable an erc721 token template', async () => {
+    const currentNFTTemplateCount = await nftFactory.getCurrentNFTTemplateCount()
+
+    let nftTemplate = await nftFactory.getNFTTemplate(currentNFTTemplateCount)
+    assert(nftTemplate.isActive === true)
+
+    await nftFactory.disableNFTTemplate(factoryOwner, currentNFTTemplateCount)
+
+    nftTemplate = await nftFactory.getNFTTemplate(currentNFTTemplateCount)
+    assert(nftTemplate.isActive === false)
+  })
+
+  it('#reactivateNFTTemplate - should reactivate an erc721 previously disabled token template', async () => {
+    const currentNFTTemplateCount = await nftFactory.getCurrentNFTTemplateCount()
+
+    let nftTemplate = await nftFactory.getNFTTemplate(currentNFTTemplateCount)
+    assert(nftTemplate.isActive === false)
+
+    await nftFactory.reactivateNFTTemplate(factoryOwner, currentNFTTemplateCount)
+
+    nftTemplate = await nftFactory.getNFTTemplate(currentNFTTemplateCount)
+    assert(nftTemplate.isActive === true)
+  })
+
+  it('#addTokenTemplate - should add a new erc20 token template', async () => {
+    const currentTokenTemplateCount = await nftFactory.getCurrentTokenTemplateCount()
+
+    await nftFactory.addTokenTemplate(factoryOwner, contracts.template20Address)
+
+    expect(
+      (await nftFactory.getCurrentTokenTemplateCount()) === currentTokenTemplateCount + 1
+    )
+  })
+
+  it('#disableTokenTemplate - should disable an erc20 token template', async () => {
+    const currentTokenTemplateCount = await nftFactory.getCurrentTokenTemplateCount()
+
+    let tokenTemplate = await nftFactory.getTokenTemplate(currentTokenTemplateCount)
+    assert(tokenTemplate.isActive === true)
+
+    await nftFactory.disableTokenTemplate(factoryOwner, currentTokenTemplateCount)
+
+    tokenTemplate = await nftFactory.getTokenTemplate(currentTokenTemplateCount)
+    assert(tokenTemplate.isActive === false)
+  })
+
+  it('#reactivateTokenTemplate - should reactivate an previously disabled erc20 token template', async () => {
+    const currentTokenTemplateCount = await nftFactory.getCurrentTokenTemplateCount()
+
+    let tokenTemplate = await nftFactory.getTokenTemplate(currentTokenTemplateCount)
+    assert(tokenTemplate.isActive === false)
+
+    await nftFactory.reactivateTokenTemplate(factoryOwner, currentTokenTemplateCount)
+
+    tokenTemplate = await nftFactory.getTokenTemplate(currentTokenTemplateCount)
+    assert(tokenTemplate.isActive === true)
+  })
 })


### PR DESCRIPTION
Fixes #1367  .

Changes proposed in this PR:
- Check `CurrentTokenTemplateCount` instead of `CurrentNFTTemplateCount` in `NftFactory.disableTokenTemplate()` and `NftFactory.reactivateTokenTemplate()`