### PR TITLE
default nonce dateNow, include nonce in computeResult params

### DIFF
--- a/src/provider/Provider.ts
+++ b/src/provider/Provider.ts
@@ -100,7 +100,8 @@ export class Provider {
         },
         signal: signal
       })
-      return (await response.json()).nonce.toString()
+      const nonce = (await response.json()).nonce || Date.now()
+      return nonce.toString()
     } catch (e) {
       LoggerInstance.error(e)
       throw new Error('HTTP request failed')
@@ -626,6 +627,7 @@ export class Provider {
     consumeUrl += `?consumerAddress=${accountId}`
     consumeUrl += `&jobId=${jobId}`
     consumeUrl += `&index=${String(index)}`
+    consumeUrl += `&nonce=${nonce}`
     consumeUrl += (signature && `&signature=${signature}`) || ''
 
     if (!computeResultUrl) return null


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- default getNonce to date.now if not in redis
- include nonce in computeResult params as commented (`The UTC timestamp, used to prevent replay attacks`) in provider endpoint but not in used yet