### PR TITLE
bump @oceanprotocol/contracts to v1.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@oceanprotocol/contracts": "^1.1.7",
+        "@oceanprotocol/contracts": "^1.1.8",
         "bignumber.js": "^9.1.0",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
-        "web3": "^1.7.4",
+        "web3": "^1.8.0",
         "web3-core": "^1.8.0",
         "web3-eth-contract": "^1.8.0"
       },
@@ -2622,9 +2622,9 @@
       }
     },
     "node_modules/@oceanprotocol/contracts": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.7.tgz",
-      "integrity": "sha512-Oe+oBRiu1dlco9PQ7eUYcTYi2Nua69S3TiSw62H46AIpwnFK8ORuO0Ny20No++KisBA9F+84b5lDn6kQy5Lt/Q=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.8.tgz",
+      "integrity": "sha512-I6xoADZpP/8EyN3VWZ+dLYv24DbJj3xzmSDcYv0FolXeAUF3FluzminL5AgQtAaoyUtlHl1D3ij1B++KupWcQQ=="
     },
     "node_modules/@octokit/auth-token": {
       "version": "3.0.1",
@@ -3032,20 +3032,31 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@truffle/hdwallet": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet/-/hdwallet-0.1.0.tgz",
+      "integrity": "sha512-tRqx7Kn5SbQoe56S5pWrIN3/aM9YMK2bFR8iD5gHGv6uXHRCL7b+PkeI1gyKk09SRWkY11YjRw+Up/V0x6tw6A==",
+      "dev": true,
+      "dependencies": {
+        "ethereum-cryptography": "1.1.2",
+        "keccak": "3.0.2",
+        "secp256k1": "4.0.3"
+      }
+    },
     "node_modules/@truffle/hdwallet-provider": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-2.0.16.tgz",
-      "integrity": "sha512-YnWimWTH0UV8r+BjSHSPm1Qa/axsjq86RyjlvZf0Mv1Xdi5jkZETPaCJBcn80XqeJglMtiRHYz48OTBXNnUjDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-2.1.0.tgz",
+      "integrity": "sha512-I4VlMJsYYwUCkMFWaEuTE3MhI5k7qKwYQj+axMKeoZDWVLtZ6QbkWynUrVdmwELQ+wFSyNzvsBj7F2Sqb0S0/Q==",
       "dev": true,
       "dependencies": {
         "@ethereumjs/common": "^2.4.0",
         "@ethereumjs/tx": "^3.3.0",
         "@metamask/eth-sig-util": "4.0.1",
+        "@truffle/hdwallet": "^0.1.0",
         "@types/web3": "^1.0.20",
         "ethereum-cryptography": "1.1.2",
         "ethereum-protocol": "^1.0.1",
         "ethereumjs-util": "^7.1.5",
-        "ethereumjs-wallet": "^1.0.2",
         "web3": "1.7.4",
         "web3-provider-engine": "16.0.3"
       }
@@ -3608,6 +3619,18 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true
+    },
+    "node_modules/@truffle/hdwallet/node_modules/ethereum-cryptography": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.6.3",
+        "@scure/bip32": "1.1.0",
+        "@scure/bip39": "1.1.0"
+      }
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -4197,12 +4220,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/aes-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
-      "dev": true
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -8310,22 +8327,6 @@
         "ethereum-cryptography": "^0.1.3",
         "ethjs-util": "0.1.6",
         "rlp": "^2.2.3"
-      }
-    },
-    "node_modules/ethereumjs-wallet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
-      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
-      "dev": true,
-      "dependencies": {
-        "aes-js": "^3.1.2",
-        "bs58check": "^2.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^7.1.2",
-        "randombytes": "^2.1.0",
-        "scrypt-js": "^3.0.1",
-        "utf8": "^3.0.0",
-        "uuid": "^8.3.2"
       }
     },
     "node_modules/ethjs-unit": {
@@ -15488,12 +15489,12 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "node_modules/secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "hasInstallScript": true,
       "dependencies": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       },
@@ -16882,15 +16883,6 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -19744,9 +19736,9 @@
       }
     },
     "@oceanprotocol/contracts": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.7.tgz",
-      "integrity": "sha512-Oe+oBRiu1dlco9PQ7eUYcTYi2Nua69S3TiSw62H46AIpwnFK8ORuO0Ny20No++KisBA9F+84b5lDn6kQy5Lt/Q=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-1.1.8.tgz",
+      "integrity": "sha512-I6xoADZpP/8EyN3VWZ+dLYv24DbJj3xzmSDcYv0FolXeAUF3FluzminL5AgQtAaoyUtlHl1D3ij1B++KupWcQQ=="
     },
     "@octokit/auth-token": {
       "version": "3.0.1",
@@ -20036,20 +20028,45 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@truffle/hdwallet": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet/-/hdwallet-0.1.0.tgz",
+      "integrity": "sha512-tRqx7Kn5SbQoe56S5pWrIN3/aM9YMK2bFR8iD5gHGv6uXHRCL7b+PkeI1gyKk09SRWkY11YjRw+Up/V0x6tw6A==",
+      "dev": true,
+      "requires": {
+        "ethereum-cryptography": "1.1.2",
+        "keccak": "3.0.2",
+        "secp256k1": "4.0.3"
+      },
+      "dependencies": {
+        "ethereum-cryptography": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "dev": true,
+          "requires": {
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.6.3",
+            "@scure/bip32": "1.1.0",
+            "@scure/bip39": "1.1.0"
+          }
+        }
+      }
+    },
     "@truffle/hdwallet-provider": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-2.0.16.tgz",
-      "integrity": "sha512-YnWimWTH0UV8r+BjSHSPm1Qa/axsjq86RyjlvZf0Mv1Xdi5jkZETPaCJBcn80XqeJglMtiRHYz48OTBXNnUjDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-2.1.0.tgz",
+      "integrity": "sha512-I4VlMJsYYwUCkMFWaEuTE3MhI5k7qKwYQj+axMKeoZDWVLtZ6QbkWynUrVdmwELQ+wFSyNzvsBj7F2Sqb0S0/Q==",
       "dev": true,
       "requires": {
         "@ethereumjs/common": "^2.4.0",
         "@ethereumjs/tx": "^3.3.0",
         "@metamask/eth-sig-util": "4.0.1",
+        "@truffle/hdwallet": "^0.1.0",
         "@types/web3": "^1.0.20",
         "ethereum-cryptography": "1.1.2",
         "ethereum-protocol": "^1.0.1",
         "ethereumjs-util": "^7.1.5",
-        "ethereumjs-wallet": "^1.0.2",
         "web3": "1.7.4",
         "web3-provider-engine": "16.0.3"
       },
@@ -20922,12 +20939,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
-    },
-    "aes-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
       "dev": true
     },
     "agent-base": {
@@ -24140,22 +24151,6 @@
             "rlp": "^2.2.3"
           }
         }
-      }
-    },
-    "ethereumjs-wallet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
-      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
-      "dev": true,
-      "requires": {
-        "aes-js": "^3.1.2",
-        "bs58check": "^2.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^7.1.2",
-        "randombytes": "^2.1.0",
-        "scrypt-js": "^3.0.1",
-        "utf8": "^3.0.0",
-        "uuid": "^8.3.2"
       }
     },
     "ethjs-unit": {
@@ -29494,11 +29489,11 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "requires": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }
@@ -30571,12 +30566,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "web3": "^1.7.4"
   },
   "dependencies": {
-    "@oceanprotocol/contracts": "^1.1.7",
+    "@oceanprotocol/contracts": "^1.1.8",
     "bignumber.js": "^9.1.0",
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",


### PR DESCRIPTION
- updates `veFeeEstimate` contract
- removes Rinkeby & Ropsten