### PR TITLE
Fix compute stop update orderHelper to be reused c2d as well

### DIFF
--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -643,6 +643,7 @@ export class Provider {
     payload.signature = signature
     payload.documentId = this.noZeroX(did)
     payload.consumerAddress = consumerAddress
+    payload.nonce = nonce
     if (jobId) payload.jobId = jobId
 
     if (!computeStopUrl) return null


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- add missing nonce param to stop compute job
- refactor orderAsset to be reused by order compute assets as well
