### PR TITLE
moving the getChainId call

### DIFF
--- a/src/services/Provider.ts
+++ b/src/services/Provider.ts
@@ -131,11 +131,12 @@ export class Provider {
       [ethers.utils.hexlify(ethers.utils.toUtf8Bytes(message))]
     )
     const messageHashBytes = ethers.utils.arrayify(consumerMessage)
-    const chainId = await signer.getChainId()
     try {
       return await signer.signMessage(messageHashBytes)
     } catch (error) {
       LoggerInstance.error('Sign provider message error: ', error)
+      // Check if the user is using barge chain
+      const chainId = await signer.getChainId()
       if (chainId === 8996) {
         return await (signer as providers.JsonRpcSigner)._legacySignMessage(
           messageHashBytes


### PR DESCRIPTION
Fixes #1927 

Changes proposed in this PR:

- Moving the getChainId call
- This is needed so that we don't have to set up the signer with an RPC, e.g. `const signer = new ethers.Wallet(privateKey)`. Free compute doesn't need an RPC.