### PR TITLE
Ethers v6 - cast bigint to number

### DIFF
--- a/src/contracts/AccessList.ts
+++ b/src/contracts/AccessList.ts
@@ -53,7 +53,8 @@ export class AccessListContract extends SmartContractWithAddress {
    * @return {Promise<string>} Id
    */
   public async getId(): Promise<number> {
-    return await this.contract.getId()
+    const id = await this.contract.getId()
+    return Number(id)
   }
 
   /**

--- a/src/contracts/Datatoken.ts
+++ b/src/contracts/Datatoken.ts
@@ -732,7 +732,7 @@ export class Datatoken extends SmartContract {
   public async getId(dtAddress: string): Promise<number> {
     const dtContract = this.getContract(dtAddress)
     const id = await dtContract.getId()
-    return id
+    return Number(id)
   }
 
   /**

--- a/src/contracts/FixedRateExchange.ts
+++ b/src/contracts/FixedRateExchange.ts
@@ -138,7 +138,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
    */
   public async getNumberOfExchanges(): Promise<number> {
     const numExchanges = await this.contract.getNumberOfExchanges()
-    return numExchanges
+    return Number(numExchanges)
   }
 
   /**

--- a/src/contracts/Router.ts
+++ b/src/contracts/Router.ts
@@ -253,14 +253,16 @@ export class Router extends SmartContractWithAddress {
    * @return {Promise<number>} OPC fee for a specific baseToken
    */
   public async getOPCFee(baseToken: string): Promise<number> {
-    return await this.contract.getOPCFee(baseToken)
+    const fee = await this.contract.getOPCFee(baseToken)
+    return Number(fee)
   }
 
   /** Get Current OPF Fee
    * @return {Promise<number>} OPF fee
    */
   public async getCurrentOPCFee(): Promise<number> {
-    return await this.contract.swapOceanFee()
+    const fee = await this.contract.swapOceanFee()
+    return Number(fee)
   }
 
   /**

--- a/src/contracts/ve/VeAllocate.ts
+++ b/src/contracts/ve/VeAllocate.ts
@@ -81,7 +81,7 @@ export class VeAllocate extends SmartContractWithAddress {
    */
   public async getTotalAllocation(userAddress: string): Promise<number> {
     const allocation = await this.contract.getTotalAllocation(userAddress)
-    return allocation
+    return Number(allocation)
   }
 
   /** Get getveAllocation for address, nft, chainId
@@ -96,6 +96,6 @@ export class VeAllocate extends SmartContractWithAddress {
     chainId: string
   ): Promise<number> {
     const allocation = await this.contract.getveAllocation(userAddress, nft, chainId)
-    return allocation
+    return Number(allocation)
   }
 }

--- a/src/contracts/ve/VeOcean.ts
+++ b/src/contracts/ve/VeOcean.ts
@@ -142,7 +142,7 @@ export class VeOcean extends SmartContractWithAddress {
    */
   public async getVotingPower(userAddress: string): Promise<number> {
     const balance = await this.contract.balanceOf(userAddress)
-    return balance
+    return Number(balance)
   }
 
   /** Get locked balance

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -200,5 +200,6 @@ export async function allowanceWei(
  */
 export async function decimals(signer: Signer, tokenAddress: string): Promise<number> {
   const tokenContract = new ethers.Contract(tokenAddress, minAbi, signer)
-  return await tokenContract.decimals()
+  const decimals = await tokenContract.decimals()
+  return Number(decimals)
 }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- Ethers v6 returns an bigint, we cast it to 'Number' to keep the same flows