### PR TITLE
Fixing import, and how to initialize marketplace.js file. Making it n…

### DIFF
--- a/CodeExamples.md
+++ b/CodeExamples.md
@@ -116,6 +116,16 @@ import {
 import { getAddresses, getTestConfig, web3 } from '../config'
 ```
 
+### Update relative import paths
+Change the import header of marketplace.js to import from the ocean.js module
+1. Change the line
+From: ```} from '../../src'```
+To: ```} from '@oceanprotocol/lib'```
+///
+2. Change the line
+From: ```import { getAddresses, getTestConfig, web3 } from '../config'```
+To: ```import { getAddresses, getTestConfig, web3 } from '@oceanprotocol/lib/dist/test/config'```
+
 <!--
 describe('Marketplace flow tests
 -->

--- a/test/integration/CodeExamples.test.ts
+++ b/test/integration/CodeExamples.test.ts
@@ -116,6 +116,16 @@ import {
 import { getAddresses, getTestConfig, web3 } from '../config'
 /// ```
 
+/// ### Update relative import paths
+/// Change the import header of marketplace.js to import from the ocean.js module
+/// 1. Change the line
+/// From: ```} from '../../src'```
+/// To: ```} from '@oceanprotocol/lib'```
+///
+/// 2. Change the line
+/// From: ```import { getAddresses, getTestConfig, web3 } from '../config'```
+/// To: ```import { getAddresses, getTestConfig, web3 } from '@oceanprotocol/lib/dist/test/config'```
+
 /// <!--
 describe('Marketplace flow tests', async () => {
   /// -->


### PR DESCRIPTION
I was reviewing/learning/hacking ocean.js and ocean.py over the weekend and noticed some issues in the ocean.js examples when trying to run these.

I got my test running using a different DX flow, so I'm submitting this PR to address both issues:
- using `touch` instead of `cat` (cat > file.ext hangs in this case, as you are streaming null into a file)
- importing from `@oceanprotocol/lib` rather than `../../src`

@miquelcabot, I believe you had touched parts of this last time.
Cheers!