### PR TITLE
fix using custom address file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,7 @@ jobs:
           docker image rm node:16-alpine
           docker image rm node:18
           docker image rm node:18-alpine
-          docker image rm buildpack-deps:buster
-          docker image rm buildpack-deps:bullseye
+          docker image rm node:20
           docker image rm debian:10
           docker image rm debian:11
           docker image rm moby/buildkit:latest

--- a/src/config/ConfigHelper.ts
+++ b/src/config/ConfigHelper.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-named-default
 import { default as DefaultContractsAddresses } from '@oceanprotocol/contracts/addresses/address.json'
+import fs from 'fs'
 import { Config } from '.'
 import { LoggerInstance } from '../utils'
 
@@ -261,8 +262,14 @@ export class ConfigHelper {
 
     let addresses
     try {
-      addresses = JSON.parse(process.env.ADDRESS_FILE)
+      addresses = process.env.ADDRESS_FILE
+        ? JSON.parse(
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
+            fs.readFileSync(process.env.ADDRESS_FILE, 'utf8')
+          )
+        : null
     } catch (e) {
+      console.log(e)
       addresses = null
     }
     const contractAddressesConfig = this.getAddressesFromEnv(config.network, addresses)


### PR DESCRIPTION
Fixes bug introduced in https://github.com/oceanprotocol/ocean.js/commit/38cc02849eae054ffe942e7371c1d74201b2e988

We are trying to parse ENV as json, instead of file content pointed by ADDRESS_FILE env
