### PR TITLE
Issue-#1487: Disable "Use object destructuring" warning in tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "no-empty": ["error", { "allowEmptyCatch": true }],
-    "prefer-destructuring": ["warn", { "object": true, "array": false }],
+    "prefer-destructuring": ["warn", { "object": false, "array": false }],
     "no-dupe-class-members": ["warn"],
     "no-useless-constructor": ["warn"],
     "no-unused-vars": ["warn"],


### PR DESCRIPTION
Fixes #1487 

Changes proposed in this PR:
- Disable `"Use object destructuring"` warning in tests
