### PR TITLE
Let do any query in Aquarius

### DIFF
--- a/src/aquarius/Aquarius.ts
+++ b/src/aquarius/Aquarius.ts
@@ -5,24 +5,10 @@ import fetch from 'cross-fetch'
 export interface SearchQuery {
   from?: number
   size?: number
-  query: {
-    match?: {
-      [property: string]:
-        | string
-        | number
-        | boolean
-        | Record<string, string | number | boolean>
-    }
-    // eslint-disable-next-line camelcase
-    query_string?: {
-      [property: string]: string | number | string[] | number[] | boolean
-    }
-    // eslint-disable-next-line camelcase
-    simple_query_string?: {
-      [property: string]: string | number | string[] | number[] | boolean
-    }
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: any
   sort?: { [jsonPath: string]: string }
+  aggs?: any
 }
 
 export class Aquarius {


### PR DESCRIPTION
Changes proposed in this PR:
- change the `SearchQuery` interface, as in the Market repository (https://github.com/oceanprotocol/market/blob/09f21eb9177bef155c0156dffbe7aa8dbed5d0bd/src/%40types/aquarius/SearchQuery.ts#L41), to let do any query in Aquarius
