### PR TITLE
get files checksum using fileInfo helper

### DIFF
--- a/src/@types/FileInfo.ts
+++ b/src/@types/FileInfo.ts
@@ -37,6 +37,12 @@ export interface FileInfo {
   method?: string
 
   /**
+   * Computed file checksum
+   * @type {string}
+   */
+  checksum?: string
+
+  /**
    * check if file exists
    * @type {boolean}
    */

--- a/src/provider/Provider.ts
+++ b/src/provider/Provider.ts
@@ -168,8 +168,9 @@ export class Provider {
    */
   public async checkDidFiles(
     did: string,
-    serviceId: number,
+    serviceId: string,
     providerUri: string,
+    withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
     const providerEndpoints = await this.getEndpoints(providerUri)
@@ -177,7 +178,7 @@ export class Provider {
       providerUri,
       providerEndpoints
     )
-    const args = { did: did, serviceId: serviceId }
+    const args = { did: did, serviceId: serviceId, checksum: withChecksum }
     const files: FileInfo[] = []
     const path = this.getEndpointURL(serviceEndpoints, 'fileinfo')
       ? this.getEndpointURL(serviceEndpoints, 'fileinfo').urlPath


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- add withChecksum param to fileinfo provider request
- add checksum attribute to FIleInfo type