### PR TITLE
Lock microbundle to v0.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "fs": "0.0.1-security",
-        "microbundle": "^0.15.0",
+        "microbundle": "0.14.2",
         "mocha": "^10.0.0",
         "mock-local-storage": "^1.1.21",
         "nyc": "^15.1.0",
@@ -11335,9 +11335,9 @@
       }
     },
     "node_modules/microbundle": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.15.0.tgz",
-      "integrity": "sha512-EkFst5ntLXoQGewkvga/Kd72RcN7IuJRl5ivLihJSbvLfJQo8LDS0n9X0q81vegiC59vhtKIM6qjrl1fOAtuGw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.14.2.tgz",
+      "integrity": "sha512-jODALfU3w7jnJAqw7Tou9uU8e8zH0GRVWzOd/V7eAvD1fsfb9pyMbmzhFZqnX6SCb54eP1EF5oRyNlSxBAxoag==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.10",
@@ -11376,7 +11376,6 @@
         "rollup-plugin-postcss": "^4.0.0",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.29.0",
-        "rollup-plugin-visualizer": "^5.6.0",
         "sade": "^1.7.4",
         "terser": "^5.7.0",
         "tiny-glob": "^0.2.8",
@@ -15131,63 +15130,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
       "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
       "dev": true
-    },
-    "node_modules/rollup-plugin-visualizer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.6.0.tgz",
-      "integrity": "sha512-CKcc8GTUZjC+LsMytU8ocRr/cGZIfMR7+mdy4YnlyetlmIl/dM8BMnOEpD4JPIGt+ZVW7Db9ZtSsbgyeBH3uTA==",
-      "dev": true,
-      "dependencies": {
-        "nanoid": "^3.1.32",
-        "open": "^8.4.0",
-        "source-map": "^0.7.3",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "rollup-plugin-visualizer": "dist/bin/cli.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/rollup-pluginutils": {
       "version": "2.8.2",
@@ -26645,9 +26587,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "microbundle": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.15.0.tgz",
-      "integrity": "sha512-EkFst5ntLXoQGewkvga/Kd72RcN7IuJRl5ivLihJSbvLfJQo8LDS0n9X0q81vegiC59vhtKIM6qjrl1fOAtuGw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.14.2.tgz",
+      "integrity": "sha512-jODALfU3w7jnJAqw7Tou9uU8e8zH0GRVWzOd/V7eAvD1fsfb9pyMbmzhFZqnX6SCb54eP1EF5oRyNlSxBAxoag==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.10",
@@ -26686,7 +26628,6 @@
         "rollup-plugin-postcss": "^4.0.0",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.29.0",
-        "rollup-plugin-visualizer": "^5.6.0",
         "sade": "^1.7.4",
         "terser": "^5.7.0",
         "tiny-glob": "^0.2.8",
@@ -29389,47 +29330,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
           "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
-          "dev": true
-        }
-      }
-    },
-    "rollup-plugin-visualizer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.6.0.tgz",
-      "integrity": "sha512-CKcc8GTUZjC+LsMytU8ocRr/cGZIfMR7+mdy4YnlyetlmIl/dM8BMnOEpD4JPIGt+ZVW7Db9ZtSsbgyeBH3uTA==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.1.32",
-        "open": "^8.4.0",
-        "source-map": "^0.7.3",
-        "yargs": "^17.3.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "17.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./dist/lib.module.js",
   "exports": {
     "require": "./dist/lib.js",
-    "default": "./dist/lib.modern.mjs"
+    "default": "./dist/lib.modern.js"
   },
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "fs": "0.0.1-security",
-    "microbundle": "^0.15.0",
+    "microbundle": "0.14.2",
     "mocha": "^10.0.0",
     "mock-local-storage": "^1.1.21",
     "nyc": "^15.1.0",


### PR DESCRIPTION
As v0.15.0 generates the modern bundle with `.mjs` extension as it's CommonJS, not ESM, build tools will pick this up as ESM and fail on everything when build tool is not set to use ESM.

Proper way out of this is to use `type: module` in `package.js` making this repo into pure ESM package. But this leads to new problems which can't be solved quickly.

So downgrade and be done with it, see https://github.com/oceanprotocol/market/pull/1393#issuecomment-1118776457