### PR TITLE
Issue 1746 fee t oken decimals

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "mocha": "TS_NODE_PROJECT='./test/tsconfig.json' mocha --config=test/.mocharc.json --node-env=test --exit",
     "test": "npm run lint && npm run test:unit:cover && npm run test:integration:cover",
     "test:unit": "npm run mocha -- 'test/unit/**/*.test.ts'",
-    "test:fixed": "npm run mocha -- 'test/unit/FixedRateExchange.test.ts'",
     "test:integration": "npm run mocha --  'test/integration/**/*.test.ts'",
     "test:unit:cover": "nyc --report-dir coverage/unit npm run test:unit",
     "test:integration:cover": "nyc --report-dir coverage/integration --no-clean npm run test:integration",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mocha": "TS_NODE_PROJECT='./test/tsconfig.json' mocha --config=test/.mocharc.json --node-env=test --exit",
     "test": "npm run lint && npm run test:unit:cover && npm run test:integration:cover",
     "test:unit": "npm run mocha -- 'test/unit/**/*.test.ts'",
+    "test:fixed": "npm run mocha -- 'test/unit/FixedRateExchange.test.ts'",
     "test:integration": "npm run mocha --  'test/integration/**/*.test.ts'",
     "test:unit:cover": "nyc --report-dir coverage/unit npm run test:unit",
     "test:integration:cover": "nyc --report-dir coverage/integration --no-clean npm run test:integration",

--- a/src/contracts/NFTFactory.ts
+++ b/src/contracts/NFTFactory.ts
@@ -1,6 +1,13 @@
 import { BigNumber } from 'ethers'
 import ERC721Factory from '@oceanprotocol/contracts/artifacts/contracts/ERC721Factory.sol/ERC721Factory.json'
-import { generateDtName, ZERO_ADDRESS, sendTx, getEventFromTx } from '../utils'
+import {
+  generateDtName,
+  ZERO_ADDRESS,
+  sendTx,
+  getEventFromTx,
+  getTokenDecimals,
+  LoggerInstance
+} from '../utils'
 import {
   AbiItem,
   FreCreationParams,
@@ -553,6 +560,16 @@ export class NftFactory extends SmartContractWithAddress {
     if (!dtParams.name || !dtParams.symbol) {
       ;({ name, symbol } = generateDtName())
     }
+
+    let feeTokenDecimals = 18
+    if (dtParams.feeToken !== ZERO_ADDRESS) {
+      try {
+        feeTokenDecimals = await getTokenDecimals(this.signer, dtParams.feeToken)
+      } catch (error) {
+        LoggerInstance.error('getTokenDecimals error', error)
+      }
+    }
+
     return {
       templateIndex: dtParams.templateIndex,
       strings: [dtParams.name || name, dtParams.symbol || symbol],
@@ -564,7 +581,7 @@ export class NftFactory extends SmartContractWithAddress {
       ],
       uints: [
         await this.amountToUnits(null, dtParams.cap, 18),
-        await this.amountToUnits(null, dtParams.feeAmount, 18)
+        await this.amountToUnits(null, dtParams.feeAmount, feeTokenDecimals)
       ],
       bytess: []
     }

--- a/test/unit/FixedRateExchange.test.ts
+++ b/test/unit/FixedRateExchange.test.ts
@@ -64,7 +64,7 @@ describe('Fixed Rate unit test', () => {
     dtParams.mpFeeAddress = await factoryOwner.getAddress()
   })
 
-  describe('Test a Fixed Rate Exchange with DAI (18 Decimals)', () => {
+  describe('Test a Fixed Rate Exchange with DAI (18 Decimals) as Basetoken', () => {
     it('#create an exchange', async () => {
       // CREATE AN Exchange
       // we prepare transaction parameters objects
@@ -459,7 +459,7 @@ describe('Fixed Rate unit test', () => {
     })
   })
 
-  describe('Test a Fixed Rate Exchange with USDC (6 Decimals)', () => {
+  describe('Test a Fixed Rate Exchange with USDC (6 Decimals) as Basetoken', () => {
     it('#create an exchange', async () => {
       // CREATE AN Exchange
       // we prepare transaction parameters objects
@@ -808,6 +808,91 @@ describe('Fixed Rate unit test', () => {
 
       expect((await fixedRate.getFeesInfo(exchangeId)).marketFeeCollector).to.equal(
         await user1.getAddress()
+      )
+    })
+  })
+
+  describe('Test a Fixed Rate Exchange With Different Fee Tokens', () => {
+    it('#create a fixed rate exchange with DAI as feetoken', async () => {
+      // CREATE AN Exchange
+      // we prepare transaction parameters objects
+
+      const nftFactory = new NftFactory(addresses.ERC721Factory, exchangeOwner)
+
+      const freParams: FreCreationParams = {
+        fixedRateAddress: addresses.FixedPrice,
+        baseTokenAddress: addresses.MockDAI,
+        owner: await exchangeOwner.getAddress(),
+        marketFeeCollector: await user2.getAddress(),
+        baseTokenDecimals: 18,
+        datatokenDecimals: 18,
+        fixedRate: '1',
+        marketFee: '0.001',
+        allowedConsumer: ZERO_ADDRESS,
+        withMint: false
+      }
+
+      dtParams.feeToken = addresses.MockDAI
+      dtParams.feeAmount = '0.123456789'
+
+      const tx = await nftFactory.createNftWithDatatokenWithFixedRate(
+        nftData,
+        dtParams,
+        freParams
+      )
+      const txReceipt = await tx.wait()
+      const tokenCreatedEvent = getEventFromTx(txReceipt, 'TokenCreated')
+
+      const datatokenAddress = tokenCreatedEvent.args.newTokenAddress
+
+      const datatoken = new Datatoken(exchangeOwner)
+
+      const publishingMarketFee = await datatoken.getPublishingMarketFee(datatokenAddress)
+
+      assert(
+        publishingMarketFee.publishMarketFeeAmount ===
+          ethers.utils.parseUnits('0.123456789').toString()
+      )
+    })
+
+    it('#create a fixed rate exchange with USDC as feetoken', async () => {
+      // CREATE AN Exchange
+      // we prepare transaction parameters objects
+
+      const nftFactory = new NftFactory(addresses.ERC721Factory, exchangeOwner)
+
+      const freParams: FreCreationParams = {
+        fixedRateAddress: addresses.FixedPrice,
+        baseTokenAddress: addresses.MockDAI,
+        owner: await exchangeOwner.getAddress(),
+        marketFeeCollector: await user2.getAddress(),
+        baseTokenDecimals: 18,
+        datatokenDecimals: 18,
+        fixedRate: '1',
+        marketFee: '0.001',
+        allowedConsumer: ZERO_ADDRESS,
+        withMint: false
+      }
+
+      dtParams.feeToken = addresses.MockUSDC
+      dtParams.feeAmount = '987654321'
+
+      const tx = await nftFactory.createNftWithDatatokenWithFixedRate(
+        nftData,
+        dtParams,
+        freParams
+      )
+      const txReceipt = await tx.wait()
+      const tokenCreatedEvent = getEventFromTx(txReceipt, 'TokenCreated')
+
+      const datatokenAddress = tokenCreatedEvent.args.newTokenAddress
+
+      const datatoken = new Datatoken(exchangeOwner)
+
+      const publishingMarketFee = await datatoken.getPublishingMarketFee(datatokenAddress)
+      assert(
+        publishingMarketFee.publishMarketFeeAmount ===
+          ethers.utils.parseUnits('987654321', 6).toString()
       )
     })
   })


### PR DESCRIPTION
Fixes #1746

Changes proposed in this PR:

- Checking the decimals for the fee token before sending the publishMarketFee amount to the smart contract
- Adding new tests to check if it works for both USDC and DAI as the fee token