### PR TITLE
Updating types to include the price which is sent from Aquarius

### DIFF
--- a/src/@types/Asset.ts
+++ b/src/@types/Asset.ts
@@ -90,6 +90,11 @@ export interface AssetDatatoken {
   serviceId: string
 }
 
+export interface AssetPrice {
+  value: number
+  tokenSymbol?: string
+  tokenAddress?: string
+}
 export interface Stats {
   /**
    * How often an asset was consumed, meaning how often it was either downloaded or used as part of a compute job.
@@ -102,6 +107,12 @@ export interface Stats {
    * @type {number}
    */
   allocated?: number
+
+  /**
+   * Contains information about the price of this asset.
+   * @type {AssetPrice}
+   */
+  price?: AssetPrice
 }
 
 export interface AssetLastEvent {

--- a/src/@types/Asset.ts
+++ b/src/@types/Asset.ts
@@ -117,16 +117,16 @@ export interface Stats {
   orders: number
 
   /**
+   * Contains information about the price of this asset.
+   * @type {AssetPrice}
+   */
+  price: AssetPrice
+
+  /**
    * Total amount of veOCEAN allocated on this asset.
    * @type {number}
    */
   allocated?: number
-
-  /**
-   * Contains information about the price of this asset.
-   * @type {AssetPrice}
-   */
-  price?: AssetPrice
 }
 
 export interface AssetLastEvent {

--- a/src/@types/Asset.ts
+++ b/src/@types/Asset.ts
@@ -91,8 +91,22 @@ export interface AssetDatatoken {
 }
 
 export interface AssetPrice {
+  /**
+   * The price of the asset expressed as a number. If 0 then the price is FREE.
+   * @type {number}
+   */
   value: number
+
+  /**
+   * The symbol that the price of the asset is expressed in.
+   * @type {string}
+   */
   tokenSymbol?: string
+
+  /**
+   * The address of the token that the price needs to be paid in.
+   * @type {string}
+   */
   tokenAddress?: string
 }
 export interface Stats {


### PR DESCRIPTION
Currently getting typing errors in the market when trying to use the price from Aquarius as the Asset.Stats interface doesn't include the price object which is being sent from Aquarius. This PR is to update the typings. 

Required for: https://github.com/oceanprotocol/market/issues/1654

Changes proposed in this PR:

- Updating Asset type to include the price which is sent from Aquarius in Stats