### PR TITLE
Feature/paid compute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,8 @@ jobs:
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |
-          bash -x start_ocean.sh --no-aquarius --no-provider --no-dashboard --with-c2d --with-typesense 2>&1 > start_ocean.log &
+          export CONTRACTS_VERSION=v2.3.0
+          bash -x start_ocean.sh --no-aquarius --no-provider --no-dashboard --with-typesense 2>&1 > start_ocean.log &
       - run: npm ci
       - run: npm run build
       - run: docker image ls
@@ -136,8 +137,9 @@ jobs:
         run: |
           for i in $(seq 1 250); do
             sleep 10
-            [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
+            [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" ] && break
           done
+          cat $ADDRESS_FILE
 
       - name: docker logs
         run: docker logs ocean_ocean-contracts_1 && docker logs ocean_kindcluster_1 && docker logs ocean_computetodata_1 && docker logs ocean_typesense_1
@@ -148,7 +150,16 @@ jobs:
         with:
           repository: 'oceanprotocol/ocean-node'
           path: 'ocean-node'
-
+          ref: 'update-job-id-generation'
+      - name: Extract Ocean address using jq
+        run: |
+            OCEAN_ADDRESS=$(jq -r '.development | select(.chainId == 8996) | .Ocean' "$ADDRESS_FILE")
+            echo "OCEAN_ADDRESS_DEV=$OCEAN_ADDRESS" >> $GITHUB_ENV
+            echo "Extracted Ocean address: $OCEAN_ADDRESS"
+  
+      - name: Use the extracted Ocean address
+        run: |
+            echo "Using Ocean address for development: ${{ env.OCEAN_ADDRESS_DEV }}"
       - name: Start Ocean Node
         working-directory: ${{ github.workspace }}/ocean-node
         run: |
@@ -171,7 +182,7 @@ jobs:
           ALLOWED_ADMINS: '["0xe2DD09d719Da89e5a3D0F2549c7E24566e947260"]'
           MAX_REQ_PER_MINUTE: 320
           MAX_CONNECTIONS_PER_MINUTE: 500
-          DOCKER_COMPUTE_ENVIRONMENTS: '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+          DOCKER_COMPUTE_ENVIRONMENTS: '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"8996":[{"feeToken": "${{ env.OCEAN_ADDRESS_DEV }}","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
 
       - name: Check Ocean Node is running
         run: |

--- a/CodeExamples.md
+++ b/CodeExamples.md
@@ -183,12 +183,11 @@ Next, we define the metadata that will describe our data asset. This is what we 
     },
     services: [
       {
-        id: 'testFakeId',
+        id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
         type: 'access',
-        description: 'Download service',
         files: '',
-        datatokenAddress: '0x0',
-        serviceEndpoint: 'http://172.15.0.4:8030',
+        datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
+        serviceEndpoint: 'http://127.0.0.1:8001',
         timeout: 0
       }
     ]

--- a/ComputeExamples.md
+++ b/ComputeExamples.md
@@ -14,6 +14,8 @@ Here are the steps:
 9. [Consumer fetches compute environment](#9-get-compute-environments)
 10. [Consumer starts a free compute job using a free C2D environment](#10-consumer-starts-a-compute-job)
 11. [Check compute status and get download compute results url](#11-check-compute-status-and-get-download-compute-results-url)
+12. [Consumer starts a paid compute job](#12-consumer-starts-a-paid-compute-job)
+13. [Check paid compute job status and get download compute results URL](#13-check-paid-compute-job-status-and-get-download-compute-results-url)
 
 Let's go through each step.
 
@@ -143,12 +145,15 @@ import {
   ConfigHelper,
   getEventFromTx,
   amountToUnits,
-  isDefined
+  isDefined,
+  ComputeResourceRequest,
+  unitsToAmount
 } from '../../src/index.js'
-```
 import crypto from 'crypto-js'
 import { DDO } from '@oceanprotocol/ddo-js'
+import { EscrowContract } from '../../src/contracts/Escrow.js'
 const { SHA256 } = crypto
+```
 
 ### 4.2. Constants and variables
 
@@ -183,7 +188,7 @@ Next, we define the metadata for the dataset and algorithm that will describe ou
 ```Typescript
 const DATASET_DDO: DDO = {
   '@context': ['https://w3id.org/did/v1'],
-  id: 'id:op:efba17455c127a885ec7830d687a8f6e64f5ba559f8506f8723c1f10f05c049c',
+  id: 'did:op:efba17455c127a885ec7830d687a8f6e64f5ba559f8506f8723c1f10f05c049c',
   version: '4.1.0',
   chainId: 8996,
   nftAddress: '0x0',
@@ -201,16 +206,16 @@ const DATASET_DDO: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: '1155995dda741e93afe4b1c6ced2d01734a6ec69865cc0997daf1f4db7259a36',
       type: 'compute',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
-      serviceEndpoint: 'https://v4.provider.goerli.oceanprotocol.com/',
+      serviceEndpoint: 'http://127.0.0.1:8001',
       timeout: 300,
       compute: {
-        publisherTrustedAlgorithmPublishers: [],
-        publisherTrustedAlgorithms: [],
-        allowRawAlgorithm: true,
+        publisherTrustedAlgorithmPublishers: [] as any,
+        publisherTrustedAlgorithms: [] as any,
+        allowRawAlgorithm: false,
         allowNetworkAccess: true
       }
     }
@@ -248,11 +253,11 @@ const ALGORITHM_DDO: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
       type: 'access',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
-      serviceEndpoint: 'https://v4.provider.goerli.oceanprotocol.com',
+      serviceEndpoint: 'http://127.0.0.1:8001',
       timeout: 300
     }
   ]
@@ -609,10 +614,7 @@ Now, let's check that we successfully published a algorithm (create NFT + Datato
 
 let's check the free compute environment
 ```Typescript
-    const computeEnv = computeEnvs.find(
-      (ce) =>
-        !ce?.fees || ce.fees.find((fee) => fee.symbol === 'OCEAN' && fee.amount === '0')
-    )
+    const computeEnv = computeEnvs.find((ce) => isDefined(ce.free))
     console.log('Free compute environment = ', computeEnv)
 ```
 <!--
@@ -630,7 +632,6 @@ let's check the free compute environment
       const mytime = new Date()
       const computeMinutes = 5
       mytime.setMinutes(mytime.getMinutes() + computeMinutes)
-      const computeValidUntil = Math.floor(mytime.getTime() / 1000)
 
   ```
   Let's prepare the dataset and algorithm assets to be used in the compute job
@@ -641,7 +642,6 @@ let's check the free compute environment
           serviceId: resolvedDatasetDdo.services[0].id
         }
       ]
-      const dtAddressArray = [resolvedDatasetDdo.services[0].datatokenAddress]
 
       const algo: ComputeAlgorithm = {
         documentId: resolvedAlgorithmDdo.id,
@@ -649,39 +649,6 @@ let's check the free compute environment
         meta: resolvedAlgorithmDdo.metadata.algorithm
       }
   ```
-
-  <!--
-      // const providerInitializeComputeResults = await ProviderInstance.initializeCompute(
-      //   assets,
-      //   algo,
-      //   computeEnv.id,
-      //   computeValidUntil,
-      //   providerUrl,
-      //   consumerAccount
-      // )
-      // console.log('providerInitializeComputeResults = ', providerInitializeComputeResults)
-      //
-      //
-      // assert(!('error' in providerInitializeComputeResults), 'Cannot order algorithm')
-      //
-      //
-      // algo.transferTxId = await handleOrder(
-      //   providerInitializeComputeResults.algorithm,
-      //   resolvedAlgorithmDdo.services[0].datatokenAddress,
-      //   consumerAccount,
-      //   computeEnv.consumerAddress,
-      //   0
-      // )
-      // for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
-      //   assets[i].transferTxId = await handleOrder(
-      //     providerInitializeComputeResults.datasets[i],
-      //     dtAddressArray[i],
-      //     consumerAccount,
-      //     computeEnv.consumerAddress,
-      //     0
-      //   )
-      // }
-  -->
 
   Let's start the free compute job
   ```Typescript
@@ -752,6 +719,253 @@ let's check the free compute environment
       assert(
         computeRoutePath === null,
         'Compute route path for free compute is not defined (perhaps because provider does not support it yet?)'
+      )
+    } else {
+  -->
+
+  ```Typescript
+      await sleep(10000)
+      const downloadURL = await ProviderInstance.getComputeResultUrl(
+        providerUrl,
+        consumerAccount,
+        computeJobId,
+        0
+      )
+  ```
+  <!--
+      assert(downloadURL, 'Provider getComputeResultUrl failed!')
+  -->
+  Let's check the compute results url for the specified index
+  ```Typescript
+      console.log(`Compute results URL: ${downloadURL}`)
+  ```
+  <!--
+    }
+  }).timeout(40000)
+-->
+
+## 12. Consumer starts a paid compute job
+
+  ### 12.1 Start a compute job using a paid C2D resources
+<!--
+    datatoken = new Datatoken(
+      consumerAccount,
+      (await consumerAccount.provider.getNetwork()).chainId
+    )
+-->
+
+let's select compute environment which have free and paid resources
+```Typescript
+    const computeEnv = computeEnvs[0]
+    console.log('Compute environment = ', computeEnv)
+```
+<!--
+    assert(computeEnv, 'Cannot find the compute env')
+-->
+
+<!--
+    const paymentToken = addresses.Ocean
+    computeRoutePath = await ProviderInstance.getComputeStartRoutes(providerUrl, false)
+    if (isDefined(computeRoutePath)) {
+  -->
+
+  Let's have 5 minute of compute access
+  ```Typescript
+
+      const mytime = new Date()
+      const computeMinutes = 5
+      mytime.setMinutes(mytime.getMinutes() + computeMinutes)
+      const computeValidUntil = Math.floor(mytime.getTime() / 1000)
+
+  ```
+
+  Let's prepare the dataset and algorithm assets to be used in the compute job
+  ```Typescript
+      const resources: ComputeResourceRequest[] = [
+        {
+          id: 'cpu',
+          amount: 2
+        },
+        {
+          id: 'ram',
+          amount: 1000000000
+        },
+        {
+          id: 'disk',
+          amount: 0
+        }
+      ]
+      const assets: ComputeAsset[] = [
+        {
+          documentId: resolvedDatasetDdo.id,
+          serviceId: resolvedDatasetDdo.services[0].id
+        }
+      ]
+      const dtAddressArray = [resolvedDatasetDdo.services[0].datatokenAddress]
+      const algo: ComputeAlgorithm = {
+        documentId: resolvedAlgorithmDdo.id,
+        serviceId: resolvedAlgorithmDdo.services[0].id,
+        meta: resolvedAlgorithmDdo.metadata.algorithm
+      }
+  ```
+
+  Triggering initialize compute to see payment options
+  ```Typescript
+      const providerInitializeComputeResults = await ProviderInstance.initializeCompute(
+        assets,
+        algo,
+        computeEnv.id,
+        paymentToken,
+        computeValidUntil,
+        providerUrl,
+        consumerAccount,
+        resources
+      )
+  <!--
+      console.log(
+        'providerInitializeComputeResults = ',
+        JSON.stringify(providerInitializeComputeResults)
+      )
+  -->
+
+  <!--
+      assert(!('error' in providerInitializeComputeResults), 'Cannot order algorithm')
+  -->
+
+  ```
+
+  Let's check funds for escrow payment
+  ```Typescript
+      const escrow = new EscrowContract(
+        ethers.utils.getAddress(providerInitializeComputeResults.payment.escrowAddress),
+        consumerAccount
+      )
+      const paymentTokenPublisher = new Datatoken(publisherAccount)
+      const balancePublisherPaymentToken = await paymentTokenPublisher.balance(
+        paymentToken,
+        await publisherAccount.getAddress()
+      )
+      assert(
+        ethers.utils.parseEther(balancePublisherPaymentToken) > ethers.BigNumber.from(0),
+        'Balance should be higher than 0'
+      )
+      const tx = await publisherAccount.sendTransaction({
+        to: computeEnv.consumerAddress,
+        value: ethers.utils.parseEther('1.5')
+      })
+      await tx.wait()
+
+      await paymentTokenPublisher.transfer(
+        paymentToken,
+        ethers.utils.getAddress(computeEnv.consumerAddress),
+        (Number(balancePublisherPaymentToken) / 2).toString()
+      )
+      const amountToDeposit = (
+        providerInitializeComputeResults.payment.amount * 2
+      ).toString()
+      await escrow.verifyFundsForEscrowPayment(
+        paymentToken,
+        computeEnv.consumerAddress,
+        await unitsToAmount(consumerAccount, paymentToken, amountToDeposit),
+        providerInitializeComputeResults.payment.amount.toString(),
+        providerInitializeComputeResults.payment.minLockSeconds.toString(),
+        '10'
+      )
+  ```
+
+  Let's order assets
+  ```Typescript
+
+      algo.transferTxId = await handleOrder(
+        providerInitializeComputeResults.algorithm,
+        resolvedAlgorithmDdo.services[0].datatokenAddress,
+        consumerAccount,
+        computeEnv.consumerAddress,
+        0
+      )
+      for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
+        assets[i].transferTxId = await handleOrder(
+          providerInitializeComputeResults.datasets[i],
+          dtAddressArray[i],
+          consumerAccount,
+          computeEnv.consumerAddress,
+          0
+        )
+      }
+  ```
+
+  Let's start compute job
+  ```Typescript
+      const computeJobs = await ProviderInstance.computeStart(
+        providerUrl,
+        consumerAccount,
+        computeEnv.id,
+        assets,
+        algo,
+        computeValidUntil,
+        paymentToken,
+        resources,
+        (
+          await consumerAccount.provider.getNetwork()
+        ).chainId
+      )
+  ```
+
+  <!--
+      assert(computeJobs, 'Cannot start compute job')
+  -->
+
+  Let's save the compute job it, we re going to use later
+  ```Typescript
+      computeJobId = computeJobs[0].jobId
+  ```
+  <!--
+    } else {
+      assert(
+        computeRoutePath === null,
+        'Route path for free compute is not defined (perhaps because provider does not support it yet?)'
+      )
+      hasFreeComputeSupport = false
+    }
+  }).timeout(40000)
+-->
+
+## 13. Check paid compute job status and get download compute results URL
+  ### 13.1 Check compute status for paid compute job
+<!--
+    if (!hasFreeComputeSupport) {
+      assert(
+        computeRoutePath === null,
+        'Compute route path for free compute is not defined (perhaps because provider does not support it yet?)'
+      )
+    } else {
+  -->
+  You can also add various delays so you see the various states of the compute job
+  ```Typescript
+      const jobStatus = await ProviderInstance.computeStatus(
+        providerUrl,
+        await consumerAccount.getAddress(),
+        computeJobId
+      )
+  ```
+  <!--
+      assert(jobStatus, 'Cannot retrieve compute status!')
+  -->
+  Now, let's see the current status of the previously started computer job
+  ```Typescript
+      console.log('Current status of the compute job: ', jobStatus)
+  ```
+  <!--
+    }
+  }).timeout(40000)
+-->
+
+  ### 13.2 Get download compute results URL
+<!--
+    if (!hasFreeComputeSupport) {
+      assert(
+        computeRoutePath === null,
+        'Compute route path for paid compute is not defined (perhaps because provider does not support it yet?)'
       )
     } else {
   -->

--- a/ComputeExamples.md
+++ b/ComputeExamples.md
@@ -821,18 +821,17 @@ let's select compute environment which have free and paid resources
         consumerAccount,
         resources
       )
-  <!--
+
       console.log(
         'providerInitializeComputeResults = ',
         JSON.stringify(providerInitializeComputeResults)
       )
-  -->
+
+  ```
 
   <!--
       assert(!('error' in providerInitializeComputeResults), 'Cannot order algorithm')
   -->
-
-  ```
 
   Let's check funds for escrow payment
   ```Typescript

--- a/src/@types/Compute.ts
+++ b/src/@types/Compute.ts
@@ -186,3 +186,14 @@ export interface ComputeAlgorithm {
   algocustomdata?: { [key: string]: any }
   userdata?: { [key: string]: any }
 }
+
+export interface ComputePayment {
+  chainId: number
+  token: string
+  maxJobDuration: number
+}
+
+export interface ValidationResponse {
+  isValid: boolean
+  message: string
+}

--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -22,9 +22,19 @@ export interface ProviderComputeInitialize {
   providerFee?: ProviderFees
 }
 
+export interface ProviderComputeInitializePayment {
+  escrowAddress: string
+  chainId: number
+  payee: string
+  token: string
+  amount: number
+  minLockSeconds: number
+}
+
 export interface ProviderComputeInitializeResults {
   algorithm?: ProviderComputeInitialize
   datasets?: ProviderComputeInitialize[]
+  payment?: ProviderComputeInitializePayment
 }
 
 export interface ServiceEndpoint {

--- a/src/contracts/Datatoken.ts
+++ b/src/contracts/Datatoken.ts
@@ -815,6 +815,25 @@ export class Datatoken extends SmartContract {
   }
 
   /**
+   * Get Address Allowance for datatoken
+   * @param {String} dtAddress Datatoken adress
+   * @param {String} owner owner adress
+   * @param {String} spender spender adress
+   * @param {Number} decimals numer of token decimals, default 18
+   * @return {Promise<String>} allowance  Number of datatokens. Will be converted from wei
+   */
+  public async allowance(
+    datatokenAddress: string,
+    owner: string,
+    spender: string,
+    decimals: number = 18
+  ): Promise<string> {
+    const dtContract = this.getContract(datatokenAddress)
+    const allowance = await dtContract.allowance(owner, spender)
+    return await this.unitsToAmount(null, allowance, decimals)
+  }
+
+  /**
    * Allows to set the fee required by the publisherMarket
    * only publishMarketFeeAddress can call it
    * @param {string} datatokenAddress Datatoken adress

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -1,9 +1,10 @@
-import { Signer } from 'ethers'
+import { ethers, Signer, BigNumber } from 'ethers'
 import Escrow from '@oceanprotocol/contracts/artifacts/contracts/escrow/Escrow.sol/Escrow.json'
 import { amountToUnits, sendTx } from '../utils/ContractUtils'
-import { AbiItem, ReceiptOrEstimate } from '../@types'
+import { AbiItem, ReceiptOrEstimate, ValidationResponse } from '../@types'
 import { Config } from '../config'
 import { SmartContractWithAddress } from './SmartContractWithAddress'
+import { Datatoken } from './Datatoken'
 
 export class EscrowContract extends SmartContractWithAddress {
   public abiEnterprise: AbiItem[]
@@ -69,9 +70,109 @@ export class EscrowContract extends SmartContractWithAddress {
   }
 
   /**
+   * Checks funds for escrow payment.
+   * Does authorization when needed.
+   * Does deposit when needed.
+   * @param {String} token as payment token for escrow
+   * @param {String} consumerAddress as consumerAddress for that environment
+   * @param {String} amountToDeposit wanted amount for escrow lock deposit. If this is
+   * not provided and funds for escrow are 0 -> fallback to maxLockedAmount, else
+   * use balance of payment token.
+   * @param {String} maxLockedAmount amount necessary to be paid for starting compute job,
+   * returned from initialize compute payment and used for authorize if needed.
+   * @param {String} maxLockSeconds max seconds to lock the payment,
+   * returned from initialize compute payment and used for authorize if needed.
+   * @param {String} maxLockCounts max lock counts,
+   * returned from initialize compute payment and used for authorize if needed.
+   * @return {Promise<ValidationResponse>} validation response
+   */
+  public async verifyFundsForEscrowPayment(
+    token: string,
+    consumerAddress: string,
+    amountToDeposit?: string,
+    maxLockedAmount?: string,
+    maxLockSeconds?: string,
+    maxLockCounts?: string
+  ): Promise<ValidationResponse> {
+    const { provider } = this.contract
+    const balanceNativeToken = await provider.getBalance(
+      ethers.utils.getAddress(consumerAddress)
+    )
+    if (balanceNativeToken === BigNumber.from(0)) {
+      return {
+        isValid: false,
+        message: 'Native token balance is 0. Please add funds'
+      }
+    }
+    const tokenContract = new Datatoken(this.signer)
+    const allowance = await tokenContract.allowance(
+      token,
+      await this.signer.getAddress(),
+      this.contract.address
+    )
+    if (
+      BigNumber.from(await this.amountToUnits(token, allowance, 18)).lt(
+        BigNumber.from(maxLockedAmount)
+      )
+    ) {
+      await tokenContract.approve(
+        ethers.utils.getAddress(token),
+        ethers.utils.getAddress(this.contract.address),
+        maxLockedAmount
+      )
+    }
+    const balancePaymentToken = await tokenContract.balance(
+      token,
+      await this.signer.getAddress()
+    )
+    if (ethers.utils.parseEther(balancePaymentToken) === BigNumber.from(0)) {
+      return {
+        isValid: false,
+        message: 'Payment token balance is 0. Please add funds'
+      }
+    }
+    const auths = await this.getAuthorizations(
+      token,
+      await this.signer.getAddress(),
+      consumerAddress
+    )
+    const funds = await this.getUserFunds(await this.signer.getAddress(), token)
+    if (BigNumber.from(funds[0]).eq(BigNumber.from(0))) {
+      if (
+        amountToDeposit &&
+        ethers.utils
+          .parseEther(balancePaymentToken)
+          .lte(ethers.utils.parseEther(amountToDeposit)) &&
+        ethers.utils.parseEther(amountToDeposit) > BigNumber.from(maxLockedAmount)
+      ) {
+        await this.deposit(token, amountToDeposit)
+      } else if (
+        ethers.utils.parseEther(balancePaymentToken).lte(BigNumber.from(maxLockedAmount))
+      ) {
+        await this.deposit(token, await this.unitsToAmount(token, maxLockedAmount))
+      } else {
+        await this.deposit(token, balancePaymentToken)
+      }
+    }
+    if (auths.length === 0) {
+      await this.authorize(
+        ethers.utils.getAddress(token),
+        ethers.utils.getAddress(consumerAddress),
+        (Number(maxLockedAmount) / 2).toString(),
+        maxLockSeconds,
+        maxLockCounts
+      )
+    }
+    return {
+      isValid: true,
+      message: ''
+    }
+  }
+
+  /**
    * Deposit funds
    * @param {String} token Token address
-   * @param {String} amount tokenURI
+   * @param {String} amount amount
    * @param {Boolean} estimateGas if True, return gas estimate
    * @return {Promise<ReceiptOrEstimate>} returns the transaction receipt or the estimateGas value
    */
@@ -106,7 +207,33 @@ export class EscrowContract extends SmartContractWithAddress {
     amounts: string[],
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const amountsParsed = amounts.map((amount) => amountToUnits(null, null, amount, 18))
+    // check if funds exist in escrow in order to be withdrawed
+    const tokensWithSufficientFunds = []
+    const amountsWithSufficientFunds = []
+
+    if (tokens.length !== amounts.length) {
+      throw new Error('Tokens and amounts arrays must have the same length')
+    }
+
+    const userAddress = await this.signer.getAddress()
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i]
+      const amount = BigNumber.from(amounts[i])
+
+      const funds = await this.getUserFunds(userAddress, token)
+      const available = BigNumber.from(funds[0])
+
+      if (amount.gt(0) && amount.lte(available)) {
+        tokensWithSufficientFunds.push(token)
+        amountsWithSufficientFunds.push(amounts[i])
+      } else {
+        console.log(`Insufficient funds for token ${token}`)
+      }
+    }
+    const amountsParsed = amountsWithSufficientFunds.map((amount) =>
+      amountToUnits(null, null, amount, 18)
+    )
 
     const estGas = await this.contract.estimateGas.withdraw(tokens, amountsParsed)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
@@ -116,7 +243,7 @@ export class EscrowContract extends SmartContractWithAddress {
       this.getSignerAccordingSdk(),
       this.config?.gasFeeMultiplier,
       this.contract.withdraw,
-      tokens,
+      tokensWithSufficientFunds,
       amountsParsed
     )
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -140,6 +267,15 @@ export class EscrowContract extends SmartContractWithAddress {
     maxLockCounts: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const auths = await this.getAuthorizations(
+      token,
+      await this.signer.getAddress(),
+      payee
+    )
+    if (auths.length !== 0) {
+      console.log(`Payee ${payee} already authorized`)
+      return null
+    }
     const maxLockedAmountParsed = amountToUnits(null, null, maxLockedAmount, 18)
     const maxLockSecondsParsed = amountToUnits(null, null, maxLockSeconds, 18)
     const maxLockCountsParsed = amountToUnits(null, null, maxLockCounts, 18)
@@ -161,6 +297,42 @@ export class EscrowContract extends SmartContractWithAddress {
       maxLockedAmountParsed,
       maxLockSecondsParsed,
       maxLockCountsParsed
+    )
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  /**
+   * Cancel expired locks
+   * @param {String} jobId Job ID with hash
+   * @param {String} token Token address
+   * @param {String} payee, Payee address for the compute job,
+   * @param {String} payer, Payer address for the compute job
+   * @param {Boolean} estimateGas if True, return gas estimate
+   * @return {Promise<ReceiptOrEstimate>} returns the transaction receipt or the estimateGas value
+   */
+  public async cancelExpiredLocks<G extends boolean = false>(
+    jobIds: string[],
+    tokens: string[],
+    payers: string[],
+    payees: string[],
+    estimateGas?: G
+  ): Promise<ReceiptOrEstimate<G>> {
+    const estGas = await this.contract.estimateGas.cancelExpiredLocks(
+      jobIds,
+      tokens,
+      payers,
+      payees
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const trxReceipt = await sendTx(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier,
+      this.contract.cancelExpiredLocks,
+      jobIds,
+      tokens,
+      payers,
+      payees
     )
     return <ReceiptOrEstimate<G>>trxReceipt
   }

--- a/src/services/Aquarius.ts
+++ b/src/services/Aquarius.ts
@@ -62,7 +62,7 @@ export class Aquarius {
     did: string,
     txid?: string,
     signal?: AbortSignal,
-    interval: number = 3000,
+    interval: number = 30000,
     maxRetries: number = 100
   ): Promise<Asset> {
     let tries = 0

--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -15,7 +15,8 @@ import {
   UrlFile,
   UserCustomParameters,
   Ipfs,
-  ComputeResourceRequest
+  ComputeResourceRequest,
+  ComputePayment
 } from '../@types'
 
 export class Provider {
@@ -423,9 +424,11 @@ export class Provider {
     assets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
     computeEnv: string,
-    validUntil: number,
     providerUri: string,
     accountId: string,
+    chainId: number,
+    token: string,
+    maxJobDuration: number,
     signal?: AbortSignal
   ): Promise<ProviderComputeInitializeResults> {
     const providerEndpoints = await this.getEndpoints(providerUri)
@@ -433,11 +436,17 @@ export class Provider {
       providerUri,
       providerEndpoints
     )
-    const providerData = {
+    const payment: ComputePayment = {
+      chainId,
+      token,
+      maxJobDuration
+    }
+    const payload: Object = {
       datasets: assets,
       algorithm,
-      compute: { env: computeEnv, validUntil },
-      consumerAddress: accountId
+      payment,
+      consumerAddress: accountId,
+      environment: computeEnv
     }
     const initializeUrl = this.getEndpointURL(serviceEndpoints, 'initializeCompute')
       ? this.getEndpointURL(serviceEndpoints, 'initializeCompute').urlPath
@@ -447,7 +456,7 @@ export class Provider {
     try {
       response = await fetch(initializeUrl, {
         method: 'POST',
-        body: JSON.stringify(providerData),
+        body: JSON.stringify(payload),
         headers: { 'Content-Type': 'application/json' },
         signal
       })
@@ -467,7 +476,7 @@ export class Provider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', providerData)
+    LoggerInstance.error('Payload was:', JSON.stringify(payload))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 
@@ -475,6 +484,7 @@ export class Provider {
    * @param {ComputeAsset[]} assets The datasets array to initialize compute request.
    * @param {ComputeAlgorithmber} algorithm The algorithm to use.
    * @param {string} computeEnv The compute environment.
+   * @param {string} token The payment token address.
    * @param {number} validUntil  The job expiration date.
    * @param {string} providerUri The provider URI.
    * @param {Signer} signer caller address
@@ -485,9 +495,11 @@ export class Provider {
     assets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
     computeEnv: string,
+    token: string,
     validUntil: number,
     providerUri: string,
     signer: Signer,
+    resources: ComputeResourceRequest[],
     signal?: AbortSignal
   ): Promise<ProviderComputeInitializeResults> {
     const providerEndpoints = await this.getEndpoints(providerUri)
@@ -515,10 +527,16 @@ export class Provider {
     signatureMessage += nonce
     const signature = await this.signProviderRequest(signer, signatureMessage)
 
-    const providerData = {
+    const providerData: Object = {
       datasets: assets,
       algorithm,
-      compute: { env: computeEnv, validUntil },
+      environment: computeEnv,
+      payment: {
+        chainId: await signer.getChainId(),
+        token,
+        resources
+      },
+      maxJobDuration: validUntil,
       consumerAddress,
       signature
     }
@@ -537,10 +555,14 @@ export class Provider {
         signal
       })
       console.log('Raw response:', response)
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`${errorText}`)
+      }
     } catch (e) {
       LoggerInstance.error('Initialize compute failed: ')
       LoggerInstance.error(e)
-      throw new Error('ComputeJob cannot be initialized')
+      throw new Error(`ComputeJob cannot be initialized: ${e.message}.`)
     }
     if (response?.ok) {
       const params = await response.json()
@@ -553,7 +575,7 @@ export class Provider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', providerData)
+    LoggerInstance.error('Payload was:', JSON.stringify(providerData))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 
@@ -707,10 +729,11 @@ export class Provider {
    * @param {string} computeEnv The compute environment.
    * @param {ComputeAsset} datasets The dataset to start compute on + additionalDatasets (the additional datasets if that is the case)
    * @param {ComputeAlgorithm} algorithm The algorithm to start compute with.
+   * @param {number} maxJobDuration The compute job max execution time.
+   * @param {string} token The token address for compute payment.
    * @param {ComputeResourceRequest} resources The resources to start compute job with.
    * @param {chainId} chainId The chain used to do payments
    * @param {ComputeOutput} output The compute job output settings.
-   * @param {boolean} freeEnvironment is it a free environment? uses different route
    * @param {AbortSignal} signal abort signal
    * @return {Promise<ComputeJob | ComputeJob[]>} The compute job or jobs.
    */
@@ -720,7 +743,9 @@ export class Provider {
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
-    resources?: ComputeResourceRequest[],
+    maxJobDuration: number,
+    token: string,
+    resources: ComputeResourceRequest[],
     chainId?: number, // network used by payment (only for payed compute jobs)
     output?: ComputeOutput,
     signal?: AbortSignal
@@ -765,15 +790,23 @@ export class Provider {
     payload.signature = signature
     payload.nonce = nonce
     payload.environment = computeEnv
+    payload.maxJobDuration = maxJobDuration
     payload.resources = resources
-    payload.chainId = chainId
     // kept for backwards compatibility (tests running against existing provider)
     payload.dataset = datasets[0]
     // new field for C2D v2
     payload.datasets = datasets
     payload.algorithm = algorithm
+    const chainIdCompute = chainId ?? (await consumer.getChainId())
+    payload.chainId = chainIdCompute
+    payload.payment = {
+      chainId: chainIdCompute,
+      token,
+      maxJobDuration
+    }
+    if (resources) payload.payment.resources = resources
     // if (additionalDatasets) payload.additionalDatasets = additionalDatasets
-    payload.output = output
+    if (output) payload.output = output
     let response
     try {
       response = await fetch(computeStartUrl, {

--- a/test/config.ts
+++ b/test/config.ts
@@ -31,7 +31,7 @@ export const provider = new providers.JsonRpcProvider(
 // export const signer = wallet.connect(provider)
 
 export const getTestConfig = async (signer: Signer) => {
-  const { chainId } = await signer.provider.getNetwork()
+  const chainId = await signer.getChainId()
   const config = new ConfigHelper().getConfig(parseInt(String(chainId)))
 
   if (process.env.OCEAN_NODE_URL) {

--- a/test/integration/CodeExamples.test.ts
+++ b/test/integration/CodeExamples.test.ts
@@ -183,12 +183,11 @@ describe('Marketplace flow tests', async () => {
     },
     services: [
       {
-        id: 'testFakeId',
+        id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
         type: 'access',
-        description: 'Download service',
         files: '',
-        datatokenAddress: '0x0',
-        serviceEndpoint: 'http://172.15.0.4:8030',
+        datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
+        serviceEndpoint: 'http://127.0.0.1:8001',
         timeout: 0
       }
     ]

--- a/test/integration/ComputeExamples.test.ts
+++ b/test/integration/ComputeExamples.test.ts
@@ -14,6 +14,8 @@
 /// 9. [Consumer fetches compute environment](#9-get-compute-environments)
 /// 10. [Consumer starts a free compute job using a free C2D environment](#10-consumer-starts-a-compute-job)
 /// 11. [Check compute status and get download compute results url](#11-check-compute-status-and-get-download-compute-results-url)
+/// 12. [Consumer starts a paid compute job](#12-consumer-starts-a-paid-compute-job)
+/// 13. [Check paid compute job status and get download compute results URL](#13-check-paid-compute-job-status-and-get-download-compute-results-url)
 
 /// Let's go through each step.
 
@@ -143,12 +145,15 @@ import {
   ConfigHelper,
   getEventFromTx,
   amountToUnits,
-  isDefined
+  isDefined,
+  ComputeResourceRequest,
+  unitsToAmount
 } from '../../src/index.js'
-/// ```
 import crypto from 'crypto-js'
 import { DDO } from '@oceanprotocol/ddo-js'
+import { EscrowContract } from '../../src/contracts/Escrow.js'
 const { SHA256 } = crypto
+/// ```
 
 /// ### 4.2. Constants and variables
 
@@ -183,7 +188,7 @@ const ALGORITHM_ASSET_URL: Files = {
 /// ```Typescript
 const DATASET_DDO: DDO = {
   '@context': ['https://w3id.org/did/v1'],
-  id: 'id:op:efba17455c127a885ec7830d687a8f6e64f5ba559f8506f8723c1f10f05c049c',
+  id: 'did:op:efba17455c127a885ec7830d687a8f6e64f5ba559f8506f8723c1f10f05c049c',
   version: '4.1.0',
   chainId: 8996,
   nftAddress: '0x0',
@@ -201,16 +206,16 @@ const DATASET_DDO: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: '1155995dda741e93afe4b1c6ced2d01734a6ec69865cc0997daf1f4db7259a36',
       type: 'compute',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
-      serviceEndpoint: 'https://v4.provider.goerli.oceanprotocol.com/',
+      serviceEndpoint: 'http://127.0.0.1:8001',
       timeout: 300,
       compute: {
-        publisherTrustedAlgorithmPublishers: [],
-        publisherTrustedAlgorithms: [],
-        allowRawAlgorithm: true,
+        publisherTrustedAlgorithmPublishers: [] as any,
+        publisherTrustedAlgorithms: [] as any,
+        allowRawAlgorithm: false,
         allowNetworkAccess: true
       }
     }
@@ -248,11 +253,11 @@ const ALGORITHM_DDO: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
       type: 'access',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
-      serviceEndpoint: 'https://v4.provider.goerli.oceanprotocol.com',
+      serviceEndpoint: 'http://127.0.0.1:8001',
       timeout: 300
     }
   ]
@@ -609,10 +614,7 @@ describe('Compute-to-data example tests', async () => {
 
     /// let's check the free compute environment
     /// ```Typescript
-    const computeEnv = computeEnvs.find(
-      (ce) =>
-        !ce?.fees || ce.fees.find((fee) => fee.symbol === 'OCEAN' && fee.amount === '0')
-    )
+    const computeEnv = computeEnvs.find((ce) => isDefined(ce.free))
     console.log('Free compute environment = ', computeEnv)
     /// ```
     /// <!--
@@ -630,7 +632,6 @@ describe('Compute-to-data example tests', async () => {
       const mytime = new Date()
       const computeMinutes = 5
       mytime.setMinutes(mytime.getMinutes() + computeMinutes)
-      const computeValidUntil = Math.floor(mytime.getTime() / 1000)
 
       /// ```
       /// Let's prepare the dataset and algorithm assets to be used in the compute job
@@ -641,7 +642,6 @@ describe('Compute-to-data example tests', async () => {
           serviceId: resolvedDatasetDdo.services[0].id
         }
       ]
-      const dtAddressArray = [resolvedDatasetDdo.services[0].datatokenAddress]
 
       const algo: ComputeAlgorithm = {
         documentId: resolvedAlgorithmDdo.id,
@@ -649,39 +649,6 @@ describe('Compute-to-data example tests', async () => {
         meta: resolvedAlgorithmDdo.metadata.algorithm
       }
       /// ```
-
-      /// <!--
-      // const providerInitializeComputeResults = await ProviderInstance.initializeCompute(
-      //   assets,
-      //   algo,
-      //   computeEnv.id,
-      //   computeValidUntil,
-      //   providerUrl,
-      //   consumerAccount
-      // )
-      // console.log('providerInitializeComputeResults = ', providerInitializeComputeResults)
-      //
-      //
-      // assert(!('error' in providerInitializeComputeResults), 'Cannot order algorithm')
-      //
-      //
-      // algo.transferTxId = await handleOrder(
-      //   providerInitializeComputeResults.algorithm,
-      //   resolvedAlgorithmDdo.services[0].datatokenAddress,
-      //   consumerAccount,
-      //   computeEnv.consumerAddress,
-      //   0
-      // )
-      // for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
-      //   assets[i].transferTxId = await handleOrder(
-      //     providerInitializeComputeResults.datasets[i],
-      //     dtAddressArray[i],
-      //     consumerAccount,
-      //     computeEnv.consumerAddress,
-      //     0
-      //   )
-      // }
-      /// -->
 
       /// Let's start the free compute job
       /// ```Typescript
@@ -752,6 +719,252 @@ describe('Compute-to-data example tests', async () => {
       assert(
         computeRoutePath === null,
         'Compute route path for free compute is not defined (perhaps because provider does not support it yet?)'
+      )
+    } else {
+      /// -->
+
+      /// ```Typescript
+      await sleep(10000)
+      const downloadURL = await ProviderInstance.getComputeResultUrl(
+        providerUrl,
+        consumerAccount,
+        computeJobId,
+        0
+      )
+      /// ```
+      /// <!--
+      assert(downloadURL, 'Provider getComputeResultUrl failed!')
+      /// -->
+      /// Let's check the compute results url for the specified index
+      /// ```Typescript
+      console.log(`Compute results URL: ${downloadURL}`)
+      /// ```
+      /// <!--
+    }
+  }).timeout(40000)
+  /// -->
+
+  /// ## 12. Consumer starts a paid compute job
+
+  it('12.1 Start a compute job using a paid C2D resources', async () => {
+    /// <!--
+    datatoken = new Datatoken(
+      consumerAccount,
+      (await consumerAccount.provider.getNetwork()).chainId
+    )
+    /// -->
+
+    /// let's select compute environment which have free and paid resources
+    /// ```Typescript
+    const computeEnv = computeEnvs[0]
+    console.log('Compute environment = ', computeEnv)
+    /// ```
+    /// <!--
+    assert(computeEnv, 'Cannot find the compute env')
+    /// -->
+
+    /// <!--
+    const paymentToken = addresses.Ocean
+    computeRoutePath = await ProviderInstance.getComputeStartRoutes(providerUrl, false)
+    if (isDefined(computeRoutePath)) {
+      /// -->
+
+      /// Let's have 5 minute of compute access
+      /// ```Typescript
+
+      const mytime = new Date()
+      const computeMinutes = 5
+      mytime.setMinutes(mytime.getMinutes() + computeMinutes)
+      const computeValidUntil = Math.floor(mytime.getTime() / 1000)
+
+      /// ```
+
+      /// Let's prepare the dataset and algorithm assets to be used in the compute job
+      /// ```Typescript
+      const resources: ComputeResourceRequest[] = [
+        {
+          id: 'cpu',
+          amount: 2
+        },
+        {
+          id: 'ram',
+          amount: 1000000000
+        },
+        {
+          id: 'disk',
+          amount: 0
+        }
+      ]
+      const assets: ComputeAsset[] = [
+        {
+          documentId: resolvedDatasetDdo.id,
+          serviceId: resolvedDatasetDdo.services[0].id
+        }
+      ]
+      const dtAddressArray = [resolvedDatasetDdo.services[0].datatokenAddress]
+      const algo: ComputeAlgorithm = {
+        documentId: resolvedAlgorithmDdo.id,
+        serviceId: resolvedAlgorithmDdo.services[0].id,
+        meta: resolvedAlgorithmDdo.metadata.algorithm
+      }
+      /// ```
+
+      /// Triggering initialize compute to see payment options
+      /// ```Typescript
+      const providerInitializeComputeResults = await ProviderInstance.initializeCompute(
+        assets,
+        algo,
+        computeEnv.id,
+        paymentToken,
+        computeValidUntil,
+        providerUrl,
+        consumerAccount,
+        resources
+      )
+
+      console.log(
+        'providerInitializeComputeResults = ',
+        JSON.stringify(providerInitializeComputeResults)
+      )
+
+      /// ```
+
+      /// <!--
+      assert(!('error' in providerInitializeComputeResults), 'Cannot order algorithm')
+      /// -->
+
+      /// Let's check funds for escrow payment
+      /// ```Typescript
+      const escrow = new EscrowContract(
+        ethers.utils.getAddress(providerInitializeComputeResults.payment.escrowAddress),
+        consumerAccount
+      )
+      const paymentTokenPublisher = new Datatoken(publisherAccount)
+      const balancePublisherPaymentToken = await paymentTokenPublisher.balance(
+        paymentToken,
+        await publisherAccount.getAddress()
+      )
+      assert(
+        ethers.utils.parseEther(balancePublisherPaymentToken) > ethers.BigNumber.from(0),
+        'Balance should be higher than 0'
+      )
+      const tx = await publisherAccount.sendTransaction({
+        to: computeEnv.consumerAddress,
+        value: ethers.utils.parseEther('1.5')
+      })
+      await tx.wait()
+
+      await paymentTokenPublisher.transfer(
+        paymentToken,
+        ethers.utils.getAddress(computeEnv.consumerAddress),
+        (Number(balancePublisherPaymentToken) / 2).toString()
+      )
+      const amountToDeposit = (
+        providerInitializeComputeResults.payment.amount * 2
+      ).toString()
+      await escrow.verifyFundsForEscrowPayment(
+        paymentToken,
+        computeEnv.consumerAddress,
+        await unitsToAmount(consumerAccount, paymentToken, amountToDeposit),
+        providerInitializeComputeResults.payment.amount.toString(),
+        providerInitializeComputeResults.payment.minLockSeconds.toString(),
+        '10'
+      )
+      /// ```
+
+      /// Let's order assets
+      /// ```Typescript
+
+      algo.transferTxId = await handleOrder(
+        providerInitializeComputeResults.algorithm,
+        resolvedAlgorithmDdo.services[0].datatokenAddress,
+        consumerAccount,
+        computeEnv.consumerAddress,
+        0
+      )
+      for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
+        assets[i].transferTxId = await handleOrder(
+          providerInitializeComputeResults.datasets[i],
+          dtAddressArray[i],
+          consumerAccount,
+          computeEnv.consumerAddress,
+          0
+        )
+      }
+      /// ```
+
+      /// Let's start compute job
+      /// ```Typescript
+      const computeJobs = await ProviderInstance.computeStart(
+        providerUrl,
+        consumerAccount,
+        computeEnv.id,
+        assets,
+        algo,
+        computeValidUntil,
+        paymentToken,
+        resources,
+        (
+          await consumerAccount.provider.getNetwork()
+        ).chainId
+      )
+      /// ```
+
+      /// <!--
+      assert(computeJobs, 'Cannot start compute job')
+      /// -->
+
+      /// Let's save the compute job it, we re going to use later
+      /// ```Typescript
+      computeJobId = computeJobs[0].jobId
+      /// ```
+      /// <!--
+    } else {
+      assert(
+        computeRoutePath === null,
+        'Route path for free compute is not defined (perhaps because provider does not support it yet?)'
+      )
+      hasFreeComputeSupport = false
+    }
+  }).timeout(40000)
+  /// -->
+
+  /// ## 13. Check paid compute job status and get download compute results URL
+  it('13.1 Check compute status for paid compute job', async () => {
+    /// <!--
+    if (!hasFreeComputeSupport) {
+      assert(
+        computeRoutePath === null,
+        'Compute route path for free compute is not defined (perhaps because provider does not support it yet?)'
+      )
+    } else {
+      /// -->
+      /// You can also add various delays so you see the various states of the compute job
+      /// ```Typescript
+      const jobStatus = await ProviderInstance.computeStatus(
+        providerUrl,
+        await consumerAccount.getAddress(),
+        computeJobId
+      )
+      /// ```
+      /// <!--
+      assert(jobStatus, 'Cannot retrieve compute status!')
+      /// -->
+      /// Now, let's see the current status of the previously started computer job
+      /// ```Typescript
+      console.log('Current status of the compute job: ', jobStatus)
+      /// ```
+      /// <!--
+    }
+  }).timeout(40000)
+  /// -->
+
+  it('13.2 Get download compute results URL', async () => {
+    /// <!--
+    if (!hasFreeComputeSupport) {
+      assert(
+        computeRoutePath === null,
+        'Compute route path for paid compute is not defined (perhaps because provider does not support it yet?)'
       )
     } else {
       /// -->

--- a/test/integration/ComputeFlow.test.ts
+++ b/test/integration/ComputeFlow.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { ethers, Signer } from 'ethers'
+import { BigNumber, ethers, Signer } from 'ethers'
 import { getTestConfig, getAddresses, provider } from '../config.js'
 import {
   Config,
@@ -7,16 +7,20 @@ import {
   Aquarius,
   Datatoken,
   sendTx,
-  amountToUnits
+  amountToUnits,
+  isDefined,
+  unitsToAmount
 } from '../../src/index.js'
 import {
   ComputeJob,
   ComputeAsset,
   ComputeAlgorithm,
-  Files
+  Files,
+  ComputeResourceRequest
 } from '../../src/@types/index.js'
-import { createAssetHelper } from './helpers.js'
+import { createAssetHelper, handleComputeOrder } from './helpers.js'
 import { DDO } from '@oceanprotocol/ddo-js'
+import { EscrowContract } from '../../src/contracts/Escrow.js'
 
 let config: Config
 
@@ -28,17 +32,18 @@ let publisherAccount: Signer
 let providerInitializeComputeResults
 let computeEnvs
 let addresses: any
-let ddoWith5mTimeoutId
+let ddoWith2mTimeoutId
 let ddoWithNoTimeoutId
-let algoDdoWith5mTimeoutId
+let algoDdoWith2mTimeoutId
 let algoDdoWithNoTimeoutId
+let paymentToken: string
 
 let freeComputeJobId: string
 let paidComputeJobId: string
 
-let resolvedDdoWith5mTimeout
+let resolvedDdoWith2mTimeout
 let resolvedDdoWithNoTimeout
-let resolvedAlgoDdoWith5mTimeout
+let resolvedAlgoDdoWith2mTimeout
 let resolvedAlgoDdoWithNoTimeout
 
 let freeEnvDatasetTxId
@@ -46,8 +51,10 @@ let freeEnvAlgoTxId
 let paidEnvDatasetTxId
 let paidEnvAlgoTxId
 let computeValidUntil
-
+let escrow: EscrowContract
 let freeComputeRouteSupport = null
+
+const computeJobDuration = 60 * 15 // 15 minutes
 
 const assetUrl: Files = {
   datatokenAddress: '0x0',
@@ -73,7 +80,7 @@ const ddoWithNoTimeout: DDO = {
     name: 'dfgdfgdg',
     description: 'd dfgd fgd dfg dfgdfgd dfgdf',
     tags: [''],
-    author: 'dd',
+    author: 'oceanprotocol',
     license: 'https://market.oceanprotocol.com/terms',
     additionalInformation: {
       termsAndConditions: true
@@ -81,23 +88,23 @@ const ddoWithNoTimeout: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: '1155995dda741e93afe4b1c6ced2d01734a6ec69865cc0997daf1f4db7259a36',
       type: 'compute',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
       serviceEndpoint: 'http://127.0.0.1:8001',
       timeout: 0,
       compute: {
-        publisherTrustedAlgorithmPublishers: [],
-        publisherTrustedAlgorithms: [],
-        allowRawAlgorithm: true,
+        publisherTrustedAlgorithmPublishers: [] as any,
+        publisherTrustedAlgorithms: [] as any,
+        allowRawAlgorithm: false,
         allowNetworkAccess: true
       }
     }
   ]
 }
 
-const ddoWith5mTimeout: DDO = {
+const ddoWith2mTimeout: DDO = {
   '@context': ['https://w3id.org/did/v1'],
   id: 'did:op:efba17455c127a885ec7830d687a8f6e64f5ba559f8506f8723c1f10f05c049c',
   version: '4.1.0',
@@ -118,16 +125,16 @@ const ddoWith5mTimeout: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: '1155995dda741e93afe4b1c6ced2d01734a6ec69865cc0997daf1f4db7259a36',
       type: 'compute',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
       serviceEndpoint: 'http://127.0.0.1:8001',
-      timeout: 300,
+      timeout: 120,
       compute: {
-        publisherTrustedAlgorithmPublishers: [],
-        publisherTrustedAlgorithms: [],
-        allowRawAlgorithm: true,
+        publisherTrustedAlgorithmPublishers: [] as any,
+        publisherTrustedAlgorithms: [] as any,
+        allowRawAlgorithm: false,
         allowNetworkAccess: true
       }
     }
@@ -154,7 +161,7 @@ const algoDdoWithNoTimeout: DDO = {
     created: '2021-12-20T14:35:20Z',
     updated: '2021-12-20T14:35:20Z',
     type: 'algorithm',
-    name: 'dfgdfgdg',
+    name: 'Ocean.js Algo',
     description: 'd dfgd fgd dfg dfgdfgd dfgdf',
     tags: [''],
     author: 'dd',
@@ -176,7 +183,7 @@ const algoDdoWithNoTimeout: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
       type: 'access',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
@@ -186,7 +193,7 @@ const algoDdoWithNoTimeout: DDO = {
   ]
 }
 
-const algoDdoWith5mTimeout: DDO = {
+const algoDdoWith2mTimeout: DDO = {
   '@context': ['https://w3id.org/did/v1'],
   id: 'did:op:efba17455c127a885ec7830d687a8f6e64f5ba559f8506f8723c1f10f05c049c',
   version: '4.1.0',
@@ -218,12 +225,12 @@ const algoDdoWith5mTimeout: DDO = {
   },
   services: [
     {
-      id: 'notAnId',
+      id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
       type: 'access',
       files: '',
       datatokenAddress: '0xa15024b732A8f2146423D14209eFd074e61964F3',
       serviceEndpoint: 'http://127.0.0.1:8001',
-      timeout: 300
+      timeout: 120
     }
   ]
 }
@@ -231,7 +238,7 @@ const algoDdoWith5mTimeout: DDO = {
 function delay(interval: number) {
   return it('should delay', (done) => {
     setTimeout(() => done(), interval)
-  }).timeout(interval + 100)
+  }).timeout(interval + 200)
 }
 
 async function waitTillJobEnds(): Promise<number> {
@@ -258,6 +265,7 @@ describe('Compute flow tests', async () => {
     aquarius = new Aquarius(config?.oceanNodeUri)
     providerUrl = config?.oceanNodeUri
     addresses = getAddresses()
+    paymentToken = addresses.Ocean
   })
 
   it('should publish datasets and algorithms', async () => {
@@ -282,7 +290,7 @@ describe('Compute flow tests', async () => {
     const tokenContract = new ethers.Contract(addresses.Ocean, minAbi, publisherAccount)
     const estGasPublisher = await tokenContract.estimateGas.mint(
       await publisherAccount.getAddress(),
-      amountToUnits(null, null, '1000', 18)
+      amountToUnits(null, null, '100000', 18)
     )
 
     await sendTx(
@@ -291,13 +299,13 @@ describe('Compute flow tests', async () => {
       1,
       tokenContract.mint,
       await publisherAccount.getAddress(),
-      amountToUnits(null, null, '1000', 18)
+      amountToUnits(null, null, '60000000', 18)
     )
 
     // mint ocean to consumer
     const estGasConsumer = await tokenContract.estimateGas.mint(
       await consumerAccount.getAddress(),
-      amountToUnits(null, null, '1000', 18)
+      amountToUnits(null, null, '60000000', 18)
     )
 
     await sendTx(
@@ -306,15 +314,15 @@ describe('Compute flow tests', async () => {
       1,
       tokenContract.mint,
       await consumerAccount.getAddress(),
-      amountToUnits(null, null, '1000', 18)
+      amountToUnits(null, null, '100000', 18)
     )
 
-    ddoWith5mTimeoutId = await createAssetHelper(
+    ddoWith2mTimeoutId = await createAssetHelper(
       'D1Min',
       'D1M',
       publisherAccount,
       assetUrl,
-      ddoWith5mTimeout,
+      ddoWith2mTimeout,
       providerUrl,
       addresses.ERC721Factory,
       aquarius
@@ -329,12 +337,12 @@ describe('Compute flow tests', async () => {
       addresses.ERC721Factory,
       aquarius
     )
-    algoDdoWith5mTimeoutId = await createAssetHelper(
+    algoDdoWith2mTimeoutId = await createAssetHelper(
       'A1Min',
       'A1M',
       publisherAccount,
       algoAssetUrl,
-      algoDdoWith5mTimeout,
+      algoDdoWith2mTimeout,
       providerUrl,
       addresses.ERC721Factory,
       aquarius
@@ -355,15 +363,15 @@ describe('Compute flow tests', async () => {
   delay(10000)
 
   it('should resolve published datasets and algorithms', async () => {
-    resolvedDdoWith5mTimeout = await aquarius.waitForIndexer(ddoWith5mTimeoutId)
-    assert(resolvedDdoWith5mTimeout, 'Cannot fetch DDO from Aquarius')
+    resolvedDdoWith2mTimeout = await aquarius.waitForIndexer(ddoWith2mTimeoutId)
+    assert(resolvedDdoWith2mTimeout, 'Cannot fetch DDO from Aquarius')
     resolvedDdoWithNoTimeout = await aquarius.waitForIndexer(ddoWithNoTimeoutId)
     assert(resolvedDdoWithNoTimeout, 'Cannot fetch DDO from Aquarius')
-    resolvedAlgoDdoWith5mTimeout = await aquarius.waitForIndexer(algoDdoWith5mTimeoutId)
-    assert(resolvedAlgoDdoWith5mTimeout, 'Cannot fetch DDO from Aquarius')
+    resolvedAlgoDdoWith2mTimeout = await aquarius.waitForIndexer(algoDdoWith2mTimeoutId)
+    assert(resolvedAlgoDdoWith2mTimeout, 'Cannot fetch DDO from Aquarius')
     resolvedAlgoDdoWithNoTimeout = await aquarius.waitForIndexer(algoDdoWithNoTimeoutId)
     assert(resolvedAlgoDdoWithNoTimeout, 'Cannot fetch DDO from Aquarius')
-  }).timeout(40000)
+  }).timeout(80000)
 
   it('should send DT to consumer', async () => {
     const datatoken = new Datatoken(
@@ -371,7 +379,7 @@ describe('Compute flow tests', async () => {
       (await publisherAccount.provider.getNetwork()).chainId
     )
     await datatoken.mint(
-      resolvedDdoWith5mTimeout.services[0].datatokenAddress,
+      resolvedDdoWith2mTimeout.services[0].datatokenAddress,
       await publisherAccount.getAddress(),
       '10',
       await consumerAccount.getAddress()
@@ -383,7 +391,7 @@ describe('Compute flow tests', async () => {
       await consumerAccount.getAddress()
     )
     await datatoken.mint(
-      resolvedAlgoDdoWith5mTimeout.services[0].datatokenAddress,
+      resolvedAlgoDdoWith2mTimeout.services[0].datatokenAddress,
       await publisherAccount.getAddress(),
       '10',
       await consumerAccount.getAddress()
@@ -414,24 +422,20 @@ describe('Compute flow tests', async () => {
     computeValidUntil = Math.floor(mytime.getTime() / 1000)
 
     // we choose the free env
-    const computeEnv = computeEnvs.find(
-      (ce) =>
-        !ce?.fees || ce.fees.find((fee) => fee.symbol === 'OCEAN' && fee.amount === '0')
-    )
+    const computeEnv = computeEnvs.find((ce) => ce.priceMin === 0 || isDefined(ce.free))
     assert(computeEnv, 'Cannot find the free compute env')
 
     const assets: ComputeAsset[] = [
       {
-        documentId: resolvedDdoWith5mTimeout.id,
-        serviceId: resolvedDdoWith5mTimeout.services[0].id
+        documentId: resolvedDdoWith2mTimeout.id,
+        serviceId: resolvedDdoWith2mTimeout.services[0].id
       }
     ]
-    const dtAddressArray = [resolvedDdoWith5mTimeout.services[0].datatokenAddress]
 
     const algo: ComputeAlgorithm = {
-      documentId: resolvedAlgoDdoWith5mTimeout.id,
-      serviceId: resolvedAlgoDdoWith5mTimeout.services[0].id,
-      meta: resolvedAlgoDdoWith5mTimeout.metadata.algorithm
+      documentId: resolvedAlgoDdoWith2mTimeout.id,
+      serviceId: resolvedAlgoDdoWith2mTimeout.services[0].id,
+      meta: resolvedAlgoDdoWith2mTimeout.metadata.algorithm
     }
 
     freeComputeRouteSupport = await ProviderInstance.getComputeStartRoutes(
@@ -472,348 +476,447 @@ describe('Compute flow tests', async () => {
 
   //   // moving to paid environments
 
-  // it('should start a computeJob on a paid environment', async () => {
-  //   // we choose the paid env
-  //   const computeEnv = computeEnvs[resolvedDdoWith5mTimeout.chainId].find(
-  //     (ce) => ce.priceMin !== 0 || !isDefined(ce.free)
-  //   )
-  //   assert(computeEnv, 'Cannot find the paid compute env')
+  it('Should fast forward time and set a new computeValidUntil', async () => {
+    const mytime = new Date()
+    const computeMinutes = 2
+    mytime.setMinutes(mytime.getMinutes() + computeMinutes)
+    computeValidUntil = Math.floor(mytime.getTime() / 1000)
+  })
 
-  //   const assets: ComputeAsset[] = [
-  //     {
-  //       documentId: resolvedDdoWith5mTimeout.id,
-  //       serviceId: resolvedDdoWith5mTimeout.services[0].id
-  //     }
-  //   ]
-  //   const dtAddressArray = [resolvedDdoWith5mTimeout.services[0].datatokenAddress]
-  //   const algo: ComputeAlgorithm = {
-  //     documentId: resolvedAlgoDdoWith5mTimeout.id,
-  //     serviceId: resolvedAlgoDdoWith5mTimeout.services[0].id
-  //   }
+  it('should NOT initialize compute with the paid resources, exceeding max resources', async () => {
+    // we choose the paid env
+    computeEnvs = await ProviderInstance.getComputeEnvironments(providerUrl)
+    const computeEnv = computeEnvs[0]
+    assert(computeEnv, 'Cannot find the paid compute env')
 
-  //   providerInitializeComputeResults = await ProviderInstance.initializeCompute(
-  //     assets,
-  //     algo,
-  //     computeEnv.id,
-  //     computeValidUntil,
-  //     providerUrl,
-  //     consumerAccount
-  //   )
-  //   assert(
-  //     !('error' in providerInitializeComputeResults.algorithm),
-  //     'Cannot order algorithm'
-  //   )
-  //   algo.transferTxId = await handleComputeOrder(
-  //     providerInitializeComputeResults.algorithm,
-  //     resolvedAlgoDdoWith5mTimeout.services[0].datatokenAddress,
-  //     consumerAccount,
-  //     computeEnv.consumerAddress,
-  //     0,
-  //     datatoken,
-  //     config
-  //   )
-  //   for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
-  //     assets[i].transferTxId = await handleComputeOrder(
-  //       providerInitializeComputeResults.datasets[i],
-  //       dtAddressArray[i],
-  //       consumerAccount,
-  //       computeEnv.consumerAddress,
-  //       0,
-  //       datatoken,
-  //       config
-  //     )
-  //   }
+    const resources: ComputeResourceRequest[] = [
+      {
+        id: 'cpu',
+        amount: computeEnv.resources[0].max + 1
+      },
+      {
+        id: 'ram',
+        amount: computeEnv.resources[1].max + 100
+      },
+      {
+        id: 'disk',
+        amount: computeEnv.resources[2].max + 100
+      }
+    ]
 
-  //   const computeJobs = await ProviderInstance.computeStart(
-  //     providerUrl,
-  //     consumerAccount,
-  //     computeEnv.id,
-  //     assets,
-  //     algo
-  //   )
-  //   paidEnvDatasetTxId = assets[0].transferTxId
-  //   paidEnvAlgoTxId = algo.transferTxId
-  //   assert(computeJobs, 'Cannot start compute job')
-  //   paidComputeJobId = computeJobs[0].jobId
-  // })
+    const assets: ComputeAsset[] = [
+      {
+        documentId: resolvedDdoWith2mTimeout.id,
+        serviceId: resolvedDdoWith2mTimeout.services[0].id
+      }
+    ]
+    const algo: ComputeAlgorithm = {
+      documentId: resolvedAlgoDdoWith2mTimeout.id,
+      serviceId: resolvedAlgoDdoWith2mTimeout.services[0].id
+    }
+    try {
+      await ProviderInstance.initializeCompute(
+        assets,
+        algo,
+        computeEnv.id,
+        paymentToken,
+        computeValidUntil,
+        providerUrl,
+        consumerAccount,
+        resources
+      )
+    } catch (e) {
+      assert(
+        e.message ===
+          `ComputeJob cannot be initialized: Error: Not enough cpu resources. Requested 5, but max is 4.`
+      )
+    }
+  })
 
-  // delay(100000)
+  it('should start a computeJob with paid resources', async () => {
+    // we choose the paid env
+    computeEnvs = await ProviderInstance.getComputeEnvironments(providerUrl)
+    const computeEnv = computeEnvs[0] // it is only one environment with paid and free resources
+    assert(computeEnv, 'Cannot find the paid compute env')
+    const resources: ComputeResourceRequest[] = [
+      {
+        id: 'cpu',
+        amount: 2
+      },
+      {
+        id: 'ram',
+        amount: 1000000000
+      },
+      {
+        id: 'disk',
+        amount: 0
+      }
+    ]
+    const assets: ComputeAsset[] = [
+      {
+        documentId: resolvedDdoWith2mTimeout.id,
+        serviceId: resolvedDdoWith2mTimeout.services[0].id
+      }
+    ]
+    const dtAddressArray = [resolvedDdoWith2mTimeout.services[0].datatokenAddress]
+    const algo: ComputeAlgorithm = {
+      documentId: resolvedAlgoDdoWith2mTimeout.id,
+      serviceId: resolvedAlgoDdoWith2mTimeout.services[0].id
+    }
+    providerInitializeComputeResults = await ProviderInstance.initializeCompute(
+      assets,
+      algo,
+      computeEnv.id,
+      paymentToken,
+      computeValidUntil,
+      providerUrl,
+      consumerAccount,
+      resources
+    )
+    assert(providerInitializeComputeResults.payment, ' Payment structure does not exists')
+    assert(
+      providerInitializeComputeResults.payment.escrowAddress === addresses.Escrow,
+      'Incorrect escrow address'
+    )
+    assert(
+      providerInitializeComputeResults.payment.payee === computeEnv.consumerAddress,
+      'Incorrect payee address'
+    )
+    assert(
+      providerInitializeComputeResults.payment.token === paymentToken,
+      'Incorrect payment token address'
+    )
+    const { price } = computeEnv.fees[await consumerAccount.getChainId()][0].prices[0]
+    assert(
+      Number(
+        ethers.utils.formatUnits(providerInitializeComputeResults.payment.amount, 18)
+      ) ===
+        (computeEnv.maxJobDuration / 60) * price,
+      'Incorrect payment token amount'
+    ) // 60 minutes per price 1 -> amount = 60
+    assert(
+      !('error' in providerInitializeComputeResults.algorithm),
+      'Cannot order algorithm'
+    )
+    // escrow adding funds for paid compute
+    escrow = new EscrowContract(
+      ethers.utils.getAddress(providerInitializeComputeResults.payment.escrowAddress),
+      consumerAccount
+    )
+    const paymentTokenPublisher = new Datatoken(publisherAccount)
+    const balancePublisherPaymentToken = await paymentTokenPublisher.balance(
+      paymentToken,
+      await publisherAccount.getAddress()
+    )
+    assert(
+      ethers.utils.parseEther(balancePublisherPaymentToken) > ethers.BigNumber.from(0),
+      'Balance should be higher than 0'
+    )
+    const tx = await publisherAccount.sendTransaction({
+      to: computeEnv.consumerAddress,
+      value: ethers.utils.parseEther('1.5')
+    })
+    await tx.wait()
 
-  // it('Check compute status', async () => {
-  //   const jobStatus = (await ProviderInstance.computeStatus(
-  //     providerUrl,
-  //     await consumerAccount.getAddress(),
-  //     paidComputeJobId,
-  //     resolvedDdoWith5mTimeout.id
-  //   )) as ComputeJob
-  //   assert(jobStatus, 'Cannot retrieve compute status!')
-  // })
+    await paymentTokenPublisher.transfer(
+      paymentToken,
+      ethers.utils.getAddress(computeEnv.consumerAddress),
+      (Number(balancePublisherPaymentToken) / 2).toString()
+    )
+    const amountToDeposit = (
+      providerInitializeComputeResults.payment.amount * 2
+    ).toString()
+    await escrow.verifyFundsForEscrowPayment(
+      paymentToken,
+      computeEnv.consumerAddress,
+      await unitsToAmount(consumerAccount, paymentToken, amountToDeposit),
+      providerInitializeComputeResults.payment.amount.toString(),
+      providerInitializeComputeResults.payment.minLockSeconds.toString(),
+      '10'
+    )
+    const auth = await escrow.getAuthorizations(
+      paymentToken,
+      await consumerAccount.getAddress(),
+      computeEnv.consumerAddress
+    )
+    const funds = await escrow.getUserFunds(
+      await consumerAccount.getAddress(),
+      paymentToken
+    )
+    assert(BigNumber.from(funds[0]) > BigNumber.from(0), 'Should have funds in escrow')
+    assert(auth.length > 0, 'Should have authorization')
+    assert(
+      BigInt(auth[0].maxLockedAmount.toString()) > BigInt(0),
+      ' Should have maxLockedAmount in auth'
+    )
+    assert(
+      BigInt(auth[0].maxLockCounts.toString()) > BigInt(0),
+      ' Should have maxLockCounts in auth'
+    )
+    algo.transferTxId = await handleComputeOrder(
+      providerInitializeComputeResults.algorithm,
+      resolvedAlgoDdoWith2mTimeout.services[0].datatokenAddress,
+      consumerAccount,
+      computeEnv.consumerAddress,
+      0,
+      datatoken,
+      config
+    )
+    algo.meta = resolvedAlgoDdoWith2mTimeout.metadata.algorithm
+    for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
+      assets[i].transferTxId = await handleComputeOrder(
+        providerInitializeComputeResults.datasets[i],
+        dtAddressArray[i],
+        consumerAccount,
+        computeEnv.consumerAddress,
+        0,
+        datatoken,
+        config
+      )
+    }
+    const computeJobs = await ProviderInstance.computeStart(
+      providerUrl,
+      consumerAccount,
+      computeEnv.id,
+      assets,
+      algo,
+      computeJobDuration,
+      paymentToken,
+      computeEnv.resources,
+      8996
+    )
+    paidEnvDatasetTxId = assets[0].transferTxId
+    paidEnvAlgoTxId = algo.transferTxId
+    assert(computeJobs, 'Cannot start compute job')
+    paidComputeJobId = computeJobs[0].jobId
+  })
 
-  // it('should restart a computeJob on paid environment, without paying anything, because order is valid and providerFees are still valid', async () => {
-  //   // we choose the paid env
-  //   const computeEnv = computeEnvs[resolvedDdoWith5mTimeout.chainId].find(
-  //     (ce) => ce.priceMin !== 0 || !isDefined(ce.free)
-  //   )
-  //   assert(computeEnv, 'Cannot find the paid compute env')
+  delay(100000)
 
-  //   const assets: ComputeAsset[] = [
-  //     {
-  //       documentId: resolvedDdoWith5mTimeout.id,
-  //       serviceId: resolvedDdoWith5mTimeout.services[0].id,
-  //       transferTxId: paidEnvDatasetTxId
-  //     }
-  //   ]
-  //   const algo: ComputeAlgorithm = {
-  //     documentId: resolvedAlgoDdoWith5mTimeout.id,
-  //     serviceId: resolvedAlgoDdoWith5mTimeout.services[0].id,
-  //     transferTxId: paidEnvAlgoTxId
-  //   }
+  it('Check compute status', async () => {
+    const jobStatus = (await ProviderInstance.computeStatus(
+      providerUrl,
+      await consumerAccount.getAddress(),
+      paidComputeJobId,
+      resolvedDdoWith2mTimeout.id
+    )) as ComputeJob
+    assert(jobStatus, 'Cannot retrieve compute status!')
+  })
 
-  //   providerInitializeComputeResults = await ProviderInstance.initializeCompute(
-  //     assets,
-  //     algo,
-  //     computeEnv.id,
-  //     computeValidUntil,
-  //     providerUrl,
-  //     consumerAccount
-  //   )
-  //   assert(
-  //     providerInitializeComputeResults.algorithm.validOrder,
-  //     'We should have a valid order for algorithm'
-  //   )
-  //   assert(
-  //     !providerInitializeComputeResults.algorithm.providerFee,
-  //     'We should not pay providerFees again for algorithm'
-  //   )
-  //   assert(
-  //     providerInitializeComputeResults.datasets[0].validOrder,
-  //     'We should have a valid order for dataset'
-  //   )
-  //   assert(
-  //     !providerInitializeComputeResults.datasets[0].providerFee,
-  //     'We should not pay providerFees again for dataset'
-  //   )
-  //   algo.transferTxId = providerInitializeComputeResults.algorithm.validOrder
-  //   assets[0].transferTxId = providerInitializeComputeResults.datasets[0].validOrder
-  //   assert(
-  //     algo.transferTxId === paidEnvAlgoTxId &&
-  //       assets[0].transferTxId === paidEnvDatasetTxId,
-  //     'We should use the same orders, because no fess must be paid'
-  //   )
-  //   const computeJobs = await ProviderInstance.computeStart(
-  //     providerUrl,
-  //     consumerAccount,
-  //     computeEnv.id,
-  //     assets,
-  //     algo
-  //   )
-  //   assert(computeJobs, 'Cannot start compute job')
-  // })
+  it('should restart a computeJob on paid resources, by paying only escrow lock for max job duration, because orders for assets are valid and providerFees are still valid', async () => {
+    // we choose the paid env
+    computeEnvs = await ProviderInstance.getComputeEnvironments(providerUrl)
+    const computeEnv = computeEnvs[0]
+    assert(computeEnv, 'Cannot find the paid compute env')
 
-  // // move to reuse Orders
+    const resources: ComputeResourceRequest[] = [
+      {
+        id: 'cpu',
+        amount: 2
+      },
+      {
+        id: 'ram',
+        amount: 1000000000
+      },
+      {
+        id: 'disk',
+        amount: 0
+      }
+    ]
 
-  // it('Should fast forward time and set a new computeValidUntil', async () => {
-  //   const mytime = new Date()
-  //   const computeMinutes = 5
-  //   mytime.setMinutes(mytime.getMinutes() + computeMinutes)
-  //   computeValidUntil = Math.floor(mytime.getTime() / 1000)
-  // })
+    const assets: ComputeAsset[] = [
+      {
+        documentId: resolvedDdoWith2mTimeout.id,
+        serviceId: resolvedDdoWith2mTimeout.services[0].id,
+        transferTxId: paidEnvDatasetTxId
+      }
+    ]
+    const algo: ComputeAlgorithm = {
+      documentId: resolvedAlgoDdoWith2mTimeout.id,
+      serviceId: resolvedAlgoDdoWith2mTimeout.services[0].id,
+      transferTxId: paidEnvAlgoTxId
+    }
 
-  // it('should start a computeJob using the free environment, by paying only providerFee (reuseOrder)', async () => {
-  //   if (freeComputeRouteSupport) {
-  //     // we choose the free env
-  //     const computeEnv = computeEnvs[resolvedDdoWith5mTimeout.chainId].find(
-  //       (ce) => ce.priceMin === 0 || isDefined(ce.free)
-  //     )
-  //     assert(computeEnv, 'Cannot find the free compute env')
+    providerInitializeComputeResults = await ProviderInstance.initializeCompute(
+      assets,
+      algo,
+      computeEnv.id,
+      paymentToken,
+      computeJobDuration,
+      providerUrl,
+      consumerAccount,
+      resources
+    )
+    assert(
+      providerInitializeComputeResults.algorithm.validOrder,
+      'We should have a valid order for algorithm'
+    )
+    assert(
+      !providerInitializeComputeResults.algorithm.providerFee,
+      'We should not pay providerFees again for algorithm'
+    )
+    assert(
+      providerInitializeComputeResults.datasets[0].validOrder,
+      'We should have a valid order for dataset'
+    )
+    assert(
+      !providerInitializeComputeResults.datasets[0].providerFee,
+      'We should not pay providerFees again for dataset'
+    )
+    algo.transferTxId = providerInitializeComputeResults.algorithm.validOrder
+    assets[0].transferTxId = providerInitializeComputeResults.datasets[0].validOrder
+    assert(
+      algo.transferTxId === paidEnvAlgoTxId &&
+        assets[0].transferTxId === paidEnvDatasetTxId,
+      'We should use the same orders, because no fess must be paid'
+    )
 
-  //     const assets: ComputeAsset[] = [
-  //       {
-  //         documentId: resolvedDdoWith5mTimeout.id,
-  //         serviceId: resolvedDdoWith5mTimeout.services[0].id,
-  //         transferTxId: freeEnvDatasetTxId
-  //       }
-  //     ]
-  //     const dtAddressArray = [resolvedDdoWith5mTimeout.services[0].datatokenAddress]
-  //     const algo: ComputeAlgorithm = {
-  //       documentId: resolvedAlgoDdoWith5mTimeout.id,
-  //       serviceId: resolvedAlgoDdoWith5mTimeout.services[0].id,
-  //       transferTxId: freeEnvAlgoTxId
-  //     }
+    const computeJobs = await ProviderInstance.computeStart(
+      providerUrl,
+      consumerAccount,
+      computeEnv.id,
+      assets,
+      algo,
+      computeJobDuration,
+      paymentToken,
+      resources
+    )
+    assert(computeJobs, 'Cannot start compute job')
+  })
 
-  //     providerInitializeComputeResults = await ProviderInstance.initializeCompute(
-  //       assets,
-  //       algo,
-  //       computeEnv.id,
-  //       computeValidUntil,
-  //       providerUrl,
-  //       consumerAccount
-  //     )
-  //     assert(
-  //       providerInitializeComputeResults.algorithm.validOrder,
-  //       'We should have a valid order for algorithm'
-  //     )
-  //     assert(
-  //       providerInitializeComputeResults.datasets[0].validOrder,
-  //       'We should have a valid order for dataset'
-  //     )
+  // move to reuse Orders
 
-  //     assert(
-  //       providerInitializeComputeResults.algorithm.providerFee ||
-  //         providerInitializeComputeResults.datasets[0].providerFee,
-  //       'We should pay providerFees again for algorithm or dataset. Cannot have empty for both'
-  //     )
+  delay(180000)
 
-  //     assert(
-  //       !('error' in providerInitializeComputeResults.algorithm),
-  //       'Cannot order algorithm'
-  //     )
-  //     algo.transferTxId = await handleComputeOrder(
-  //       providerInitializeComputeResults.algorithm,
-  //       resolvedAlgoDdoWith5mTimeout.services[0].datatokenAddress,
-  //       consumerAccount,
-  //       computeEnv.consumerAddress,
-  //       0,
-  //       datatoken,
-  //       config
-  //     )
-  //     for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
-  //       assets[i].transferTxId = await handleComputeOrder(
-  //         providerInitializeComputeResults.datasets[i],
-  //         dtAddressArray[i],
-  //         consumerAccount,
-  //         computeEnv.consumerAddress,
-  //         0,
-  //         datatoken,
-  //         config
-  //       )
-  //     }
-  //     assert(
-  //       algo.transferTxId !== freeEnvAlgoTxId ||
-  //         assets[0].transferTxId !== freeEnvDatasetTxId,
-  //       'We should not use the same orders, because providerFee must be paid'
-  //     )
-  //     const computeJobs = await ProviderInstance.computeStart(
-  //       providerUrl,
-  //       consumerAccount,
-  //       computeEnv.id,
-  //       assets,
-  //       algo
-  //     )
-  //     // freeEnvDatasetTxId = assets[0].transferTxId
-  //     // freeEnvAlgoTxId = algo.transferTxId
-  //     assert(computeJobs, 'Cannot start compute job')
-  //   } else {
-  //     assert(
-  //       freeComputeRouteSupport === null,
-  //       'Cannot start free compute job. provider at ' +
-  //         providerUrl +
-  //         ' does not implement freeCompute route'
-  //     )
-  //   }
-  // })
+  it('should start a computeJob using the paid resources, by paying the assets providerFees (reuseOrder) and paying escrow lock for max job duration', async () => {
+    // we choose the paid env
+    computeEnvs = await ProviderInstance.getComputeEnvironments(providerUrl)
+    const computeEnv = computeEnvs[0]
+    assert(computeEnv, 'Cannot find the paid compute env')
 
-  // it('should start a computeJob using the paid environment, by paying only providerFee (reuseOrder)', async () => {
-  //   // we choose the paid env
-  //   const computeEnv = computeEnvs[resolvedDdoWith5mTimeout.chainId].find(
-  //     (ce) => ce.priceMin !== 0 || !isDefined(ce.free)
-  //   )
-  //   assert(computeEnv, 'Cannot find the paid compute env')
+    const resources: ComputeResourceRequest[] = [
+      {
+        id: 'cpu',
+        amount: 2
+      },
+      {
+        id: 'ram',
+        amount: 1000000000
+      },
+      {
+        id: 'disk',
+        amount: 0
+      }
+    ]
 
-  //   const assets: ComputeAsset[] = [
-  //     {
-  //       documentId: resolvedDdoWith5mTimeout.id,
-  //       serviceId: resolvedDdoWith5mTimeout.services[0].id,
-  //       transferTxId: paidEnvDatasetTxId
-  //     }
-  //   ]
-  //   const dtAddressArray = [resolvedDdoWith5mTimeout.services[0].datatokenAddress]
-  //   const algo: ComputeAlgorithm = {
-  //     documentId: resolvedAlgoDdoWith5mTimeout.id,
-  //     serviceId: resolvedAlgoDdoWith5mTimeout.services[0].id,
-  //     transferTxId: paidEnvAlgoTxId
-  //   }
+    const assets: ComputeAsset[] = [
+      {
+        documentId: resolvedDdoWith2mTimeout.id,
+        serviceId: resolvedDdoWith2mTimeout.services[0].id,
+        transferTxId: paidEnvDatasetTxId
+      }
+    ]
+    const dtAddressArray = [resolvedDdoWith2mTimeout.services[0].datatokenAddress]
+    const algo: ComputeAlgorithm = {
+      documentId: resolvedAlgoDdoWith2mTimeout.id,
+      serviceId: resolvedAlgoDdoWith2mTimeout.services[0].id,
+      transferTxId: paidEnvAlgoTxId
+    }
+    providerInitializeComputeResults = await ProviderInstance.initializeCompute(
+      assets,
+      algo,
+      computeEnv.id,
+      paymentToken,
+      computeValidUntil,
+      providerUrl,
+      consumerAccount,
+      resources
+    )
+    assert(
+      providerInitializeComputeResults.datasets[0].providerFee,
+      'We should have a providerFee for algorithm'
+    )
+    assert(
+      providerInitializeComputeResults.algorithm.providerFee,
+      'We should have a providerFee for algorithm'
+    )
+    assert(
+      providerInitializeComputeResults.algorithm.validOrder === false, // expired provider fees which is expected
+      'We should not have a valid order for algorithm'
+    )
+    assert(
+      providerInitializeComputeResults.datasets[0].validOrder === false, // expired provider fees which is expected
+      'We should not have a valid order for dataset'
+    )
+    assert(providerInitializeComputeResults.payment, ' Payment structure does not exists')
+    assert(
+      providerInitializeComputeResults.payment.escrowAddress === addresses.Escrow,
+      'Incorrect escrow address'
+    )
+    assert(
+      providerInitializeComputeResults.payment.payee === computeEnv.consumerAddress,
+      'Incorrect payee address'
+    )
+    assert(
+      providerInitializeComputeResults.payment.token === paymentToken,
+      'Incorrect payment token address'
+    )
 
-  //   providerInitializeComputeResults = await ProviderInstance.initializeCompute(
-  //     assets,
-  //     algo,
-  //     computeEnv.id,
-  //     computeValidUntil,
-  //     providerUrl,
-  //     consumerAccount
-  //   )
-  //   assert(
-  //     providerInitializeComputeResults.algorithm.validOrder,
-  //     'We should have a valid order for algorithm'
-  //   )
-  //   assert(
-  //     providerInitializeComputeResults.datasets[0].validOrder,
-  //     'We should have a valid order for dataset'
-  //   )
-  //   assert(
-  //     providerInitializeComputeResults.algorithm.providerFee ||
-  //       providerInitializeComputeResults.datasets[0].providerFee,
-  //     'We should pay providerFees again for algorithm or dataset. Cannot have empty for both'
-  //   )
+    algo.transferTxId = await handleComputeOrder(
+      providerInitializeComputeResults.algorithm,
+      resolvedAlgoDdoWith2mTimeout.services[0].datatokenAddress,
+      consumerAccount,
+      computeEnv.consumerAddress,
+      0,
+      datatoken,
+      config
+    )
+    for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
+      assets[i].transferTxId = await handleComputeOrder(
+        providerInitializeComputeResults.datasets[i],
+        dtAddressArray[i],
+        consumerAccount,
+        computeEnv.consumerAddress,
+        0,
+        datatoken,
+        config
+      )
+    }
+    assert(
+      algo.transferTxId !== paidEnvAlgoTxId ||
+        assets[0].transferTxId !== paidEnvDatasetTxId,
+      'We should not use the same orders'
+    )
+    const computeJobs = await ProviderInstance.computeStart(
+      providerUrl,
+      consumerAccount,
+      computeEnv.id,
+      assets,
+      algo,
+      computeJobDuration,
+      paymentToken,
+      resources
+    )
+    assert(computeJobs, 'Cannot start compute job')
+  })
 
-  //   assert(
-  //     !('error' in providerInitializeComputeResults.algorithm),
-  //     'Cannot order algorithm'
-  //   )
-  //   algo.transferTxId = await handleComputeOrder(
-  //     providerInitializeComputeResults.algorithm,
-  //     resolvedAlgoDdoWith5mTimeout.services[0].datatokenAddress,
-  //     consumerAccount,
-  //     computeEnv.consumerAddress,
-  //     0,
-  //     datatoken,
-  //     config
-  //   )
-  //   for (let i = 0; i < providerInitializeComputeResults.datasets.length; i++) {
-  //     assets[i].transferTxId = await handleComputeOrder(
-  //       providerInitializeComputeResults.datasets[i],
-  //       dtAddressArray[i],
-  //       consumerAccount,
-  //       computeEnv.consumerAddress,
-  //       0,
-  //       datatoken,
-  //       config
-  //     )
-  //   }
-  //   assert(
-  //     algo.transferTxId !== paidEnvAlgoTxId ||
-  //       assets[0].transferTxId !== paidEnvDatasetTxId,
-  //     'We should not use the same orders, because providerFee must be paid'
-  //   )
-  //   const computeJobs = await ProviderInstance.computeStart(
-  //     providerUrl,
-  //     consumerAccount,
-  //     computeEnv.id,
-  //     assets,
-  //     algo
-  //   )
-  //   // freeEnvDatasetTxId = assets[0].transferTxId
-  //   // freeEnvAlgoTxId = algo.transferTxId
-  //   assert(computeJobs, 'Cannot start compute job')
-  // })
+  it('Check compute status', async () => {
+    const jobStatus = (await ProviderInstance.computeStatus(
+      providerUrl,
+      await consumerAccount.getAddress(),
+      freeComputeJobId,
+      resolvedDdoWith2mTimeout.id
+    )) as ComputeJob
+    assert(jobStatus, 'Cannot retrieve compute status!')
+  })
 
-  // it('Check compute status', async () => {
-  //   const jobStatus = (await ProviderInstance.computeStatus(
-  //     providerUrl,
-  //     await consumerAccount.getAddress(),
-  //     freeComputeJobId,
-  //     resolvedDdoWith5mTimeout.id
-  //   )) as ComputeJob
-  //   assert(jobStatus, 'Cannot retrieve compute status!')
-  // })
-
-  // it('Get download compute results url', async () => {
-  //   const downloadURL = await ProviderInstance.getComputeResultUrl(
-  //     providerUrl,
-  //     consumerAccount,
-  //     freeComputeJobId,
-  //     0
-  //   )
-  //   assert(downloadURL, 'Provider getComputeResultUrl failed!')
-  // })
+  it('Get download compute results url', async () => {
+    const downloadURL = await ProviderInstance.getComputeResultUrl(
+      providerUrl,
+      consumerAccount,
+      freeComputeJobId,
+      0
+    )
+    assert(downloadURL, 'Provider getComputeResultUrl failed!')
+  })
 })

--- a/test/integration/PublishEditConsume.test.ts
+++ b/test/integration/PublishEditConsume.test.ts
@@ -128,11 +128,11 @@ const assetDdo: DDO = {
   },
   services: [
     {
-      id: 'testFakeId',
+      id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
       type: 'access',
       files: '',
       datatokenAddress: '0x0',
-      serviceEndpoint: 'http://172.15.0.4:8030',
+      serviceEndpoint: 'http://127.0.0.1:8001',
       timeout: 0
     }
   ]
@@ -311,7 +311,7 @@ describe('Publish consume test', async () => {
   //   assert(grapqlAssetId, 'Failed to publish graphql DDO')
   // }).timeout(40000)
 
-  delay(10000) // let's wait for aquarius to index the  assets
+  delay(20000) // let's wait for aquarius to index the  assets
 
   it('Resolve published assets', async () => {
     resolvedUrlAssetDdo = await aquarius.waitForIndexer(urlAssetId)
@@ -328,7 +328,7 @@ describe('Publish consume test', async () => {
 
     // resolvedGraphqlAssetDdo = await aquarius.waitForIndexer(grapqlAssetId)
     // assert(resolvedGraphqlAssetDdo, 'Cannot fetch graphql DDO from Aquarius')
-  }).timeout(40000)
+  }).timeout(80000)
 
   it('Mint datasets datatokens to publisher', async () => {
     datatoken = new Datatoken(publisherAccount, config.chainId)

--- a/test/integration/PublishFlows.test.ts
+++ b/test/integration/PublishFlows.test.ts
@@ -73,12 +73,12 @@ describe('Publish tests', async () => {
     },
     services: [
       {
-        id: 'testFakeId',
+        id: 'db164c1b981e4d2974e90e61bda121512e6909c1035c908d68933ae4cfaba6b0',
         type: 'access',
         description: 'Download service',
         files: '',
         datatokenAddress: '0x0',
-        serviceEndpoint: 'http://172.15.0.4:8030',
+        serviceEndpoint: 'http://127.0.0.1:8001',
         timeout: 0
       }
     ]
@@ -194,7 +194,7 @@ describe('Publish tests', async () => {
       await publisherAccount.getAddress(),
       0,
       providerUrl,
-      '0x123',
+      '',
       '0x02',
       encryptedResponse,
       isAssetValid.hash,
@@ -222,6 +222,8 @@ describe('Publish tests', async () => {
 
     assert(asset !== null, 'Could not publish asset!')
   })
+
+  delay(20000) // let's wait for aquarius to index the  assets
 
   it('should resolve the fixed price dataset', async () => {
     const resolvedDDO = await aquarius.waitForIndexer(fixedPricedDID)
@@ -319,5 +321,5 @@ describe('Publish tests', async () => {
   it('should resolve the free dataset', async () => {
     const resolvedDDO = await aquarius.waitForIndexer(dispenserDID)
     assert(resolvedDDO, 'Cannot fetch DDO from Aquarius')
-  })
+  }).timeout(40000)
 })


### PR DESCRIPTION
Fixes #1909 .

Changes proposed in this PR:

- breaking changes - initializeCompute
- breaking changes - startCompute
- update tests with the new paid flow
- fixed workflow to not wait for old stack c2d to be deployed - this is the reason for taking 30 mins to finalize "Wait for contracts deployment"
- added in workflow automatically retrieve the OCEAN token address from address.json when providing DOCKER_COMPUTE_ENVIRONMENTS containing the feeToken
- enforce pasing the resources to initializeCompute and startCompute
- created test for exceeding maximum resources limits of specified environment
- added checks for funds in escrow contracts

![image](https://github.com/user-attachments/assets/42505ceb-b280-404e-a08e-2cd570a8b908)
![image](https://github.com/user-attachments/assets/8df2a6d3-014a-43e1-a553-f3d3d96f445f)
