### PR TITLE
add missing headers and checksum params

### DIFF
--- a/src/@types/File.ts
+++ b/src/@types/File.ts
@@ -1,4 +1,9 @@
 import { AbiItem } from 'web3-utils'
+
+interface FileTypeHeaders {
+  [key: string]: string
+}
+
 export interface UrlFile {
   type: 'url'
 
@@ -19,8 +24,13 @@ export interface UrlFile {
    * @type {string}
    */
   method: string
-}
 
+  /**
+   * Headers key value pairs associated with the asset GET request
+   * @type {string}
+   */
+  headers?: FileTypeHeaders
+}
 export interface GraphqlQuery {
   type: 'graphql'
 
@@ -40,6 +50,12 @@ export interface GraphqlQuery {
    * @type {string}
    */
   query: string
+
+  /**
+   * Headers key value pairs associated with the asset GET request
+   * @type {string}
+   */
+  headers?: FileTypeHeaders
 }
 
 export interface Arweave {

--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -150,9 +150,10 @@ export class Provider {
   }
 
   /** Get DDO File details (if possible)
-   * @param {string} did did
-   * @param {number} serviceId the id of the service for which to check the files
+   * @param {UrlFile | Arweave | Ipfs | GraphqlQuery | Smartcontract} file one of the supported file structures
+   * @param {string} serviceId the id of the service for which to check the files
    * @param {string} providerUri uri of the provider that will be used to check the file
+   * @param {boolean} withChecksum if true, will return checksum of files content
    * @param {AbortSignal} signal abort signal
    * @return {Promise<FileInfo[]>} urlDetails
    */
@@ -193,14 +194,16 @@ export class Provider {
   }
 
   /** Get URL details (if possible)
-   * @param {string} url or did
+   * @param {UrlFile | Arweave | Ipfs | GraphqlQuery | Smartcontract} file one of the supported file structures
    * @param {string} providerUri uri of the provider that will be used to check the file
+   * @param {boolean} withChecksum if true, will return checksum of files content
    * @param {AbortSignal} signal abort signal
    * @return {Promise<FileInfo[]>} urlDetails
    */
   public async getFileInfo(
     file: UrlFile | Arweave | Ipfs | GraphqlQuery | Smartcontract,
     providerUri: string,
+    withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
     const providerEndpoints = await this.getEndpoints(providerUri)
@@ -208,7 +211,7 @@ export class Provider {
       providerUri,
       providerEndpoints
     )
-    const args = file
+    const args = { ...file, checksum: withChecksum }
     const files: FileInfo[] = []
     const path = this.getEndpointURL(serviceEndpoints, 'fileinfo')
       ? this.getEndpointURL(serviceEndpoints, 'fileinfo').urlPath


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- added headers on `UrlFile` and `GraphqlQuery` types for provider getFileInfo
- add missing withChecksum param 
- updated jsDoc