### PR TITLE
fix hexlify numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |
-            export NODE_VERSION=pr-1017 && bash -x start_ocean.sh --with-typesense 2>&1 > start-node.log &
+            bash -x start_ocean.sh --with-typesense 2>&1 > start-node.log &
       - name: Install deps & build
         run: npm ci && npm run build:metadata
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |
-            bash -x start_ocean.sh --with-typesense 2>&1 > start-node.log &
+            export NODE_VERSION=pr-1017 && bash -x start_ocean.sh --with-typesense 2>&1 > start-node.log &
       - name: Install deps & build
         run: npm ci && npm run build:metadata
       

--- a/src/config/ConfigHelper.ts
+++ b/src/config/ConfigHelper.ts
@@ -8,7 +8,7 @@ const configHelperNetworksBase: Config = {
   chainId: null,
   network: 'unknown',
   nodeUri: 'http://127.0.0.1:8545',
-  oceanNodeUri: 'https://1.c2d.nodes.oceanprotocol.com:8000/',
+  oceanNodeUri: 'http://127.0.0.1:8001',
   explorerUri: null,
   oceanTokenAddress: null,
   oceanTokenSymbol: 'OCEAN',
@@ -30,7 +30,7 @@ export const configHelperNetworks: Config[] = [
     ...configHelperNetworksBase,
     chainId: 8996,
     network: 'development',
-    oceanNodeUri: 'https://1.c2d.nodes.oceanprotocol.com:8000/',
+    oceanNodeUri: 'http://127.0.0.1:8001',
     sdk: 'evm'
   },
   {

--- a/src/utils/Assets.ts
+++ b/src/utils/Assets.ts
@@ -1,4 +1,4 @@
-import { ethers, hexlify, Signer, toUtf8Bytes } from 'ethers'
+import { ethers, hexlify, Signer, toBeHex, toUtf8Bytes } from 'ethers'
 import { ConfigHelper } from '../../src/config/index.js'
 import { createHash } from 'crypto'
 import { Aquarius } from '../services/Aquarius.js'
@@ -243,7 +243,7 @@ export async function createAsset(
     0,
     providerUrl,
     '',
-    hexlify(flags),
+    toBeHex(flags),
     metadata,
     metadataHash
   )


### PR DESCRIPTION
Changes proposed in this PR:

- Replace oceanNodeUri with the local node, do no rely on external node
- Hexlify is no longer used to convert numbers to hexstrings, should be replace by 'toBeHex' in ethers.js

```
// v5; converting numbers to hexstrings
hex = hexlify(35)

// v6; converting numbers to hexstrings
hex = toBeHex(35)
```
Reference: https://docs.ethers.org/v6/migrating/
