### PR TITLE
Issue-#1485: Remove imports of ABIs in the tests and use utility tranfer(), mint(), balance() functions

### DIFF
--- a/test/unit/factories/NftFactory.test.ts
+++ b/test/unit/factories/NftFactory.test.ts
@@ -31,7 +31,7 @@ describe('Nft Factory test', () => {
   let dtAddress2: string
   let nftAddress: string
 
-  const DATA_TOKEN_AMOUNT = web3.utils.toWei('1')
+  const DATA_TOKEN_AMOUNT = '1'
   const FEE = '0.001'
 
   const nftData: NftCreateData = {

--- a/test/unit/pools/Router.test.ts
+++ b/test/unit/pools/Router.test.ts
@@ -1,7 +1,5 @@
 import { assert, expect } from 'chai'
-import { AbiItem } from 'web3-utils/types'
 import { deployContracts, Addresses } from '../../TestContractHandler'
-import MockERC20 from '@oceanprotocol/contracts/artifacts/contracts/utils/mock/MockERC20Decimals.sol/MockERC20Decimals.json'
 import { web3 } from '../../config'
 import {
   NftFactory,
@@ -9,7 +7,8 @@ import {
   Router,
   balance,
   approve,
-  ZERO_ADDRESS
+  ZERO_ADDRESS,
+  transfer
 } from '../../../src'
 import { Erc20CreateParams, PoolCreationParams, Operation } from '../../../src/@types'
 
@@ -123,14 +122,7 @@ describe('Router unit test', () => {
 
   it('#buyDTBatch - should buy multiple DT in one call', async () => {
     // APPROVE DAI
-    const daiContract = new web3.eth.Contract(
-      MockERC20.abi as AbiItem[],
-      contracts.daiAddress
-    )
-
-    await daiContract.methods
-      .transfer(user1, web3.utils.toWei(DAI_AMOUNT))
-      .send({ from: factoryOwner })
+    await transfer(web3, factoryOwner, contracts.daiAddress, user1, DAI_AMOUNT)
 
     await approve(web3, user1, contracts.daiAddress, contracts.routerAddress, DAI_AMOUNT)
 

--- a/test/unit/pools/fixedRate/FixedRateExchange.test.ts
+++ b/test/unit/pools/fixedRate/FixedRateExchange.test.ts
@@ -1,8 +1,5 @@
 import { assert, expect } from 'chai'
-import { AbiItem } from 'web3-utils/types'
-import { Contract } from 'web3-eth-contract'
 import BigNumber from 'bignumber.js'
-import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template.sol/ERC20Template.json'
 import { deployContracts, Addresses } from '../../../TestContractHandler'
 import { web3 } from '../../../config'
 import {
@@ -13,7 +10,8 @@ import {
   approve,
   transfer,
   balance,
-  unitsToAmount
+  unitsToAmount,
+  Datatoken
 } from '../../../../src'
 import { FreCreationParams, Erc20CreateParams } from '../../../../src/@types'
 
@@ -26,7 +24,6 @@ describe('Fixed Rate unit test', () => {
   let contracts: Addresses
   let fixedRate: FixedRateExchange
   let dtAddress: string
-  let dtContract: Contract
 
   const nftData: NftCreateData = {
     name: '72120Bundle',
@@ -96,7 +93,6 @@ describe('Fixed Rate unit test', () => {
       dtAddress = txReceipt.events.TokenCreated.returnValues.newTokenAddress
       exchangeId = txReceipt.events.NewFixedRate.returnValues.exchangeId
 
-      dtContract = new web3.eth.Contract(ERC20Template.abi as AbiItem[], dtAddress)
       // user1 has no dt1
       expect(await balance(web3, dtAddress, user1)).to.equal('0')
 
@@ -200,9 +196,8 @@ describe('Fixed Rate unit test', () => {
 
     it('#buyDT - user1 should buy some dt', async () => {
       // total supply is ZERO right now so dt owner mints 1000 DT and approves the fixed rate contract
-      await dtContract.methods
-        .mint(exchangeOwner, web3.utils.toWei('1000'))
-        .send({ from: exchangeOwner })
+      const datatoken = new Datatoken(web3)
+      await datatoken.mint(dtAddress, exchangeOwner, '1000', exchangeOwner)
       await approve(web3, exchangeOwner, dtAddress, contracts.fixedRateAddress, '1000')
       // user1 gets 100 DAI so he can buy DTs
       await transfer(web3, exchangeOwner, contracts.daiAddress, user1, '100')
@@ -411,7 +406,6 @@ describe('Fixed Rate unit test', () => {
       dtAddress = txReceipt.events.TokenCreated.returnValues.newTokenAddress
       exchangeId = txReceipt.events.NewFixedRate.returnValues.exchangeId
 
-      dtContract = new web3.eth.Contract(ERC20Template.abi as AbiItem[], dtAddress)
       // user1 has no dt1
       expect(await balance(web3, dtAddress, user1)).to.equal('0')
 
@@ -511,9 +505,8 @@ describe('Fixed Rate unit test', () => {
 
     it('#buyDT - user1 should buy some dt', async () => {
       // total supply is ZERO right now so dt owner mints 1000 DT and approves the fixed rate contract
-      await dtContract.methods
-        .mint(exchangeOwner, web3.utils.toWei('1000'))
-        .send({ from: exchangeOwner })
+      const datatoken = new Datatoken(web3)
+      await datatoken.mint(dtAddress, exchangeOwner, '1000', exchangeOwner)
       await approve(web3, exchangeOwner, dtAddress, contracts.fixedRateAddress, '1000')
       // user1 gets 100 USDC so he can buy DTs
       await transfer(web3, exchangeOwner, contracts.usdcAddress, user1, '100')

--- a/test/unit/pools/ssContracts/SideStaking.test.ts
+++ b/test/unit/pools/ssContracts/SideStaking.test.ts
@@ -15,7 +15,8 @@ import {
   Pool,
   SideStaking,
   unitsToAmount,
-  ZERO_ADDRESS
+  ZERO_ADDRESS,
+  balance
 } from '../../../../src'
 import {
   Erc20CreateParams,
@@ -35,7 +36,6 @@ describe('SideStaking unit test', () => {
   let sideStaking: SideStaking
   let poolAddress: string
   let erc20Token: string
-  let erc20Contract: Contract
   let daiContract: Contract
   let usdcContract: Contract
 
@@ -164,9 +164,8 @@ describe('SideStaking unit test', () => {
       erc20Token = txReceipt.events.TokenCreated.returnValues.newTokenAddress
       poolAddress = txReceipt.events.NewPool.returnValues.poolAddress
 
-      erc20Contract = new web3.eth.Contract(ERC20Template.abi as AbiItem[], erc20Token)
       // user1 has no dt1
-      expect(await erc20Contract.methods.balanceOf(user1).call()).to.equal('0')
+      expect(await balance(web3, erc20Token, user1)).to.equal('0')
     })
 
     it('#getRouter - should get Router address', async () => {
@@ -275,8 +274,12 @@ describe('SideStaking unit test', () => {
         amountsInOutMaxFee
       )
 
-      expect(await erc20Contract.methods.balanceOf(user1).call()).to.equal(
-        tx.events.LOG_SWAP.returnValues.tokenAmountOut
+      expect(await balance(web3, erc20Token, user1)).to.equal(
+        await unitsToAmount(
+          web3,
+          erc20Token,
+          tx.events.LOG_SWAP.returnValues.tokenAmountOut
+        )
       )
     })
 
@@ -386,9 +389,8 @@ describe('SideStaking unit test', () => {
       erc20Token = txReceipt.events.TokenCreated.returnValues.newTokenAddress
       poolAddress = txReceipt.events.NewPool.returnValues.poolAddress
 
-      erc20Contract = new web3.eth.Contract(ERC20Template.abi as AbiItem[], erc20Token)
       // user1 has no dt1
-      expect(await erc20Contract.methods.balanceOf(user1).call()).to.equal('0')
+      expect(await balance(web3, erc20Token, user1)).to.equal('0')
     })
 
     it('#getBaseTokenBalance ', async () => {
@@ -453,8 +455,12 @@ describe('SideStaking unit test', () => {
         tokenInOutMarket,
         amountsInOutMaxFee
       )
-      expect(await erc20Contract.methods.balanceOf(user1).call()).to.equal(
-        tx.events.LOG_SWAP.returnValues.tokenAmountOut
+      expect(await balance(web3, erc20Token, user1)).to.equal(
+        await unitsToAmount(
+          web3,
+          erc20Token,
+          tx.events.LOG_SWAP.returnValues.tokenAmountOut
+        )
       )
     })
 


### PR DESCRIPTION
Fixes #1485 

Changes proposed in this PR:
- Remove imports of ABIs in the tests and use utility `transfer()`, `mint()`, `balance()` functions
