### PR TITLE
Sanitize service endpoint by adding/reving slash when needed.

### DIFF
--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -61,9 +61,7 @@ export class Provider {
       const endpoint: ServiceEndpoint = {
         serviceName: i,
         method: endpoints.serviceEndpoints[i][0],
-        urlPath: providerEndpoint.endsWith('/')
-          ? providerEndpoint + endpoints.serviceEndpoints[i][1]
-          : providerEndpoint + '/' + endpoints.serviceEndpoints[i][1]
+        urlPath: providerEndpoint.replace(/\/+$/, '') + '/' + endpoints.serviceEndpoints[i][1].replace(/^\/+/, '')
       }
       serviceEndpoints.push(endpoint)
     }

--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -61,7 +61,7 @@ export class Provider {
       const endpoint: ServiceEndpoint = {
         serviceName: i,
         method: endpoints.serviceEndpoints[i][0],
-        urlPath: providerEndpoint + endpoints.serviceEndpoints[i][1]
+        urlPath: providerEndpoint.endsWith('/') ? providerEndpoint + endpoints.serviceEndpoints[i][1] : providerEndpoint + '/' + endpoints.serviceEndpoints[i][1]
       }
       serviceEndpoints.push(endpoint)
     }

--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -61,7 +61,9 @@ export class Provider {
       const endpoint: ServiceEndpoint = {
         serviceName: i,
         method: endpoints.serviceEndpoints[i][0],
-        urlPath: providerEndpoint.endsWith('/') ? providerEndpoint + endpoints.serviceEndpoints[i][1] : providerEndpoint + '/' + endpoints.serviceEndpoints[i][1]
+        urlPath: providerEndpoint.endsWith('/')
+          ? providerEndpoint + endpoints.serviceEndpoints[i][1]
+          : providerEndpoint + '/' + endpoints.serviceEndpoints[i][1]
       }
       serviceEndpoints.push(endpoint)
     }

--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -61,7 +61,7 @@ export class Provider {
       const endpoint: ServiceEndpoint = {
         serviceName: i,
         method: endpoints.serviceEndpoints[i][0],
-        urlPath: 
+        urlPath:
           providerEndpoint.replace(/\/+$/, '') +
           '/' +
           endpoints.serviceEndpoints[i][1].replace(/^\/+/, '')

--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -61,7 +61,10 @@ export class Provider {
       const endpoint: ServiceEndpoint = {
         serviceName: i,
         method: endpoints.serviceEndpoints[i][0],
-        urlPath: providerEndpoint.replace(/\/+$/, '') + '/' + endpoints.serviceEndpoints[i][1].replace(/^\/+/, '')
+        urlPath: 
+          providerEndpoint.replace(/\/+$/, '') +
+          '/' +
+          endpoints.serviceEndpoints[i][1].replace(/^\/+/, '')
       }
       serviceEndpoints.push(endpoint)
     }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- Sanitize service endpoint by adding/reving slash when needed.
- @alexcos20 and I decided to modify in ocean.js instead of pod-configuration, see [this PR](https://github.com/oceanprotocol/pod-configuration/pull/72)