### PR TITLE
update default ESM export

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./dist/lib.module.js",
   "exports": {
     "require": "./dist/lib.js",
-    "default": "./dist/lib.modern.js"
+    "default": "./dist/lib.modern.mjs"
   },
   "types": "./dist/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Fix for recent `microbundle` update which changed the file extension for some of its output, see https://github.com/oceanprotocol/ocean.js/pull/1442 & https://github.com/oceanprotocol/market/pull/1393#issuecomment-1118692059