### PR TITLE
Add back check for access list factory.

### DIFF
--- a/src/config/ConfigHelper.ts
+++ b/src/config/ConfigHelper.ts
@@ -338,7 +338,7 @@ export class ConfigHelper {
         config.sdk = 'evm'
       }
     }
-    if ('accessListFactory' in contractAddressesConfig && config.sdk === 'oasis') {
+    if ('accessListFactory' in contractAddressesConfig) {
       config.accessListFactory = contractAddressesConfig.accessListFactory
     }
 

--- a/src/config/ConfigHelper.ts
+++ b/src/config/ConfigHelper.ts
@@ -338,7 +338,7 @@ export class ConfigHelper {
         config.sdk = 'evm'
       }
     }
-    if ('accessListFactory' in contractAddressesConfig) {
+    if (contractAddressesConfig && 'accessListFactory' in contractAddressesConfig) {
       config.accessListFactory = contractAddressesConfig.accessListFactory
     }
 

--- a/src/config/ConfigHelper.ts
+++ b/src/config/ConfigHelper.ts
@@ -338,8 +338,9 @@ export class ConfigHelper {
         config.sdk = 'evm'
       }
     }
-
-    config.accessListFactory = contractAddressesConfig.accessListFactory
+    if ('accessListFactory' in contractAddressesConfig && config.sdk === 'oasis') {
+      config.accessListFactory = contractAddressesConfig.accessListFactory
+    }
 
     config = { ...config, ...contractAddressesConfig }
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

From this discussion https://github.com/oceanprotocol/ocean.js/pull/1868#discussion_r1824334821, I reopened the topic, that assignement does not check if  the accessListFactory exists and throws this error for not EVM chains (for example in barge):
Error publishing asset: Cannot read properties of undefined (reading 'accessListFactory')

