### PR TITLE
Update ddo-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@oasisprotocol/sapphire-paratime": "^1.3.2",
         "@oceanprotocol/contracts": "^2.4.0",
-        "@oceanprotocol/ddo-js": "^0.1.2",
+        "@oceanprotocol/ddo-js": "^0.1.3",
         "@rdfjs/dataset": "^2.0.2",
         "@rdfjs/formats-common": "^3.1.0",
         "@zazuko/env-node": "^2.1.4",
@@ -2690,26 +2690,6 @@
         "@ethersproject/bytes": "^5.8.0"
       }
     },
-    "node_modules/@ethersproject/basex": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
-      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0"
-      }
-    },
     "node_modules/@ethersproject/bignumber": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
@@ -2775,34 +2755,6 @@
         "@ethersproject/bignumber": "^5.8.0"
       }
     },
-    "node_modules/@ethersproject/contracts": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
-      "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abi": "^5.8.0",
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0"
-      }
-    },
     "node_modules/@ethersproject/hash": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
@@ -2829,73 +2781,6 @@
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
       }
-    },
-    "node_modules/@ethersproject/hdnode": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
-      "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/basex": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/pbkdf2": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0",
-        "@ethersproject/signing-key": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/wordlists": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/json-wallets": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
-      "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/hdnode": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/pbkdf2": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/random": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "license": "MIT"
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.8.0",
@@ -2952,26 +2837,6 @@
         "@ethersproject/logger": "^5.8.0"
       }
     },
-    "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
-      "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0"
-      }
-    },
     "node_modules/@ethersproject/properties": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
@@ -2988,85 +2853,6 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/providers": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
-      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/base64": "^5.8.0",
-        "@ethersproject/basex": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/networks": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/random": "^5.8.0",
-        "@ethersproject/rlp": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/web": "^5.8.0",
-        "bech32": "1.1.4",
-        "ws": "8.18.0"
-      }
-    },
-    "node_modules/@ethersproject/providers/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ethersproject/random": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
-      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
       }
     },
@@ -3088,27 +2874,6 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/sha2": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
-      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -3140,30 +2905,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "license": "MIT"
-    },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
-      "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
-      }
     },
     "node_modules/@ethersproject/strings": {
       "version": "5.8.0",
@@ -3213,60 +2954,6 @@
         "@ethersproject/signing-key": "^5.8.0"
       }
     },
-    "node_modules/@ethersproject/units": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
-      "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/wallet": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
-      "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
-        "@ethersproject/hdnode": "^5.8.0",
-        "@ethersproject/json-wallets": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/random": "^5.8.0",
-        "@ethersproject/signing-key": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/wordlists": "^5.8.0"
-      }
-    },
     "node_modules/@ethersproject/web": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
@@ -3285,29 +2972,6 @@
       "dependencies": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/wordlists": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
-      "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
@@ -4306,66 +3970,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@oceanprotocol/ddo-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/ddo-js/-/ddo-js-0.1.2.tgz",
-      "integrity": "sha512-cDhZ9yk0rpMDqnhkHL3V8eCp2DHQpSqAijlBKBORI6p1CDyb9Q0nDR1kgJObQzEsP1vCOleFkL5cN5vTYBZI3w==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/ddo-js/-/ddo-js-0.1.3.tgz",
+      "integrity": "sha512-CHZ0dZIM85xND6ckrVg5KIIXN5bYcNQV8udTISgCP3cTNOOlgnXdBPXELTKPg5h89qP8oEjofKC/kJjg+CJbng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@rdfjs/formats-common": "^3.1.0",
         "@types/rdfjs__formats-common": "^3.1.5",
         "@zazuko/env-node": "^2.1.4",
         "chai": "^5.1.2",
-        "ethers": "^5.7.2",
+        "ethers": "^6.15.0",
         "rdf-literal": "^2.0.0",
         "rdf-validate-shacl": "^0.5.6"
-      }
-    },
-    "node_modules/@oceanprotocol/ddo-js/node_modules/ethers": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
-      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abi": "5.8.0",
-        "@ethersproject/abstract-provider": "5.8.0",
-        "@ethersproject/abstract-signer": "5.8.0",
-        "@ethersproject/address": "5.8.0",
-        "@ethersproject/base64": "5.8.0",
-        "@ethersproject/basex": "5.8.0",
-        "@ethersproject/bignumber": "5.8.0",
-        "@ethersproject/bytes": "5.8.0",
-        "@ethersproject/constants": "5.8.0",
-        "@ethersproject/contracts": "5.8.0",
-        "@ethersproject/hash": "5.8.0",
-        "@ethersproject/hdnode": "5.8.0",
-        "@ethersproject/json-wallets": "5.8.0",
-        "@ethersproject/keccak256": "5.8.0",
-        "@ethersproject/logger": "5.8.0",
-        "@ethersproject/networks": "5.8.0",
-        "@ethersproject/pbkdf2": "5.8.0",
-        "@ethersproject/properties": "5.8.0",
-        "@ethersproject/providers": "5.8.0",
-        "@ethersproject/random": "5.8.0",
-        "@ethersproject/rlp": "5.8.0",
-        "@ethersproject/sha2": "5.8.0",
-        "@ethersproject/signing-key": "5.8.0",
-        "@ethersproject/solidity": "5.8.0",
-        "@ethersproject/strings": "5.8.0",
-        "@ethersproject/transactions": "5.8.0",
-        "@ethersproject/units": "5.8.0",
-        "@ethersproject/wallet": "5.8.0",
-        "@ethersproject/web": "5.8.0",
-        "@ethersproject/wordlists": "5.8.0"
       }
     },
     "node_modules/@oceanprotocol/ddo-js/node_modules/rdf-literal": {
@@ -7262,12 +6878,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "license": "Unlicense"
-    },
-    "node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
     },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
@@ -24870,15 +24480,6 @@
         "@ethersproject/bytes": "^5.8.0"
       }
     },
-    "@ethersproject/basex": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
-      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
-      "requires": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0"
-      }
-    },
     "@ethersproject/bignumber": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
@@ -24912,23 +24513,6 @@
         "@ethersproject/bignumber": "^5.8.0"
       }
     },
-    "@ethersproject/contracts": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
-      "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
-      "requires": {
-        "@ethersproject/abi": "^5.8.0",
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0"
-      }
-    },
     "@ethersproject/hash": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
@@ -24943,52 +24527,6 @@
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "@ethersproject/hdnode": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
-      "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/basex": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/pbkdf2": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0",
-        "@ethersproject/signing-key": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/wordlists": "^5.8.0"
-      }
-    },
-    "@ethersproject/json-wallets": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
-      "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/hdnode": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/pbkdf2": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/random": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      },
-      "dependencies": {
-        "aes-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
-        }
       }
     },
     "@ethersproject/keccak256": {
@@ -25013,64 +24551,11 @@
         "@ethersproject/logger": "^5.8.0"
       }
     },
-    "@ethersproject/pbkdf2": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
-      "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0"
-      }
-    },
     "@ethersproject/properties": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
       "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
       "requires": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
-      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/base64": "^5.8.0",
-        "@ethersproject/basex": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/networks": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/random": "^5.8.0",
-        "@ethersproject/rlp": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/web": "^5.8.0",
-        "bech32": "1.1.4",
-        "ws": "8.18.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.18.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-          "requires": {}
-        }
-      }
-    },
-    "@ethersproject/random": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
-      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
-      "requires": {
-        "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
       }
     },
@@ -25081,16 +24566,6 @@
       "requires": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "@ethersproject/sha2": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
-      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
-      "requires": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
@@ -25111,19 +24586,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
           "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         }
-      }
-    },
-    "@ethersproject/solidity": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
-      "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/sha2": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
       }
     },
     "@ethersproject/strings": {
@@ -25152,38 +24614,6 @@
         "@ethersproject/signing-key": "^5.8.0"
       }
     },
-    "@ethersproject/units": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
-      "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "@ethersproject/wallet": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
-      "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
-        "@ethersproject/hdnode": "^5.8.0",
-        "@ethersproject/json-wallets": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/random": "^5.8.0",
-        "@ethersproject/signing-key": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/wordlists": "^5.8.0"
-      }
-    },
     "@ethersproject/web": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
@@ -25191,18 +24621,6 @@
       "requires": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "@ethersproject/wordlists": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
-      "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
@@ -25838,56 +25256,19 @@
       "integrity": "sha512-OqDUBqQXPT68geLgGJDyH9Wsg1lE1V4ZS7aCJSfGdDWlMOBUAh/KxuaY46ga6WwWz8XVGTB+HZLGLQTYROo5tw=="
     },
     "@oceanprotocol/ddo-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/ddo-js/-/ddo-js-0.1.2.tgz",
-      "integrity": "sha512-cDhZ9yk0rpMDqnhkHL3V8eCp2DHQpSqAijlBKBORI6p1CDyb9Q0nDR1kgJObQzEsP1vCOleFkL5cN5vTYBZI3w==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/ddo-js/-/ddo-js-0.1.3.tgz",
+      "integrity": "sha512-CHZ0dZIM85xND6ckrVg5KIIXN5bYcNQV8udTISgCP3cTNOOlgnXdBPXELTKPg5h89qP8oEjofKC/kJjg+CJbng==",
       "requires": {
         "@rdfjs/formats-common": "^3.1.0",
         "@types/rdfjs__formats-common": "^3.1.5",
         "@zazuko/env-node": "^2.1.4",
         "chai": "^5.1.2",
-        "ethers": "^5.7.2",
+        "ethers": "^6.15.0",
         "rdf-literal": "^2.0.0",
         "rdf-validate-shacl": "^0.5.6"
       },
       "dependencies": {
-        "ethers": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
-          "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
-          "requires": {
-            "@ethersproject/abi": "5.8.0",
-            "@ethersproject/abstract-provider": "5.8.0",
-            "@ethersproject/abstract-signer": "5.8.0",
-            "@ethersproject/address": "5.8.0",
-            "@ethersproject/base64": "5.8.0",
-            "@ethersproject/basex": "5.8.0",
-            "@ethersproject/bignumber": "5.8.0",
-            "@ethersproject/bytes": "5.8.0",
-            "@ethersproject/constants": "5.8.0",
-            "@ethersproject/contracts": "5.8.0",
-            "@ethersproject/hash": "5.8.0",
-            "@ethersproject/hdnode": "5.8.0",
-            "@ethersproject/json-wallets": "5.8.0",
-            "@ethersproject/keccak256": "5.8.0",
-            "@ethersproject/logger": "5.8.0",
-            "@ethersproject/networks": "5.8.0",
-            "@ethersproject/pbkdf2": "5.8.0",
-            "@ethersproject/properties": "5.8.0",
-            "@ethersproject/providers": "5.8.0",
-            "@ethersproject/random": "5.8.0",
-            "@ethersproject/rlp": "5.8.0",
-            "@ethersproject/sha2": "5.8.0",
-            "@ethersproject/signing-key": "5.8.0",
-            "@ethersproject/solidity": "5.8.0",
-            "@ethersproject/strings": "5.8.0",
-            "@ethersproject/transactions": "5.8.0",
-            "@ethersproject/units": "5.8.0",
-            "@ethersproject/wallet": "5.8.0",
-            "@ethersproject/web": "5.8.0",
-            "@ethersproject/wordlists": "5.8.0"
-          }
-        },
         "rdf-literal": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-2.0.0.tgz",
@@ -28021,11 +27402,6 @@
           "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
         }
       }
-    },
-    "bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "before-after-hook": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@oasisprotocol/sapphire-paratime": "^1.3.2",
     "@oceanprotocol/contracts": "^2.4.0",
-    "@oceanprotocol/ddo-js": "^0.1.2",
+    "@oceanprotocol/ddo-js": "^0.1.3",
     "@rdfjs/dataset": "^2.0.2",
     "@rdfjs/formats-common": "^3.1.0",
     "@zazuko/env-node": "^2.1.4",


### PR DESCRIPTION
Changes proposed in this PR:

- Ddo.js still had peer dependencies with ethers v5. Updateing to latest version of ddo-js which uses ethers v6
