### PR TITLE
rework p2p connection

### DIFF
--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -1,3 +1,5 @@
+import { type Multiaddr } from '@multiformats/multiaddr'
+import type { PeerId } from '@libp2p/interface'
 import type { AccessList } from './AccessList.js'
 export interface ProviderFees {
   providerFeeAddress: string
@@ -43,6 +45,12 @@ export interface ServiceEndpoint {
   method: string
   urlPath: string
 }
+
+export interface NodeP2P {
+  nodeId: string
+  multiaddress?: Multiaddr[]
+}
+export type OceanNode = string | NodeP2P | PeerId
 
 export interface NodeStatusProvider {
   chainId: string

--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -165,10 +165,10 @@ export interface NodeLogEntry {
   meta?: Record<string, any>
 }
 
-export interface AgentSignature {
+export interface CompleteSignature {
   consumerAddress: string
   nonce: string
   signature: string
 }
 
-export type SignerOrAuthTokenOrSignature = string | Signer | AgentSignature
+export type SignerOrAuthTokenOrSignature = string | Signer | CompleteSignature

--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -1,4 +1,5 @@
 import { type Multiaddr } from '@multiformats/multiaddr'
+import { Signer } from 'ethers'
 import type { PeerId } from '@libp2p/interface'
 import type { AccessList } from './AccessList.js'
 export interface ProviderFees {
@@ -163,3 +164,11 @@ export interface NodeLogEntry {
   message: string
   meta?: Record<string, any>
 }
+
+export interface AgentSignature {
+  consumerAddress: string
+  nonce: string
+  signature: string
+}
+
+export type signerOrAuthTokenOrSignature = string | Signer | AgentSignature

--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -171,4 +171,4 @@ export interface AgentSignature {
   signature: string
 }
 
-export type signerOrAuthTokenOrSignature = string | Signer | AgentSignature
+export type SignerOrAuthTokenOrSignature = string | Signer | AgentSignature

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -142,6 +142,10 @@ export class BaseProvider {
     return isP2pUri(node) ? this.p2pProvider : this.httpProvider
   }
 
+  public getP2PProvider() {
+    return this.p2pProvider
+  }
+
   public async getNonce(
     nodeUri: OceanNode,
     consumerAddress: string,

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -91,14 +91,15 @@ export function isP2pUri(node: OceanNode): boolean {
     const nodeP2p = node as NodeP2P
     if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0)
       return true
-    try {
-      multiaddr(nodeP2p.nodeId)
-      return true
-    } catch {}
-    try {
-      peerIdFromString(nodeP2p.nodeId)
-      return true
-    } catch {
+    if (nodeP2p.nodeId) {
+      try {
+        multiaddr(nodeP2p.nodeId)
+        return true
+      } catch {}
+      try {
+        peerIdFromString(nodeP2p.nodeId)
+        return true
+      } catch {}
       return false
     }
   }

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -86,20 +86,22 @@ export function isAgentSignature(v: unknown): v is CompleteSignature {
   )
 }
 
+function isPeerIdOrMultiAddr(param: string) {
+  try {
+    multiaddr(param)
+    return true
+  } catch {}
+  try {
+    peerIdFromString(param)
+    return true
+  } catch {
+    return false
+  }
+}
 export function isP2pUri(node: OceanNode): boolean {
   if (!node) return false
   if (typeof node === 'string') {
-    // Accept either peerId or multiaddr string as P2P
-    try {
-      multiaddr(node)
-      return true
-    } catch {}
-    try {
-      peerIdFromString(node)
-      return true
-    } catch {
-      return false
-    }
+    return isPeerIdOrMultiAddr(node)
   }
 
   // NodeP2P -> p2p
@@ -108,15 +110,7 @@ export function isP2pUri(node: OceanNode): boolean {
     if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0)
       return true
     if (nodeP2p.nodeId) {
-      try {
-        multiaddr(nodeP2p.nodeId)
-        return true
-      } catch {}
-      try {
-        peerIdFromString(nodeP2p.nodeId)
-        return true
-      } catch {}
-      return false
+      return isPeerIdOrMultiAddr(nodeP2p.nodeId)
     }
   }
 

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -45,8 +45,9 @@ export { OCEAN_P2P_PROTOCOL, type P2PConfig } from './P2pProvider.js'
 export async function getConsumerAddress(
   signerOrAuthToken: SignerOrAuthTokenOrSignature
 ): Promise<string> {
-  if (typeof signerOrAuthToken === 'string') return decodeJwt(signerOrAuthToken).address
   if (isAgentSignature(signerOrAuthToken)) return signerOrAuthToken.consumerAddress
+  if (typeof signerOrAuthToken === 'string') return decodeJwt(signerOrAuthToken).address
+
   return signerOrAuthToken.getAddress()
 }
 
@@ -56,10 +57,7 @@ export async function getSignature(
   command: string
 ): Promise<string | null> {
   if (typeof signerOrAuthToken === 'string') {
-    // it's either a signature already (0x..) or a jwt token
-    if (signerOrAuthToken.startsWith('0x')) {
-      return signerOrAuthToken
-    } else return null
+    return null
   }
   if (isAgentSignature(signerOrAuthToken)) {
     return signerOrAuthToken.signature

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -29,7 +29,9 @@ import {
   PersistentStorageCreateBucketRequest,
   PersistentStorageDeleteFileResponse,
   PersistentStorageFileEntry,
-  PersistentStorageObject
+  PersistentStorageObject,
+  OceanNode,
+  NodeP2P
 } from '../../@types/index.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
 import { decodeJwt } from '../../utils/Jwt.js'
@@ -52,7 +54,12 @@ export async function getSignature(
   nonce: string,
   command: string
 ): Promise<string | null> {
-  if (typeof signerOrAuthToken === 'string') return null
+  if (typeof signerOrAuthToken === 'string') {
+    // it's either a signature already (0x..) or a jwt token
+    if (signerOrAuthToken.startsWith('0x')) {
+      return signerOrAuthToken
+    } else return null
+  }
   const message = String(
     String(await signerOrAuthToken.getAddress()) + String(nonce) + String(command)
   )
@@ -63,19 +70,50 @@ export function getAuthorization(signerOrAuthToken: Signer | string): string | u
   return typeof signerOrAuthToken === 'string' ? signerOrAuthToken : undefined
 }
 
-export function isP2pUri(nodeUri: string | Multiaddr[]): boolean {
-  if (Array.isArray(nodeUri)) return true
-  if (!nodeUri) return false
-  try {
-    multiaddr(nodeUri)
-    return true
-  } catch {}
-  try {
-    peerIdFromString(nodeUri)
-    return true
-  } catch {
-    return false
+export function isP2pUri(node: OceanNode): boolean {
+  if (!node) return false
+  if (typeof node === 'string') {
+    // Accept either peerId or multiaddr string as P2P
+    try {
+      multiaddr(node)
+      return true
+    } catch {}
+    try {
+      peerIdFromString(node)
+      return true
+    } catch {
+      return false
+    }
   }
+
+  // NodeP2P -> p2p
+  if ('nodeId' in node || `multiaddress` in node) {
+    const nodeP2p = node as NodeP2P
+    if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0)
+      return true
+    try {
+      multiaddr(nodeP2p.nodeId)
+      return true
+    } catch {}
+    try {
+      peerIdFromString(nodeP2p.nodeId)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  // PeerId (libp2p) -> p2p
+  if (typeof node === 'object' && typeof (node as any).toString === 'function') {
+    const s = String((node as any).toString())
+    try {
+      peerIdFromString(s)
+      return true
+    } catch {
+      return false
+    }
+  }
+  return false
 }
 
 export class BaseProvider {
@@ -83,13 +121,12 @@ export class BaseProvider {
   private p2pProvider = new P2pProvider()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected getImpl(nodeUri: string | Multiaddr[]): any {
-    if (Array.isArray(nodeUri)) return this.p2pProvider
-    return isP2pUri(nodeUri) ? this.p2pProvider : this.httpProvider
+  protected getImpl(node: OceanNode): any {
+    return isP2pUri(node) ? this.p2pProvider : this.httpProvider
   }
 
   public async getNonce(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     consumerAddress: string,
     signal?: AbortSignal,
     providerEndpoints?: any,
@@ -107,7 +144,7 @@ export class BaseProvider {
   public async encrypt(
     data: any,
     chainId: number,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     policyServer?: any,
     signal?: AbortSignal
@@ -125,7 +162,7 @@ export class BaseProvider {
   public async checkDidFiles(
     did: string,
     serviceId: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
@@ -140,7 +177,7 @@ export class BaseProvider {
 
   public async getFileInfo(
     file: StorageObject,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
@@ -148,7 +185,7 @@ export class BaseProvider {
   }
 
   public async getComputeEnvironments(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<ComputeEnvironment[]> {
     return this.getImpl(nodeUri).getComputeEnvironments(nodeUri, signal)
@@ -159,7 +196,7 @@ export class BaseProvider {
     serviceId: string,
     fileIndex: number,
     consumerAddress: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal,
     userCustomParameters?: UserCustomParameters,
     computeEnv?: string,
@@ -184,7 +221,7 @@ export class BaseProvider {
     computeEnv: string,
     token: string,
     validUntil: number,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     consumerAddress: string,
     resources: ComputeResourceRequest[],
     chainId: number,
@@ -217,7 +254,7 @@ export class BaseProvider {
     serviceId: string,
     fileIndex: number,
     transferTxId: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
@@ -235,7 +272,7 @@ export class BaseProvider {
   }
 
   public async computeStart(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     computeEnv: string,
     datasets: ComputeAsset[],
@@ -273,7 +310,7 @@ export class BaseProvider {
   }
 
   public async freeComputeStart(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     computeEnv: string,
     datasets: ComputeAsset[],
@@ -305,7 +342,7 @@ export class BaseProvider {
   }
 
   public async computeStreamableLogs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId: string,
     signal?: AbortSignal
@@ -320,7 +357,7 @@ export class BaseProvider {
 
   public async computeStop(
     jobId: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     agreementId?: string,
     signal?: AbortSignal
@@ -335,7 +372,7 @@ export class BaseProvider {
   }
 
   public async computeStatus(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId?: string,
     agreementId?: string,
@@ -351,7 +388,7 @@ export class BaseProvider {
   }
 
   public async getComputeResultUrl(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId: string,
     index: number
@@ -365,7 +402,7 @@ export class BaseProvider {
   }
 
   public async getComputeResult(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId: string,
     index: number,
@@ -382,7 +419,7 @@ export class BaseProvider {
 
   public async generateAuthToken(
     consumer: Signer,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<string> {
     return this.getImpl(nodeUri).generateAuthToken(consumer, nodeUri, signal)
@@ -392,7 +429,7 @@ export class BaseProvider {
     address: string,
     signature: string,
     nonce: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<string> {
     return this.p2pProvider.generateSignedAuthToken(
@@ -407,14 +444,14 @@ export class BaseProvider {
   public async invalidateAuthToken(
     consumer: Signer,
     token: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<{ success: boolean }> {
     return this.getImpl(nodeUri).invalidateAuthToken(consumer, token, nodeUri, signal)
   }
 
   public async resolveDdo(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     did: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -422,7 +459,7 @@ export class BaseProvider {
   }
 
   public async validateDdo(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     ddo: DDO,
     signer: Signer,
     signal?: AbortSignal
@@ -430,15 +467,12 @@ export class BaseProvider {
     return this.getImpl(nodeUri).validateDdo(nodeUri, ddo, signer, signal)
   }
 
-  public async isValidProvider(
-    url: string | Multiaddr[],
-    signal?: AbortSignal
-  ): Promise<boolean> {
+  public async isValidProvider(url: OceanNode, signal?: AbortSignal): Promise<boolean> {
     return this.getImpl(url).isValidProvider(url, signal)
   }
 
   public async PolicyServerPassthrough(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
@@ -446,7 +480,7 @@ export class BaseProvider {
   }
 
   public async initializePSVerification(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     request: PolicyServerInitializeCommand,
     signal?: AbortSignal
   ): Promise<any> {
@@ -454,7 +488,7 @@ export class BaseProvider {
   }
 
   public async downloadNodeLogs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signer: Signer,
     startTime: string,
     endTime: string,
@@ -478,14 +512,14 @@ export class BaseProvider {
   }
 
   public async getNodeStatus(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<NodeStatus> {
     return this.getImpl(nodeUri).getNodeStatus(nodeUri, signal)
   }
 
   public async getNodeJobs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     fromTimestamp?: number,
     signal?: AbortSignal
   ): Promise<NodeComputeJob[]> {
@@ -515,7 +549,7 @@ export class BaseProvider {
    * For auto-signed log fetching (HTTP or P2P), use downloadNodeLogs().
    */
   public async fetchNodeLogs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     address: string,
     signature: string,
     nonce: string,
@@ -525,7 +559,7 @@ export class BaseProvider {
   }
 
   public async createPersistentStorageBucket(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
@@ -543,7 +577,7 @@ export class BaseProvider {
   }
 
   public async getPersistentStorageBuckets(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     owner: string,
     signal?: AbortSignal
@@ -557,7 +591,7 @@ export class BaseProvider {
   }
 
   public async listPersistentStorageFiles(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     signal?: AbortSignal
@@ -571,7 +605,7 @@ export class BaseProvider {
   }
 
   public async getPersistentStorageFileObject(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     fileName: string,
@@ -587,7 +621,7 @@ export class BaseProvider {
   }
 
   public async uploadPersistentStorageFile(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     fileName: string,
@@ -605,7 +639,7 @@ export class BaseProvider {
   }
 
   public async deletePersistentStorageFile(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     fileName: string,
@@ -621,14 +655,14 @@ export class BaseProvider {
   }
 
   public async fetchConfig(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     payload: Record<string, any>
   ): Promise<any> {
     return this.p2pProvider.fetchConfig(nodeUri, payload)
   }
 
   public async pushConfig(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     payload: Record<string, any>
   ): Promise<any> {
     return this.p2pProvider.pushConfig(nodeUri, payload)

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -103,7 +103,7 @@ export function isP2pUri(node: OceanNode): boolean {
   }
 
   // NodeP2P -> p2p
-  if (typeof node === 'object' && ('nodeId' in node || `multiaddress` in node)) {
+  if (typeof node === 'object' && ('nodeId' in node || 'multiaddress' in node)) {
     const nodeP2p = node as NodeP2P
     if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0)
       return true

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -1,5 +1,5 @@
 import { peerIdFromString } from '@libp2p/peer-id'
-import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+import { multiaddr } from '@multiformats/multiaddr'
 import { Signer } from 'ethers'
 import {
   StorageObject,
@@ -22,7 +22,6 @@ import {
   DownloadResponse,
   NodeStatus,
   NodeComputeJob,
-  NodeLogsParams,
   NodeLogEntry,
   PersistentStorageAccessList,
   PersistentStorageBucket,
@@ -31,7 +30,9 @@ import {
   PersistentStorageFileEntry,
   PersistentStorageObject,
   OceanNode,
-  NodeP2P
+  NodeP2P,
+  AgentSignature,
+  signerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
 import { decodeJwt } from '../../utils/Jwt.js'
@@ -42,15 +43,15 @@ import { P2pProvider, type P2PConfig, type P2PRequestBodyStream } from './P2pPro
 export { OCEAN_P2P_PROTOCOL, type P2PConfig } from './P2pProvider.js'
 
 export async function getConsumerAddress(
-  signerOrAuthToken: Signer | string
+  signerOrAuthToken: signerOrAuthTokenOrSignature
 ): Promise<string> {
-  return typeof signerOrAuthToken === 'string'
-    ? decodeJwt(signerOrAuthToken).address
-    : signerOrAuthToken.getAddress()
+  if (typeof signerOrAuthToken === 'string') return decodeJwt(signerOrAuthToken).address
+  if (isAgentSignature(signerOrAuthToken)) return signerOrAuthToken.consumerAddress
+  return signerOrAuthToken.getAddress()
 }
 
 export async function getSignature(
-  signerOrAuthToken: Signer | string,
+  signerOrAuthToken: signerOrAuthTokenOrSignature,
   nonce: string,
   command: string
 ): Promise<string | null> {
@@ -60,14 +61,29 @@ export async function getSignature(
       return signerOrAuthToken
     } else return null
   }
+  if (isAgentSignature(signerOrAuthToken)) {
+    return signerOrAuthToken.signature
+  }
   const message = String(
     String(await signerOrAuthToken.getAddress()) + String(nonce) + String(command)
   )
   return signRequest(signerOrAuthToken, message)
 }
 
-export function getAuthorization(signerOrAuthToken: Signer | string): string | undefined {
+export function getAuthorization(
+  signerOrAuthToken: signerOrAuthTokenOrSignature
+): string | undefined {
   return typeof signerOrAuthToken === 'string' ? signerOrAuthToken : undefined
+}
+
+export function isAgentSignature(v: unknown): v is AgentSignature {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    typeof (v as any).consumerAddress === 'string' &&
+    typeof (v as any).nonce === 'string' &&
+    typeof (v as any).signature === 'string'
+  )
 }
 
 export function isP2pUri(node: OceanNode): boolean {
@@ -146,7 +162,7 @@ export class BaseProvider {
     data: any,
     chainId: number,
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
@@ -256,7 +272,7 @@ export class BaseProvider {
     fileIndex: number,
     transferTxId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<string | DownloadResponse> {
@@ -274,7 +290,7 @@ export class BaseProvider {
 
   public async computeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -312,7 +328,7 @@ export class BaseProvider {
 
   public async freeComputeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -344,7 +360,7 @@ export class BaseProvider {
 
   public async computeStreamableLogs(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -359,7 +375,7 @@ export class BaseProvider {
   public async computeStop(
     jobId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
@@ -374,7 +390,7 @@ export class BaseProvider {
 
   public async computeStatus(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
     signal?: AbortSignal
@@ -390,7 +406,7 @@ export class BaseProvider {
 
   public async getComputeResultUrl(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     index: number
   ): Promise<string> {
@@ -404,7 +420,7 @@ export class BaseProvider {
 
   public async getComputeResult(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     index: number,
     offset: number = 0
@@ -490,7 +506,7 @@ export class BaseProvider {
 
   public async downloadNodeLogs(
     nodeUri: OceanNode,
-    signer: Signer,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     startTime: string,
     endTime: string,
     maxLogs?: number,
@@ -501,7 +517,7 @@ export class BaseProvider {
   ): Promise<NodeLogEntry[]> {
     return this.getImpl(nodeUri).downloadNodeLogs(
       nodeUri,
-      signer,
+      signerOrAuthToken,
       startTime,
       endTime,
       maxLogs,
@@ -545,23 +561,9 @@ export class BaseProvider {
     return this.p2pProvider.getMultiaddrFromPeerId(peerId)
   }
 
-  /**
-   * Fetch node logs via P2P with a pre-signed payload.
-   * For auto-signed log fetching (HTTP or P2P), use downloadNodeLogs().
-   */
-  public async fetchNodeLogs(
-    nodeUri: OceanNode,
-    address: string,
-    signature: string,
-    nonce: string,
-    logParams?: NodeLogsParams
-  ): Promise<NodeLogEntry[]> {
-    return this.p2pProvider.fetchNodeLogs(nodeUri, address, signature, nonce, logParams)
-  }
-
   public async createPersistentStorageBucket(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
   ): Promise<{
@@ -579,7 +581,7 @@ export class BaseProvider {
 
   public async getPersistentStorageBuckets(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
@@ -593,7 +595,7 @@ export class BaseProvider {
 
   public async listPersistentStorageFiles(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
@@ -607,7 +609,7 @@ export class BaseProvider {
 
   public async getPersistentStorageFileObject(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal
@@ -623,7 +625,7 @@ export class BaseProvider {
 
   public async uploadPersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     content: P2PRequestBodyStream,
@@ -641,7 +643,7 @@ export class BaseProvider {
 
   public async deletePersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -478,10 +478,10 @@ export class BaseProvider {
   public async validateDdo(
     nodeUri: OceanNode,
     ddo: DDO,
-    signer: Signer,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
-    return this.getImpl(nodeUri).validateDdo(nodeUri, ddo, signer, signal)
+    return this.getImpl(nodeUri).validateDdo(nodeUri, ddo, signerOrAuthToken, signal)
   }
 
   public async isValidProvider(url: OceanNode, signal?: AbortSignal): Promise<boolean> {

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -31,7 +31,7 @@ import {
   PersistentStorageObject,
   OceanNode,
   NodeP2P,
-  AgentSignature,
+  CompleteSignature,
   SignerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
@@ -76,7 +76,7 @@ export function getAuthorization(
   return typeof signerOrAuthToken === 'string' ? signerOrAuthToken : undefined
 }
 
-export function isAgentSignature(v: unknown): v is AgentSignature {
+export function isAgentSignature(v: unknown): v is CompleteSignature {
   return (
     !!v &&
     typeof v === 'object' &&

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -87,7 +87,7 @@ export function isP2pUri(node: OceanNode): boolean {
   }
 
   // NodeP2P -> p2p
-  if ('nodeId' in node || `multiaddress` in node) {
+  if (typeof node === 'object' && ('nodeId' in node || `multiaddress` in node)) {
     const nodeP2p = node as NodeP2P
     if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0)
       return true

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -32,7 +32,7 @@ import {
   OceanNode,
   NodeP2P,
   AgentSignature,
-  signerOrAuthTokenOrSignature
+  SignerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
 import { decodeJwt } from '../../utils/Jwt.js'
@@ -43,7 +43,7 @@ import { P2pProvider, type P2PConfig, type P2PRequestBodyStream } from './P2pPro
 export { OCEAN_P2P_PROTOCOL, type P2PConfig } from './P2pProvider.js'
 
 export async function getConsumerAddress(
-  signerOrAuthToken: signerOrAuthTokenOrSignature
+  signerOrAuthToken: SignerOrAuthTokenOrSignature
 ): Promise<string> {
   if (typeof signerOrAuthToken === 'string') return decodeJwt(signerOrAuthToken).address
   if (isAgentSignature(signerOrAuthToken)) return signerOrAuthToken.consumerAddress
@@ -51,7 +51,7 @@ export async function getConsumerAddress(
 }
 
 export async function getSignature(
-  signerOrAuthToken: signerOrAuthTokenOrSignature,
+  signerOrAuthToken: SignerOrAuthTokenOrSignature,
   nonce: string,
   command: string
 ): Promise<string | null> {
@@ -71,7 +71,7 @@ export async function getSignature(
 }
 
 export function getAuthorization(
-  signerOrAuthToken: signerOrAuthTokenOrSignature
+  signerOrAuthToken: SignerOrAuthTokenOrSignature
 ): string | undefined {
   return typeof signerOrAuthToken === 'string' ? signerOrAuthToken : undefined
 }
@@ -162,7 +162,7 @@ export class BaseProvider {
     data: any,
     chainId: number,
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
@@ -272,7 +272,7 @@ export class BaseProvider {
     fileIndex: number,
     transferTxId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<string | DownloadResponse> {
@@ -290,7 +290,7 @@ export class BaseProvider {
 
   public async computeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -328,7 +328,7 @@ export class BaseProvider {
 
   public async freeComputeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -360,7 +360,7 @@ export class BaseProvider {
 
   public async computeStreamableLogs(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -375,7 +375,7 @@ export class BaseProvider {
   public async computeStop(
     jobId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
@@ -390,7 +390,7 @@ export class BaseProvider {
 
   public async computeStatus(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
     signal?: AbortSignal
@@ -406,7 +406,7 @@ export class BaseProvider {
 
   public async getComputeResultUrl(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     index: number
   ): Promise<string> {
@@ -420,7 +420,7 @@ export class BaseProvider {
 
   public async getComputeResult(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     index: number,
     offset: number = 0
@@ -478,7 +478,7 @@ export class BaseProvider {
   public async validateDdo(
     nodeUri: OceanNode,
     ddo: DDO,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
     return this.getImpl(nodeUri).validateDdo(nodeUri, ddo, signerOrAuthToken, signal)
@@ -506,7 +506,7 @@ export class BaseProvider {
 
   public async downloadNodeLogs(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     startTime: string,
     endTime: string,
     maxLogs?: number,
@@ -563,7 +563,7 @@ export class BaseProvider {
 
   public async createPersistentStorageBucket(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
   ): Promise<{
@@ -581,7 +581,7 @@ export class BaseProvider {
 
   public async getPersistentStorageBuckets(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
@@ -595,7 +595,7 @@ export class BaseProvider {
 
   public async listPersistentStorageFiles(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
@@ -609,7 +609,7 @@ export class BaseProvider {
 
   public async getPersistentStorageFileObject(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal
@@ -625,7 +625,7 @@ export class BaseProvider {
 
   public async uploadPersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     content: P2PRequestBodyStream,
@@ -643,7 +643,7 @@ export class BaseProvider {
 
   public async deletePersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -926,7 +926,9 @@ export class HttpProvider {
         body: JSON.stringify(payload),
         headers: {
           'Content-Type': 'application/json',
-          Authorization: this.getAuthorization(signerOrAuthToken)
+          ...(this.getAuthorization(signerOrAuthToken)
+            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
+            : {})
         },
         signal
       })
@@ -1014,7 +1016,9 @@ export class HttpProvider {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: this.getAuthorization(signerOrAuthToken)
+          ...(this.getAuthorization(signerOrAuthToken)
+            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
+            : {})
         },
         signal
       })
@@ -1088,12 +1092,13 @@ export class HttpProvider {
     if (!queryString) return null
     let response
     try {
-      const auth = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStopUrl + '?' + queryString, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          ...(auth ? { Authorization: auth } : {})
+          ...(this.getAuthorization(signerOrAuthToken)
+            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
+            : {})
         },
         signal
       })
@@ -1133,7 +1138,6 @@ export class HttpProvider {
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
     const consumerAddress = await getConsumerAddress(signerOrAuthToken)
-    const authorization = getAuthorization(signerOrAuthToken)
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const computeStatusUrl = this.getEndpointURL(serviceEndpoints, 'computeStatus')
@@ -1149,7 +1153,12 @@ export class HttpProvider {
     try {
       response = await fetch(computeStatusUrl + url, {
         method: 'GET',
-        headers: { 'Content-Type': 'application/json', Authorization: authorization },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(this.getAuthorization(signerOrAuthToken)
+            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
+            : {})
+        },
         signal
       })
     } catch (e) {
@@ -1566,7 +1575,9 @@ export class HttpProvider {
         }),
         headers: {
           'Content-Type': 'application/json',
-          Authorization: this.getAuthorization(signerOrAuthToken)
+          ...(this.getAuthorization(signerOrAuthToken)
+            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
+            : {})
         },
         signal
       })

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -28,7 +28,8 @@ import {
   PersistentStorageDeleteFileResponse,
   PersistentStorageFileEntry,
   PersistentStorageObject,
-  SignerOrAuthTokenOrSignature
+  SignerOrAuthTokenOrSignature,
+  CompleteSignature
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
@@ -43,18 +44,6 @@ import {
 import { type P2PRequestBodyStream } from './P2pProvider.js'
 
 export class HttpProvider {
-  protected getConsumerAddress(s: SignerOrAuthTokenOrSignature) {
-    return getConsumerAddress(s)
-  }
-
-  protected getSignature(
-    s: SignerOrAuthTokenOrSignature,
-    nonce: string,
-    command: string
-  ) {
-    return getSignature(s, nonce, command)
-  }
-
   protected getAuthorization(s: SignerOrAuthTokenOrSignature) {
     return getAuthorization(s)
   }
@@ -66,10 +55,7 @@ export class HttpProvider {
     signal?: AbortSignal,
     providerEndpoints?: any,
     serviceEndpoints?: any
-  ): Promise<{ consumerAddress: string; nonce: string; signature: string | null }> {
-    if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
-    if (!serviceEndpoints)
-      serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
+  ): Promise<CompleteSignature> {
     if (isAgentSignature(signerOrAuthToken)) {
       return {
         consumerAddress: signerOrAuthToken.consumerAddress,
@@ -77,8 +63,18 @@ export class HttpProvider {
         signature: signerOrAuthToken.signature
       }
     }
+    if (typeof signerOrAuthToken === 'string') {
+      return {
+        consumerAddress: undefined,
+        nonce: undefined,
+        signature: undefined
+      }
+    }
+    if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
+    if (!serviceEndpoints)
+      serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
 
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const nonce = (
       (await this.getNonce(
         nodeUri,
@@ -88,32 +84,9 @@ export class HttpProvider {
         serviceEndpoints
       )) + 1
     ).toString()
-    const signature = await this.getSignature(signerOrAuthToken, nonce, command)
+    const signature = await getSignature(signerOrAuthToken, nonce, command)
     if (!signature) throw new Error('Could not sign persistent storage request.')
     return { consumerAddress, nonce, signature }
-  }
-
-  private async getPersistentStorageSignaturePayload(
-    nodeUri: string,
-    signerOrAuthToken: SignerOrAuthTokenOrSignature,
-    command: string,
-    signal?: AbortSignal,
-    providerEndpoints?: any,
-    serviceEndpoints?: any
-  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
-    if (typeof signerOrAuthToken === 'string') {
-      throw new Error(
-        'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
-      )
-    }
-    return this.getSignedCommandParams(
-      nodeUri,
-      signerOrAuthToken,
-      command,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
-    )
   }
 
   private resolvePersistentStorageRoute(
@@ -1102,7 +1075,7 @@ export class HttpProvider {
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const computeStatusUrl = this.getEndpointURL(serviceEndpoints, 'computeStatus')
@@ -1240,7 +1213,7 @@ export class HttpProvider {
       )) + 1
     ).toString()
 
-    const signature = await this.getSignature(
+    const signature = await getSignature(
       consumer,
       nonce,
       PROTOCOL_COMMANDS.CREATE_AUTH_TOKEN
@@ -1647,7 +1620,7 @@ export class HttpProvider {
       ['persistentStorageCreateBucket'],
       '/api/services/persistentStorage/buckets'
     )
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_CREATE_BUCKET,
@@ -1684,7 +1657,7 @@ export class HttpProvider {
       ['persistentStorageGetBuckets'],
       '/api/services/persistentStorage/buckets'
     )
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_GET_BUCKETS,
@@ -1721,7 +1694,7 @@ export class HttpProvider {
       ['persistentStorageListFiles'],
       `/api/services/persistentStorage/buckets/${encodeURIComponent(bucketId)}/files`
     )
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_LIST_FILES,
@@ -1761,7 +1734,7 @@ export class HttpProvider {
         bucketId
       )}/files/${encodeURIComponent(fileName)}/object`
     )
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_GET_FILE_OBJECT,
@@ -1801,7 +1774,7 @@ export class HttpProvider {
         bucketId
       )}/files/${encodeURIComponent(fileName)}`
     )
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_UPLOAD_FILE,
@@ -1907,7 +1880,7 @@ export class HttpProvider {
         bucketId
       )}/files/${encodeURIComponent(fileName)}`
     )
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_DELETE_FILE,

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -67,7 +67,7 @@ export class HttpProvider {
     signal?: AbortSignal,
     providerEndpoints?: any,
     serviceEndpoints?: any
-  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+  ): Promise<{ consumerAddress: string; nonce: string; signature: string | null }> {
     if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
     if (!serviceEndpoints)
       serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -78,11 +78,6 @@ export class HttpProvider {
         signature: signerOrAuthToken.signature
       }
     }
-    if (typeof signerOrAuthToken === 'string') {
-      throw new Error(
-        'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
-      )
-    }
 
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
     const nonce = (

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -65,10 +65,8 @@ export class HttpProvider {
     }
     if (typeof signerOrAuthToken === 'string') {
       return {
-        consumerAddress: await getConsumerAddress(signerOrAuthToken),
-        nonce: undefined,
-        signature: undefined
-      }
+        consumerAddress: await getConsumerAddress(signerOrAuthToken)
+      } as CompleteSignature
     }
     if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
     if (!serviceEndpoints)
@@ -285,9 +283,9 @@ export class HttpProvider {
         ? this.getEndpointURL(serviceEndpoints, 'encrypt').urlPath
         : null) + `?chainId=${chainId}`
     if (!path) return null
-    path += `&nonce=${nonce}`
-    path += `&consumerAddress=${consumerAddress}`
-    path += `&signature=${signature}`
+    if (nonce) path += `&nonce=${nonce}`
+    if (consumerAddress) path += `&consumerAddress=${consumerAddress}`
+    if (signature) path += `&signature=${signature}`
 
     try {
       const response = await fetch(path, {
@@ -655,13 +653,13 @@ export class HttpProvider {
     consumeUrl += `&documentId=${did}`
     consumeUrl += `&transferTxId=${transferTxId}`
     consumeUrl += `&serviceId=${serviceId}`
-    consumeUrl += `&consumerAddress=${consumerAddress}`
-    consumeUrl += `&nonce=${nonce}`
+    if (consumerAddress) consumeUrl += `&consumerAddress=${consumerAddress}`
+    if (nonce) consumeUrl += `&nonce=${nonce}`
+    if (signature) consumeUrl += `&signature=${signature}`
     if (policyServer) {
       consumeUrl += '&policyServer=' + encodeURI(JSON.stringify(policyServer))
     }
 
-    consumeUrl += `&signature=${signature}`
     if (userCustomParameters)
       consumeUrl += '&userdata=' + encodeURI(JSON.stringify(userCustomParameters))
     return consumeUrl
@@ -1002,7 +1000,6 @@ export class HttpProvider {
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    const isAuthToken = typeof signerOrAuthToken === 'string'
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const computeStopUrl = this.getEndpointURL(serviceEndpoints, 'computeStop')
@@ -1018,12 +1015,10 @@ export class HttpProvider {
       serviceEndpoints
     )
     const queryParams = new URLSearchParams()
-    queryParams.set('consumerAddress', consumerAddress)
-    queryParams.set('nonce', nonce)
+    if (consumerAddress) queryParams.set('consumerAddress', consumerAddress)
+    if (nonce) queryParams.set('nonce', nonce)
+    if (signature) queryParams.set('signature', signature)
     queryParams.set('jobId', jobId)
-    if (!isAuthToken) {
-      queryParams.set('signature', signature)
-    }
 
     if (agreementId) queryParams.set('agreementId', agreementId)
 

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -65,8 +65,10 @@ export class HttpProvider {
     }
     if (typeof signerOrAuthToken === 'string') {
       return {
-        consumerAddress: await getConsumerAddress(signerOrAuthToken)
-      } as CompleteSignature
+        consumerAddress: await getConsumerAddress(signerOrAuthToken),
+        nonce: undefined,
+        signature: undefined
+      }
     }
     if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
     if (!serviceEndpoints)
@@ -924,7 +926,6 @@ export class HttpProvider {
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
-    const isAuthToken = typeof signerOrAuthToken === 'string'
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
 
@@ -950,12 +951,10 @@ export class HttpProvider {
       serviceEndpoints
     )
 
-    let url = `?consumerAddress=${consumerAddress}&jobId=${jobId}`
-    // Is signer, add signature and nonce
-    if (!isAuthToken) {
-      url += `&signature=${signature}`
-      url += `&nonce=${nonce}`
-    }
+    let url = `?jobId=${jobId}`
+    if (consumerAddress) url += `&consumerAddress=${consumerAddress}`
+    if (signature) url += `&signature=${signature}`
+    if (nonce) url += `&nonce=${nonce}`
 
     let response
     try {

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -27,36 +27,56 @@ import {
   PersistentStorageCreateBucketRequest,
   PersistentStorageDeleteFileResponse,
   PersistentStorageFileEntry,
-  PersistentStorageObject
+  PersistentStorageObject,
+  signerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
 import { eciesencrypt } from '../../utils/eciesencrypt.js'
 import { signRequest } from '../../utils/SignatureUtils.js'
-import { getConsumerAddress, getSignature, getAuthorization } from './BaseProvider.js'
+import {
+  getConsumerAddress,
+  getSignature,
+  getAuthorization,
+  isAgentSignature
+} from './BaseProvider.js'
 import { type P2PRequestBodyStream } from './P2pProvider.js'
 
 export class HttpProvider {
-  protected getConsumerAddress(s: Signer | string) {
+  protected getConsumerAddress(s: signerOrAuthTokenOrSignature) {
+    if (isAgentSignature(s)) return s.consumerAddress
     return getConsumerAddress(s)
   }
 
-  protected getSignature(s: Signer | string, nonce: string, command: string) {
+  protected getSignature(
+    s: signerOrAuthTokenOrSignature,
+    nonce: string,
+    command: string
+  ) {
     return getSignature(s, nonce, command)
   }
 
-  protected getAuthorization(s: Signer | string) {
+  protected getAuthorization(s: signerOrAuthTokenOrSignature) {
     return getAuthorization(s)
   }
 
   private async getPersistentStorageSignaturePayload(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
-  ): Promise<{} | { consumerAddress: string; nonce: string; signature: string }> {
+  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+    if (isAgentSignature(signerOrAuthToken)) {
+      return {
+        consumerAddress: signerOrAuthToken.consumerAddress,
+        nonce: signerOrAuthToken.nonce,
+        signature: signerOrAuthToken.signature
+      }
+    }
     if (typeof signerOrAuthToken === 'string') {
-      return {}
+      throw new Error(
+        'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
+      )
     }
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
@@ -251,27 +271,27 @@ export class HttpProvider {
     data: any,
     chainId: number,
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.ENCRYPT
-    )
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            signal,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.ENCRYPT)
 
     let path =
       (this.getEndpointURL(serviceEndpoints, 'encrypt')
@@ -625,7 +645,7 @@ export class HttpProvider {
     fileIndex: number,
     transferTxId: string,
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<any> {
@@ -636,21 +656,21 @@ export class HttpProvider {
       : null
     if (!downloadUrl) return null
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        null,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            null,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
 
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.DOWNLOAD
-    )
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.DOWNLOAD)
     let consumeUrl = downloadUrl
     consumeUrl += `?fileIndex=${fileIndex}`
     consumeUrl += `&documentId=${did}`
@@ -688,7 +708,7 @@ export class HttpProvider {
    */
   public async computeStart(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -719,20 +739,20 @@ export class HttpProvider {
     }
 
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.COMPUTE_START
-    )
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            signal,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_START)
     const payload = Object()
     payload.consumerAddress = consumerAddress
     payload.signature = signature
@@ -821,7 +841,7 @@ export class HttpProvider {
    */
   public async freeComputeStart(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -849,21 +869,25 @@ export class HttpProvider {
     }
 
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            signal,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
 
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.FREE_COMPUTE_START
-    )
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(
+          signerOrAuthToken,
+          nonce,
+          PROTOCOL_COMMANDS.FREE_COMPUTE_START
+        )
     const payload = Object()
     payload.consumerAddress = consumerAddress
     payload.signature = signature
@@ -936,7 +960,7 @@ export class HttpProvider {
    */
   public async computeStreamableLogs(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -958,24 +982,28 @@ export class HttpProvider {
       return null
     }
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            signal,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
 
     let url = `?consumerAddress=${consumerAddress}&jobId=${jobId}`
     // Is signer, add signature and nonce
     if (!isAuthToken) {
-      const signature = await this.getSignature(
-        signerOrAuthToken,
-        nonce,
-        PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS
-      )
+      const signature = isAgentSignature(signerOrAuthToken)
+        ? signerOrAuthToken.signature
+        : await this.getSignature(
+            signerOrAuthToken,
+            nonce,
+            PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS
+          )
       url += `&signature=${signature}`
       url += `&nonce=${nonce}`
     }
@@ -1018,7 +1046,7 @@ export class HttpProvider {
   public async computeStop(
     jobId: string,
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
@@ -1031,21 +1059,21 @@ export class HttpProvider {
 
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
 
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            signal,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
 
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.COMPUTE_STOP
-    )
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_STOP)
     const queryParams = new URLSearchParams()
     queryParams.set('consumerAddress', consumerAddress)
     queryParams.set('nonce', nonce)
@@ -1060,11 +1088,12 @@ export class HttpProvider {
     if (!queryString) return null
     let response
     try {
+      const auth = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStopUrl + '?' + queryString, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: this.getAuthorization(signerOrAuthToken)
+          ...(auth ? { Authorization: auth } : {})
         },
         signal
       })
@@ -1098,7 +1127,7 @@ export class HttpProvider {
    */
   public async computeStatus(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
     signal?: AbortSignal
@@ -1160,7 +1189,7 @@ export class HttpProvider {
    */
   public async getComputeResultUrl(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     index: number
   ): Promise<string> {
@@ -1172,20 +1201,24 @@ export class HttpProvider {
       : null
 
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        null,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
-    )
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            null,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(
+          signerOrAuthToken,
+          nonce,
+          PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
+        )
     if (!computeResultUrl) return null
     let resultUrl = computeResultUrl
     resultUrl += `?consumerAddress=${consumerAddress}`
@@ -1200,7 +1233,7 @@ export class HttpProvider {
 
   public async getComputeResult(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     index: number,
     offset: number = 0
@@ -1478,7 +1511,7 @@ export class HttpProvider {
    */
   public async downloadNodeLogs(
     nodeUri: string,
-    signer: Signer,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     startTime: string,
     endTime: string,
     maxLogs?: number,
@@ -1500,18 +1533,22 @@ export class HttpProvider {
       )
       return null
     }
-    const consumerAddress = await signer.getAddress()
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : (
+          (await this.getNonce(
+            nodeUri,
+            consumerAddress,
+            signal,
+            providerEndpoints,
+            serviceEndpoints
+          )) + 1
+        ).toString()
 
-    const signature = await this.getSignature(signer, nonce, PROTOCOL_COMMANDS.GET_LOGS)
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.GET_LOGS)
     let url = logsUrl + `?startTime=${startTime}&endTime=${endTime}`
     if (maxLogs) url += `&maxLogs=${maxLogs}`
     if (moduleName) url += `&moduleName=${moduleName}`
@@ -1527,7 +1564,10 @@ export class HttpProvider {
           nonce,
           address: consumerAddress
         }),
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: this.getAuthorization(signerOrAuthToken)
+        },
         signal
       })
     } catch (e) {
@@ -1636,7 +1676,7 @@ export class HttpProvider {
 
   public async createPersistentStorageBucket(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
   ): Promise<{
@@ -1677,7 +1717,7 @@ export class HttpProvider {
 
   public async getPersistentStorageBuckets(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
@@ -1714,7 +1754,7 @@ export class HttpProvider {
 
   public async listPersistentStorageFiles(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
@@ -1751,7 +1791,7 @@ export class HttpProvider {
 
   public async getPersistentStorageFileObject(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal
@@ -1790,7 +1830,7 @@ export class HttpProvider {
 
   public async uploadPersistentStorageFile(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     content: P2PRequestBodyStream,
@@ -1900,7 +1940,7 @@ export class HttpProvider {
 
   public async deletePersistentStorageFile(
     nodeUri: string,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -65,7 +65,7 @@ export class HttpProvider {
     }
     if (typeof signerOrAuthToken === 'string') {
       return {
-        consumerAddress: undefined,
+        consumerAddress: await getConsumerAddress(signerOrAuthToken),
         nonce: undefined,
         signature: undefined
       }
@@ -1567,20 +1567,28 @@ export class HttpProvider {
   public async validateDdo(
     nodeUri: string,
     ddo: DDO,
-    signer: Signer,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
-    const publisherAddress = await signer.getAddress()
-    const nonceResp = await (
-      await this.getData(`${nodeUri}/api/services/nonce?userAddress=${publisherAddress}`)
-    ).json()
-    const nonce = (Number(nonceResp.nonce ?? 0) + 1).toString()
-    const message = publisherAddress + nonce + PROTOCOL_COMMANDS.VALIDATE_DDO
-    const signature = await signRequest(signer, message)
+    const {
+      consumerAddress: publisherAddress,
+      nonce,
+      signature
+    } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.VALIDATE_DDO,
+      signal
+    )
+
+    const authHeader = this.getAuthorization(signerOrAuthToken)
     const response = await fetch(`${nodeUri}/api/aquarius/assets/ddo/validate`, {
       method: 'POST',
       body: JSON.stringify({ ddo, publisherAddress, nonce, signature }),
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader ? { Authorization: authHeader } : {})
+      },
       signal
     })
     if (!response.ok) return null

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -28,7 +28,7 @@ import {
   PersistentStorageDeleteFileResponse,
   PersistentStorageFileEntry,
   PersistentStorageObject,
-  signerOrAuthTokenOrSignature
+  SignerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
@@ -43,26 +43,25 @@ import {
 import { type P2PRequestBodyStream } from './P2pProvider.js'
 
 export class HttpProvider {
-  protected getConsumerAddress(s: signerOrAuthTokenOrSignature) {
-    if (isAgentSignature(s)) return s.consumerAddress
+  protected getConsumerAddress(s: SignerOrAuthTokenOrSignature) {
     return getConsumerAddress(s)
   }
 
   protected getSignature(
-    s: signerOrAuthTokenOrSignature,
+    s: SignerOrAuthTokenOrSignature,
     nonce: string,
     command: string
   ) {
     return getSignature(s, nonce, command)
   }
 
-  protected getAuthorization(s: signerOrAuthTokenOrSignature) {
+  protected getAuthorization(s: SignerOrAuthTokenOrSignature) {
     return getAuthorization(s)
   }
 
   private async getSignedCommandParams(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal,
     providerEndpoints?: any,
@@ -96,7 +95,7 @@ export class HttpProvider {
 
   private async getPersistentStorageSignaturePayload(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal,
     providerEndpoints?: any,
@@ -293,7 +292,7 @@ export class HttpProvider {
     data: any,
     chainId: number,
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
@@ -660,7 +659,7 @@ export class HttpProvider {
     fileIndex: number,
     transferTxId: string,
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<any> {
@@ -715,7 +714,7 @@ export class HttpProvider {
    */
   public async computeStart(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -794,12 +793,13 @@ export class HttpProvider {
     if (queueMaxWaitTime) payload.queueMaxWaitTime = queueMaxWaitTime
     let response
     try {
+      const authHeader = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStartUrl, {
         method: 'POST',
         body: JSON.stringify(payload),
         headers: {
           'Content-Type': 'application/json',
-          Authorization: this.getAuthorization(signerOrAuthToken)
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -841,7 +841,7 @@ export class HttpProvider {
    */
   public async freeComputeStart(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -909,14 +909,13 @@ export class HttpProvider {
     if (queueMaxWaitTime) payload.queueMaxWaitTime = queueMaxWaitTime
     let response
     try {
+      const authHeader = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStartUrl, {
         method: 'POST',
         body: JSON.stringify(payload),
         headers: {
           'Content-Type': 'application/json',
-          ...(this.getAuthorization(signerOrAuthToken)
-            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
-            : {})
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -950,7 +949,7 @@ export class HttpProvider {
    */
   public async computeStreamableLogs(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -989,13 +988,12 @@ export class HttpProvider {
 
     let response
     try {
+      const authHeader = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStreamableLogs + url, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.getAuthorization(signerOrAuthToken)
-            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
-            : {})
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -1027,7 +1025,7 @@ export class HttpProvider {
   public async computeStop(
     jobId: string,
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
@@ -1060,13 +1058,12 @@ export class HttpProvider {
     if (!queryString) return null
     let response
     try {
+      const authHeader = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStopUrl + '?' + queryString, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.getAuthorization(signerOrAuthToken)
-            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
-            : {})
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -1100,12 +1097,12 @@ export class HttpProvider {
    */
   public async computeStatus(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
+    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const computeStatusUrl = this.getEndpointURL(serviceEndpoints, 'computeStatus')
@@ -1119,13 +1116,12 @@ export class HttpProvider {
     if (!computeStatusUrl) return null
     let response
     try {
+      const authHeader = this.getAuthorization(signerOrAuthToken)
       response = await fetch(computeStatusUrl + url, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.getAuthorization(signerOrAuthToken)
-            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
-            : {})
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -1166,7 +1162,7 @@ export class HttpProvider {
    */
   public async getComputeResultUrl(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     index: number
   ): Promise<string> {
@@ -1199,7 +1195,7 @@ export class HttpProvider {
 
   public async getComputeResult(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     index: number,
     offset: number = 0
@@ -1477,7 +1473,7 @@ export class HttpProvider {
    */
   public async downloadNodeLogs(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     startTime: string,
     endTime: string,
     maxLogs?: number,
@@ -1515,6 +1511,7 @@ export class HttpProvider {
 
     let response
     try {
+      const authHeader = this.getAuthorization(signerOrAuthToken)
       response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify({
@@ -1524,9 +1521,7 @@ export class HttpProvider {
         }),
         headers: {
           'Content-Type': 'application/json',
-          ...(this.getAuthorization(signerOrAuthToken)
-            ? { Authorization: this.getAuthorization(signerOrAuthToken) }
-            : {})
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -1636,7 +1631,7 @@ export class HttpProvider {
 
   public async createPersistentStorageBucket(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
   ): Promise<{
@@ -1677,7 +1672,7 @@ export class HttpProvider {
 
   public async getPersistentStorageBuckets(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
@@ -1714,7 +1709,7 @@ export class HttpProvider {
 
   public async listPersistentStorageFiles(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
@@ -1751,7 +1746,7 @@ export class HttpProvider {
 
   public async getPersistentStorageFileObject(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal
@@ -1790,7 +1785,7 @@ export class HttpProvider {
 
   public async uploadPersistentStorageFile(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     content: P2PRequestBodyStream,
@@ -1880,17 +1875,14 @@ export class HttpProvider {
       }) as unknown as BodyInit
     }
 
-    const uploadHeaders: Record<string, string> = {
-      'Content-Type': 'application/octet-stream'
-    }
-    const maybeAuth = this.getAuthorization(signerOrAuthToken)
-    if (maybeAuth) uploadHeaders.Authorization = maybeAuth
-
+    const authHeader = this.getAuthorization(signerOrAuthToken)
     const response = await fetch(`${routeBase}?${query.toString()}`, {
       method: 'POST',
       body,
+
       headers: {
-        ...uploadHeaders
+        'Content-Type': 'application/octet-stream',
+        ...(authHeader ? { Authorization: authHeader } : {})
       },
       signal
     })
@@ -1900,7 +1892,7 @@ export class HttpProvider {
 
   public async deletePersistentStorageFile(
     nodeUri: string,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -60,12 +60,17 @@ export class HttpProvider {
     return getAuthorization(s)
   }
 
-  private async getPersistentStorageSignaturePayload(
+  private async getSignedCommandParams(
     nodeUri: string,
     signerOrAuthToken: signerOrAuthTokenOrSignature,
     command: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    providerEndpoints?: any,
+    serviceEndpoints?: any
   ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+    if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
+    if (!serviceEndpoints)
+      serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     if (isAgentSignature(signerOrAuthToken)) {
       return {
         consumerAddress: signerOrAuthToken.consumerAddress,
@@ -78,8 +83,7 @@ export class HttpProvider {
         'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
       )
     }
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
+
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
     const nonce = (
       (await this.getNonce(
@@ -93,6 +97,29 @@ export class HttpProvider {
     const signature = await this.getSignature(signerOrAuthToken, nonce, command)
     if (!signature) throw new Error('Could not sign persistent storage request.')
     return { consumerAddress, nonce, signature }
+  }
+
+  private async getPersistentStorageSignaturePayload(
+    nodeUri: string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    command: string,
+    signal?: AbortSignal,
+    providerEndpoints?: any,
+    serviceEndpoints?: any
+  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+    if (typeof signerOrAuthToken === 'string') {
+      throw new Error(
+        'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
+      )
+    }
+    return this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      command,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
   }
 
   private resolvePersistentStorageRoute(
@@ -277,21 +304,14 @@ export class HttpProvider {
   ): Promise<string> {
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            signal,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.ENCRYPT)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.ENCRYPT,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
 
     let path =
       (this.getEndpointURL(serviceEndpoints, 'encrypt')
@@ -655,22 +675,14 @@ export class HttpProvider {
       ? this.getEndpointURL(serviceEndpoints, 'download').urlPath
       : null
     if (!downloadUrl) return null
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            null,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.DOWNLOAD)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.DOWNLOAD,
+      undefined,
+      providerEndpoints,
+      serviceEndpoints
+    )
     let consumeUrl = downloadUrl
     consumeUrl += `?fileIndex=${fileIndex}`
     consumeUrl += `&documentId=${did}`
@@ -738,21 +750,14 @@ export class HttpProvider {
       return null
     }
 
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            signal,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_START)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_START,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
     const payload = Object()
     payload.consumerAddress = consumerAddress
     payload.signature = signature
@@ -868,26 +873,14 @@ export class HttpProvider {
       return null
     }
 
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            signal,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(
-          signerOrAuthToken,
-          nonce,
-          PROTOCOL_COMMANDS.FREE_COMPUTE_START
-        )
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.FREE_COMPUTE_START,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
     const payload = Object()
     payload.consumerAddress = consumerAddress
     payload.signature = signature
@@ -983,29 +976,18 @@ export class HttpProvider {
       )
       return null
     }
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            signal,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
 
     let url = `?consumerAddress=${consumerAddress}&jobId=${jobId}`
     // Is signer, add signature and nonce
     if (!isAuthToken) {
-      const signature = isAgentSignature(signerOrAuthToken)
-        ? signerOrAuthToken.signature
-        : await this.getSignature(
-            signerOrAuthToken,
-            nonce,
-            PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS
-          )
       url += `&signature=${signature}`
       url += `&nonce=${nonce}`
     }
@@ -1061,23 +1043,14 @@ export class HttpProvider {
       ? this.getEndpointURL(serviceEndpoints, 'computeStop').urlPath
       : null
 
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            signal,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_STOP)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_STOP,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
     const queryParams = new URLSearchParams()
     queryParams.set('consumerAddress', consumerAddress)
     queryParams.set('nonce', nonce)
@@ -1209,25 +1182,14 @@ export class HttpProvider {
       ? this.getEndpointURL(serviceEndpoints, 'computeResult').urlPath
       : null
 
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            null,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(
-          signerOrAuthToken,
-          nonce,
-          PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
-        )
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_GET_RESULT,
+      undefined,
+      providerEndpoints,
+      serviceEndpoints
+    )
     if (!computeResultUrl) return null
     let resultUrl = computeResultUrl
     resultUrl += `?consumerAddress=${consumerAddress}`
@@ -1542,22 +1504,14 @@ export class HttpProvider {
       )
       return null
     }
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : (
-          (await this.getNonce(
-            nodeUri,
-            consumerAddress,
-            signal,
-            providerEndpoints,
-            serviceEndpoints
-          )) + 1
-        ).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.GET_LOGS)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.GET_LOGS,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
     let url = logsUrl + `?startTime=${startTime}&endTime=${endTime}`
     if (maxLogs) url += `&maxLogs=${maxLogs}`
     if (moduleName) url += `&moduleName=${moduleName}`

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -329,8 +329,7 @@ export class P2pProvider {
 
   async getProvidersForString(
     input: string,
-    signal?: AbortSignal,
-    maxResults?: number
+    signal?: AbortSignal
   ): Promise<Array<{ id: string; multiaddrs: any[] }>> {
     const node = await this.getOrCreateLibp2pNode()
     const cid = await this.cidFromRawString(input)
@@ -342,11 +341,8 @@ export class P2pProvider {
         signal
       })) {
         peersFound.push(result)
-        if (maxResults !== undefined && peersFound.length >= maxResults) break
       }
-    } catch (err) {
-      if (err.name !== 'AbortError') console.error(err)
-    }
+    } catch (err) {}
     return peersFound.map((peer) => ({
       id: peer.id.toString(),
       multiaddrs: peer.multiaddrs

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -533,8 +533,10 @@ export class P2pProvider {
     }
     if (typeof signerOrAuthToken === 'string') {
       return {
-        consumerAddress: await getConsumerAddress(signerOrAuthToken)
-      } as CompleteSignature
+        consumerAddress: await getConsumerAddress(signerOrAuthToken),
+        nonce: undefined,
+        signature: undefined
+      }
     }
     const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -60,6 +60,7 @@ import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as multiFormatRaw from 'multiformats/codecs/raw'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { maxHeaderSize } from 'http'
 
 export const OCEAN_P2P_PROTOCOL = '/ocean/nodes/1.0.0'
 const OCEAN_DHT_PROTOCOL = '/ocean/nodes/1.0.0/kad/1.0.0'
@@ -273,7 +274,7 @@ export class P2pProvider {
           allowQueryWithZeroPeers: false,
           kBucketSize: 20,
           protocol: OCEAN_DHT_PROTOCOL,
-          clientMode: false // Servers can better query the network
+          clientMode: true // Servers can better query the network
         })
       },
       // Without this we are blocking connection to plain ws - the bundler thinks we are in a browser.
@@ -328,7 +329,8 @@ export class P2pProvider {
 
   async getProvidersForString(
     input: string,
-    timeout?: number
+    timeout?: number,
+    maxResults?: number
   ): Promise<Array<{ id: string; multiaddrs: any[] }>> {
     const node = await this.getOrCreateLibp2pNode()
     const cid = await this.cidFromRawString(input)
@@ -343,6 +345,7 @@ export class P2pProvider {
         useNetwork: true
       })) {
         peersFound.push(result)
+        if (maxResults !== undefined && peersFound.length >= maxResults) break
       }
     } catch (err) {
       if (err.name !== 'AbortError') console.error(err)

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -15,7 +15,7 @@ import { Signer } from 'ethers'
 import { sleep } from '../../utils/General.js'
 import { LoggerInstance } from '../../utils/Logger.js'
 import { concatUint8Arrays } from '../../utils/bytes.js'
-import type { Connection, Stream } from '@libp2p/interface'
+import type { Connection, Stream, PeerId } from '@libp2p/interface'
 import {
   StorageObject,
   FileInfo,
@@ -41,7 +41,9 @@ import {
   PersistentStorageCreateBucketRequest,
   PersistentStorageDeleteFileResponse,
   PersistentStorageFileEntry,
-  PersistentStorageObject
+  PersistentStorageObject,
+  OceanNode,
+  NodeP2P
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS, NodeLogsParams, NodeLogEntry } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
@@ -310,6 +312,14 @@ export class P2pProvider {
     return str.includes('/tls/sni')
   }
 
+  /**
+   * True when the multiaddr does not include the relay `p2p-circuit` protocol segment.
+   * (Direct / transport paths omit it; relay paths contain `/p2p-circuit/...`.)
+   */
+  private isNotP2PCircuit(ma: Multiaddr): boolean {
+    return !/\/p2p-circuit(\/|$)/.test(ma.toString())
+  }
+
   private peerIdFromMultiaddr(ma: Multiaddr): string | null {
     const parts = ma.toString().split('/p2p/')
     if (parts.length <= 1) return null
@@ -318,177 +328,113 @@ export class P2pProvider {
     return raw.split('/')[0] || null
   }
 
+  /* Dials a new connection */
   private async getConnection(
-    nodeUri: string | Multiaddr[],
-    signal: AbortSignal
+    nodeUri: OceanNode,
+    signal: AbortSignal,
+    includeP2PCircuit: boolean = false
   ): Promise<Connection> {
     const node = await this.getOrCreateLibp2pNode()
-
-    if (Array.isArray(nodeUri)) {
-      const dialable = nodeUri.filter((ma) => this.isDialable(ma))
-
-      if (dialable.length > 0) {
-        LoggerInstance.debug(`[P2P] dial array: ${dialable.length} dialable addrs`)
-        try {
-          const conn = await node.dial(dialable, { signal })
-          LoggerInstance.debug(`[P2P] dial array SUCCESS via ${conn.remoteAddr}`)
-          return conn
-        } catch (err: any) {
-          LoggerInstance.debug(`[P2P] dial array failed: ${err.message}`)
+    let peerId: PeerId | null = null
+    let addrs: Multiaddr[] = []
+    if (nodeUri && typeof nodeUri === 'string') {
+      try {
+        const addr = multiaddr(nodeUri)
+        addrs.push(addr)
+      } catch {}
+      try {
+        peerId = peerIdFromString(nodeUri)
+      } catch {}
+    }
+    if (typeof nodeUri === 'object' && nodeUri !== null && !Array.isArray(nodeUri)) {
+      if ('nodeId' in nodeUri || 'multiaddress' in nodeUri) {
+        const nodeP2p = nodeUri as NodeP2P
+        if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0) {
+          for (const addr of nodeP2p.multiaddress) addrs.push(addr)
         }
-      }
-
-      for (const ma of nodeUri) {
-        const pid = this.peerIdFromMultiaddr(ma)
-        if (pid) {
-          LoggerInstance.debug(`[P2P] Not multiaddrs, fallback to peerId: ${pid}`)
-          return this.dialByPeerId(node, pid, signal)
-        }
-      }
-      throw new Error('No valid addresses and no peer ID in multiaddrs')
-    }
-
-    try {
-      const ma = multiaddr(nodeUri)
-      if (this.isDialable(ma)) {
-        LoggerInstance.debug(`[P2P] dial single addr: ${ma}`)
-        try {
-          const conn = await node.dial(ma, { signal })
-          LoggerInstance.debug(`[P2P] dial single SUCCESS via ${conn.remoteAddr}`)
-          return conn
-        } catch (err: any) {
-          LoggerInstance.debug(`[P2P] dial single failed: ${err.message}`)
-        }
-      }
-      const pid = this.peerIdFromMultiaddr(ma)
-      if (pid) {
-        LoggerInstance.debug(`[P2P] single fallback -> dialByPeerId ${pid}`)
-        return this.dialByPeerId(node, pid, signal)
-      }
-      throw new Error(`Cannot dial address: ${nodeUri}`)
-    } catch (err: any) {
-      if (err.message?.includes('Cannot dial')) throw err
-    }
-
-    LoggerInstance.debug(`[P2P] bare peerId -> dialByPeerId ${nodeUri}`)
-    return this.dialByPeerId(node, nodeUri, signal)
-  }
-
-  private async dialByPeerId(
-    node: Libp2p,
-    peerIdStr: string,
-    signal: AbortSignal
-  ): Promise<Connection> {
-    const peerId = peerIdFromString(peerIdStr)
-
-    const existing = node.getConnections(peerId).filter((c) => c.status === 'open')
-    if (existing.length > 0) {
-      LoggerInstance.debug(
-        `[P2P] ${peerIdStr}: reusing existing connection via ${existing[0].remoteAddr}`
-      )
-      return existing[0]
-    }
-
-    // Wait briefly for bootstrap if node just started (0 connections)
-    if (node.getConnections().length === 0) {
-      LoggerInstance.debug(
-        `[P2P] ${peerIdStr}: no connections yet, waiting for bootstrap...`
-      )
-      await sleep(3000)
-      const after = node.getConnections(peerId)
-      if (after.length > 0) {
-        LoggerInstance.debug(`[P2P] ${peerIdStr}: connected during bootstrap wait`)
-        return after[0]
+        if (nodeP2p.nodeId) peerId = peerIdFromString(nodeP2p.nodeId)
+      } else {
+        peerId = nodeUri as PeerId
       }
     }
 
-    const seen = new Set<string>()
-    const allAddrs: Multiaddr[] = []
-    const addAddr = (ma: Multiaddr) => {
-      const key = ma.toString()
-      if (!seen.has(key)) {
-        seen.add(key)
-        allAddrs.push(ma)
-      }
-    }
-
-    try {
-      const peerData = await node.peerStore.get(peerId)
-      if (peerData?.addresses) {
-        for (const addr of peerData.addresses) {
-          addAddr(addr.multiaddr)
-        }
+    // check if we already have a connection
+    if (peerId) {
+      const existing = node.getConnections(peerId).filter((c) => c.status === 'open')
+      if (existing.length > 0) {
         LoggerInstance.debug(
-          `[P2P] ${peerIdStr}: ${peerData.addresses.length} peerStore addrs`
+          `[P2P] ${peerId.toString()}: reusing existing connection via ${
+            existing[0].remoteAddr
+          }`
         )
+        return existing[0]
       }
-    } catch {
-      LoggerInstance.debug(`[P2P] ${peerIdStr}: not in peerStore`)
     }
-
-    const knownDialable = allAddrs.filter((ma) => this.isDialable(ma))
-    if (knownDialable.length === 0) {
-      LoggerInstance.debug(
-        `[P2P] ${peerIdStr}: no dialable addrs in peerStore, querying DHT...`
-      )
+    // let's build the ma addr & fetch from dht if needed
+    if (addrs.length < 1 && peerId) {
+      try {
+        const peerData = await node.peerStore.get(peerId)
+        if (peerData?.addresses) {
+          for (const addr of peerData.addresses) {
+            addrs.push(addr.multiaddr)
+          }
+          LoggerInstance.debug(
+            `[P2P] ${peerId.toString()}: ${peerData.addresses.length} peerStore addrs`
+          )
+        }
+      } catch {
+        LoggerInstance.debug(`[P2P] ${peerId.toString()}: not in peerStore`)
+      }
+    }
+    // if there are no known ma, search dht
+    if (addrs.length < 1 && peerId) {
       try {
         const dhtSignal = AbortSignal.timeout(this.p2pConfig.dhtLookupTimeout ?? 60_000)
         const peerInfo = await node.peerRouting.findPeer(peerId, { signal: dhtSignal })
-        for (const ma of peerInfo.multiaddrs) addAddr(ma)
+        for (const ma of peerInfo.multiaddrs) addrs.push(ma)
         LoggerInstance.debug(
-          `[P2P] ${peerIdStr}: DHT returned ${peerInfo.multiaddrs.length} addrs`
+          `[P2P] ${peerId.toString()}: DHT returned ${peerInfo.multiaddrs.length} addrs`
         )
       } catch (err: any) {
-        LoggerInstance.debug(`[P2P] ${peerIdStr}: DHT findPeer failed: ${err.message}`)
+        LoggerInstance.debug(
+          `[P2P] ${peerId.toString}: DHT findPeer failed: ${err.message}`
+        )
       }
-    } else {
-      LoggerInstance.debug(
-        `[P2P] ${peerIdStr}: ${knownDialable.length} dialable addrs from peerStore, skipping DHT`
-      )
     }
+    addrs = addrs.filter((ma) => this.isDialable(ma))
+    const beforePFilter = addrs.length
+    if (!includeP2PCircuit) addrs = addrs.filter((ma) => this.isNotP2PCircuit(ma))
 
-    const dialable = allAddrs
-      .filter((ma) => this.isDialable(ma))
-      .map((ma) => {
+    const afterPFilter = addrs.length
+
+    if (addrs.length < 1) {
+      // try with p2p-circuits if available
+      if (!includeP2PCircuit && afterPFilter > beforePFilter) {
+        return this.getConnection(nodeUri, signal, true)
+      }
+      throw new Error('No valid multiaddresses, cannot connect')
+    }
+    // normalize all mas if we have peerId
+    if (peerId) {
+      addrs = addrs.map((ma) => {
         const str = ma.toString()
-        return str.includes('/p2p/') ? ma : multiaddr(`${str}/p2p/${peerIdStr}`)
+        return str.includes('/p2p/') ? ma : multiaddr(`${str}/p2p/${peerId.toString()}`)
       })
-
-    LoggerInstance.debug(
-      `[P2P] ${peerIdStr}: ${dialable.length}/${allAddrs.length} addrs are dialable`
-    )
-
-    if (dialable.length > 0) {
-      LoggerInstance.debug(`[P2P] ${peerIdStr}: dialing ${dialable.map(String)}`)
-      try {
-        const conn = await node.dial(dialable, { signal })
-        LoggerInstance.debug(
-          `[P2P] ${peerIdStr}: SUCCESS via ${conn.remoteAddr} (limited=${
-            conn.limits != null
-          })`
-        )
-        return conn
-      } catch (err: any) {
-        LoggerInstance.debug(`[P2P] ${peerIdStr}: direct dial failed: ${err.message}`)
-      }
     }
-
-    LoggerInstance.debug(`[P2P] ${peerIdStr}: last resort dial by peerId`)
     try {
-      const conn = await node.dial(peerId, { signal: AbortSignal.timeout(10_000) })
+      const conn = await node.dial(addrs, { signal })
       LoggerInstance.debug(
-        `[P2P] ${peerIdStr}: peerId dial SUCCESS via ${conn.remoteAddr} (limited=${
-          conn.limits != null
-        })`
+        `[P2P] Dial SUCCESS via ${conn.remoteAddr} (limited=${conn.limits != null})`
       )
       return conn
-    } catch {
+    } catch (err: any) {
       throw new Error(
-        `Cannot reach peer ${peerIdStr}. ` +
-          (allAddrs.length > 0
-            ? `Found addrs: ${allAddrs.map(String).join(', ')} (none dialable). `
+        `Cannot dial peer ${peerId?.toString()}. ` +
+          (addrs.length > 0
+            ? `Found addrs: ${addrs.map(String).join(', ')}. `
             : 'No addresses found. ') +
-          `Active connections: ${node.getConnections().length}.`
+          `Active connections: ${node.getConnections().length}. ` +
+          err.message
       )
     }
   }
@@ -501,7 +447,7 @@ export class P2pProvider {
     return getSignature(s, nonce, command)
   }
 
-  private async getNodePublicKey(nodeUri: string | Multiaddr[]): Promise<string> {
+  private async getNodePublicKey(nodeUri: OceanNode): Promise<string> {
     const endpoints = await this.getEndpoints(nodeUri)
     return endpoints?.nodePublicKey
   }
@@ -511,7 +457,7 @@ export class P2pProvider {
   }
 
   private async dialAndStream(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     payload: Record<string, any>,
     signal?: AbortSignal,
     requestBody?: P2PRequestBodyStream
@@ -557,7 +503,7 @@ export class P2pProvider {
   }
 
   private async sendP2pCommand(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     command: string,
     body: Record<string, any>,
     signerOrAuthToken?: Signer | string | null,
@@ -698,7 +644,7 @@ export class P2pProvider {
    * Returns node status via P2P STATUS command.
    * @param {string} nodeUri - multiaddr of the node
    */
-  async getEndpoints(nodeUri: string | Multiaddr[]): Promise<any> {
+  async getEndpoints(nodeUri: OceanNode): Promise<any> {
     try {
       return await this.sendP2pCommand(nodeUri, PROTOCOL_COMMANDS.STATUS, {})
     } catch (e) {
@@ -708,14 +654,14 @@ export class P2pProvider {
   }
 
   public async getNodeStatus(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<NodeStatus> {
     return this.getEndpoints(nodeUri)
   }
 
   public async getNodeJobs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     fromTimestamp?: number,
     signal?: AbortSignal
   ): Promise<NodeComputeJob[]> {
@@ -740,7 +686,7 @@ export class P2pProvider {
    * Get current nonce from the node via P2P.
    */
   public async getNonce(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     consumerAddress: string,
     signal?: AbortSignal
   ): Promise<number> {
@@ -768,7 +714,7 @@ export class P2pProvider {
   public async encrypt(
     data: any,
     chainId: number,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     _policyServer?: any,
     signal?: AbortSignal
@@ -802,7 +748,7 @@ export class P2pProvider {
   public async checkDidFiles(
     did: string,
     serviceId: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
@@ -821,7 +767,7 @@ export class P2pProvider {
    */
   public async getFileInfo(
     file: StorageObject,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
@@ -839,7 +785,7 @@ export class P2pProvider {
    * Returns compute environments via P2P.
    */
   public async getComputeEnvironments(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<ComputeEnvironment[]> {
     const result = await this.sendP2pCommand(
@@ -860,7 +806,7 @@ export class P2pProvider {
     serviceId: string,
     fileIndex: number,
     consumerAddress: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal,
     userCustomParameters?: UserCustomParameters,
     computeEnv?: string,
@@ -887,7 +833,7 @@ export class P2pProvider {
     computeEnv: string,
     token: string,
     validUntil: number,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     consumerAddress: string,
     resources: ComputeResourceRequest[],
     chainId: number,
@@ -940,7 +886,7 @@ export class P2pProvider {
     serviceId: string,
     fileIndex: number,
     transferTxId: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
@@ -1014,7 +960,7 @@ export class P2pProvider {
    * Start a paid compute job via P2P.
    */
   public async computeStart(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     computeEnv: string,
     datasets: ComputeAsset[],
@@ -1085,7 +1031,7 @@ export class P2pProvider {
    * Start a free compute job via P2P.
    */
   public async freeComputeStart(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     computeEnv: string,
     datasets: ComputeAsset[],
@@ -1149,7 +1095,7 @@ export class P2pProvider {
    * Get streamable compute logs via P2P. Returns an async generator of Uint8Array chunks.
    */
   public async computeStreamableLogs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId: string,
     signal?: AbortSignal
@@ -1186,7 +1132,7 @@ export class P2pProvider {
    */
   public async computeStop(
     jobId: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     agreementId?: string,
     signal?: AbortSignal
@@ -1216,7 +1162,7 @@ export class P2pProvider {
    * Get compute status via P2P.
    */
   public async computeStatus(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId?: string,
     agreementId?: string,
@@ -1241,7 +1187,7 @@ export class P2pProvider {
    * Supports resumable downloads via `offset` (byte position to resume from).
    */
   public async getComputeResult(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId: string,
     index: number,
@@ -1290,7 +1236,7 @@ export class P2pProvider {
   }
 
   public async getComputeResultUrl(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     jobId: string,
     index: number
@@ -1310,7 +1256,7 @@ export class P2pProvider {
    */
   public async generateAuthToken(
     consumer: Signer,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<string> {
     const address = await consumer.getAddress()
@@ -1338,7 +1284,7 @@ export class P2pProvider {
     address: string,
     signature: string,
     nonce: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<string> {
     const result = await this.sendP2pCommand(
@@ -1355,7 +1301,7 @@ export class P2pProvider {
    * Resolve a DDO by DID via P2P GET_DDO command.
    */
   public async resolveDdo(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     did: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -1372,7 +1318,7 @@ export class P2pProvider {
    * Validate a DDO via P2P VALIDATE_DDO command.
    */
   public async validateDdo(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     ddo: DDO,
     signer: Signer,
     signal?: AbortSignal
@@ -1409,7 +1355,7 @@ export class P2pProvider {
   public async invalidateAuthToken(
     consumer: Signer,
     token: string,
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<{ success: boolean }> {
     const consumerAddress = await consumer.getAddress()
@@ -1429,7 +1375,7 @@ export class P2pProvider {
    * Check if a P2P node is reachable by calling STATUS.
    */
   public async isValidProvider(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signal?: AbortSignal
   ): Promise<boolean> {
     try {
@@ -1454,7 +1400,7 @@ export class P2pProvider {
    * PolicyServer passthrough via P2P.
    */
   public async PolicyServerPassthrough(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
@@ -1471,7 +1417,7 @@ export class P2pProvider {
    * Initialize Policy Server verification via P2P.
    */
   public async initializePSVerification(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     request: PolicyServerInitializeCommand,
     signal?: AbortSignal
   ): Promise<any> {
@@ -1488,7 +1434,7 @@ export class P2pProvider {
    * Download node logs via P2P.
    */
   public async downloadNodeLogs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signer: Signer,
     startTime: string,
     endTime: string,
@@ -1522,7 +1468,7 @@ export class P2pProvider {
    * P2P only — use downloadNodeLogs() for the auto-signed variant.
    */
   public async fetchNodeLogs(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     address: string,
     signature: string,
     nonce: string,
@@ -1541,7 +1487,7 @@ export class P2pProvider {
    * the caller is responsible for nonce retrieval and signing.
    */
   public async fetchConfig(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     payload: Record<string, any>
   ): Promise<any> {
     return this.sendP2pCommand(nodeUri, PROTOCOL_COMMANDS.FETCH_CONFIG, payload)
@@ -1552,14 +1498,14 @@ export class P2pProvider {
    * the caller is responsible for nonce retrieval and signing.
    */
   public async pushConfig(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     payload: Record<string, any>
   ): Promise<any> {
     return this.sendP2pCommand(nodeUri, PROTOCOL_COMMANDS.PUSH_CONFIG, payload)
   }
 
   private async getPersistentStorageSignaturePayload(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     command: string,
     signal?: AbortSignal
@@ -1577,7 +1523,7 @@ export class P2pProvider {
   }
 
   public async createPersistentStorageBucket(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
@@ -1605,7 +1551,7 @@ export class P2pProvider {
   }
 
   public async getPersistentStorageBuckets(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     owner: string,
     signal?: AbortSignal
@@ -1627,7 +1573,7 @@ export class P2pProvider {
   }
 
   public async listPersistentStorageFiles(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     signal?: AbortSignal
@@ -1649,7 +1595,7 @@ export class P2pProvider {
   }
 
   public async getPersistentStorageFileObject(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     fileName: string,
@@ -1671,7 +1617,7 @@ export class P2pProvider {
   }
 
   public async uploadPersistentStorageFile(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     fileName: string,
@@ -1696,7 +1642,7 @@ export class P2pProvider {
   }
 
   public async deletePersistentStorageFile(
-    nodeUri: string | Multiaddr[],
+    nodeUri: OceanNode,
     signerOrAuthToken: Signer | string,
     bucketId: string,
     fileName: string,

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -44,7 +44,8 @@ import {
   PersistentStorageObject,
   OceanNode,
   NodeP2P,
-  SignerOrAuthTokenOrSignature
+  SignerOrAuthTokenOrSignature,
+  CompleteSignature
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS, NodeLogEntry } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
@@ -60,7 +61,6 @@ import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as multiFormatRaw from 'multiformats/codecs/raw'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { maxHeaderSize } from 'http'
 
 export const OCEAN_P2P_PROTOCOL = '/ocean/nodes/1.0.0'
 const OCEAN_DHT_PROTOCOL = '/ocean/nodes/1.0.0/kad/1.0.0'
@@ -509,18 +509,6 @@ export class P2pProvider {
     }
   }
 
-  protected getConsumerAddress(s: SignerOrAuthTokenOrSignature) {
-    return getConsumerAddress(s)
-  }
-
-  protected getSignature(
-    s: SignerOrAuthTokenOrSignature,
-    nonce: string,
-    command: string
-  ) {
-    return getSignature(s, nonce, command)
-  }
-
   private async getNodePublicKey(nodeUri: OceanNode): Promise<string> {
     const endpoints = await this.getEndpoints(nodeUri)
     return endpoints?.nodePublicKey
@@ -535,7 +523,7 @@ export class P2pProvider {
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
-  ): Promise<{ consumerAddress: string; nonce: string; signature: string | null }> {
+  ): Promise<CompleteSignature> {
     if (isAgentSignature(signerOrAuthToken)) {
       return {
         consumerAddress: signerOrAuthToken.consumerAddress,
@@ -543,9 +531,16 @@ export class P2pProvider {
         signature: signerOrAuthToken.signature
       }
     }
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    if (typeof signerOrAuthToken === 'string') {
+      return {
+        consumerAddress: undefined,
+        nonce: undefined,
+        signature: undefined
+      }
+    }
+    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = await this.getSignature(signerOrAuthToken, nonce, command)
+    const signature = await getSignature(signerOrAuthToken, nonce, command)
     return { consumerAddress, nonce, signature }
   }
 
@@ -1251,7 +1246,7 @@ export class P2pProvider {
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const body: Record<string, any> = { consumerAddress }
     if (jobId) body.jobId = jobId
     if (agreementId) body.agreementId = agreementId
@@ -1276,25 +1271,24 @@ export class P2pProvider {
     index: number,
     offset: number = 0
   ): Promise<ComputeResultStream> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
     const payload: Record<string, any> = {
       command: PROTOCOL_COMMANDS.COMPUTE_GET_RESULT,
       jobId,
       index,
-      offset,
-      consumerAddress
+      offset
     }
 
     if (typeof signerOrAuthToken === 'string') {
       payload.authorization = signerOrAuthToken
     } else {
-      const { nonce, signature } = await this.getSignedCommandParams(
+      const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
         nodeUri,
         signerOrAuthToken,
         PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
       )
       payload.nonce = nonce
       payload.signature = signature
+      payload.consumerAddress = consumerAddress
     }
 
     const { lp, firstBytes } = await this.dialAndStream(nodeUri, payload)
@@ -1324,7 +1318,7 @@ export class P2pProvider {
     jobId: string,
     index: number
   ): Promise<string> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const result = await this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.COMPUTE_GET_RESULT,
@@ -1344,7 +1338,7 @@ export class P2pProvider {
   ): Promise<string> {
     const address = await consumer.getAddress()
     const nonce = ((await this.getNonce(nodeUri, address, signal)) + 1).toString()
-    const signature = await this.getSignature(
+    const signature = await getSignature(
       consumer,
       nonce,
       PROTOCOL_COMMANDS.CREATE_AUTH_TOKEN
@@ -1586,11 +1580,9 @@ export class P2pProvider {
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
-  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+  ): Promise<{} | { consumerAddress: string; nonce: string; signature: string }> {
     if (typeof signerOrAuthToken === 'string') {
-      throw new Error(
-        'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
-      )
+      return {}
     }
     return this.getSignedCommandParams(nodeUri, signerOrAuthToken, command, signal)
   }
@@ -1605,7 +1597,7 @@ export class P2pProvider {
     owner: string
     accessList: PersistentStorageAccessList[]
   }> {
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_CREATE_BUCKET,
@@ -1629,7 +1621,7 @@ export class P2pProvider {
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_GET_BUCKETS,
@@ -1651,7 +1643,7 @@ export class P2pProvider {
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_LIST_FILES,
@@ -1674,7 +1666,7 @@ export class P2pProvider {
     fileName: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageObject> {
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_GET_FILE_OBJECT,
@@ -1697,7 +1689,7 @@ export class P2pProvider {
     content: P2PRequestBodyStream,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry> {
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_UPLOAD_FILE,
@@ -1721,7 +1713,7 @@ export class P2pProvider {
     fileName: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageDeleteFileResponse> {
-    const authPayload = await this.getPersistentStorageSignaturePayload(
+    const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.PERSISTENT_STORAGE_DELETE_FILE,

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -448,6 +448,16 @@ export class P2pProvider {
       )
       return conn
     } catch (err: any) {
+      if (!includeP2PCircuit && afterPFilter < beforePFilter) {
+        LoggerInstance.debug(
+          `[P2P] Direct dial failed, falling back to relayed addresses...`
+        )
+        return this.getConnection(
+          { nodeId: peerId ? peerId.toString() : '', multiaddress: addrs } as NodeP2P,
+          signal,
+          true
+        )
+      }
       throw new Error(
         `Cannot dial peer ${peerId?.toString()}. ` +
           (addrs.length > 0
@@ -486,7 +496,7 @@ export class P2pProvider {
     signerOrAuthToken: signerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
-  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+  ): Promise<{ consumerAddress: string; nonce: string; signature: string | null }> {
     if (isAgentSignature(signerOrAuthToken)) {
       return {
         consumerAddress: signerOrAuthToken.consumerAddress,

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -335,6 +335,7 @@ export class P2pProvider {
     includeP2PCircuit: boolean = false
   ): Promise<Connection> {
     const node = await this.getOrCreateLibp2pNode()
+    const hasDialable = () => addrs.some((ma) => this.isDialable(ma))
     let peerId: PeerId | null = null
     let addrs: Multiaddr[] = []
     if (nodeUri && typeof nodeUri === 'string') {
@@ -343,7 +344,7 @@ export class P2pProvider {
         addrs.push(addr)
       } catch {}
       try {
-        peerId = peerIdFromString(nodeUri)
+        if (!peerId) peerId = peerIdFromString(nodeUri)
       } catch {}
     }
     if (typeof nodeUri === 'object' && nodeUri !== null && !Array.isArray(nodeUri)) {
@@ -352,7 +353,11 @@ export class P2pProvider {
         if (Array.isArray(nodeP2p.multiaddress) && nodeP2p.multiaddress.length > 0) {
           for (const addr of nodeP2p.multiaddress) addrs.push(addr)
         }
-        if (nodeP2p.nodeId) peerId = peerIdFromString(nodeP2p.nodeId)
+        if (nodeP2p.nodeId) {
+          try {
+            peerId = peerIdFromString(nodeP2p.nodeId)
+          } catch {}
+        }
       } else {
         peerId = nodeUri as PeerId
       }
@@ -370,8 +375,8 @@ export class P2pProvider {
         return existing[0]
       }
     }
-    // let's build the ma addr & fetch from dht if needed
-    if (addrs.length < 1 && peerId) {
+    // if there are no dialable ma, search peerstore
+    if (!hasDialable() && peerId) {
       try {
         const peerData = await node.peerStore.get(peerId)
         if (peerData?.addresses) {
@@ -386,8 +391,8 @@ export class P2pProvider {
         LoggerInstance.debug(`[P2P] ${peerId.toString()}: not in peerStore`)
       }
     }
-    // if there are no known ma, search dht
-    if (addrs.length < 1 && peerId) {
+    // if there are no dialable ma, search dht
+    if (!hasDialable() && peerId) {
       try {
         const dhtSignal = AbortSignal.timeout(this.p2pConfig.dhtLookupTimeout ?? 60_000)
         const peerInfo = await node.peerRouting.findPeer(peerId, { signal: dhtSignal })
@@ -409,7 +414,8 @@ export class P2pProvider {
 
     if (addrs.length < 1) {
       // try with p2p-circuits if available
-      if (!includeP2PCircuit && afterPFilter > beforePFilter) {
+      if (!includeP2PCircuit && afterPFilter < beforePFilter) {
+        // we have some p2p-circuit addrs, let's try them
         return this.getConnection(nodeUri, signal, true)
       }
       throw new Error('No valid multiaddresses, cannot connect')

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -533,7 +533,7 @@ export class P2pProvider {
     }
     if (typeof signerOrAuthToken === 'string') {
       return {
-        consumerAddress: undefined,
+        consumerAddress: await getConsumerAddress(signerOrAuthToken),
         nonce: undefined,
         signature: undefined
       }
@@ -1271,24 +1271,24 @@ export class P2pProvider {
     index: number,
     offset: number = 0
   ): Promise<ComputeResultStream> {
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
+    )
     const payload: Record<string, any> = {
       command: PROTOCOL_COMMANDS.COMPUTE_GET_RESULT,
       jobId,
       index,
-      offset
+      offset,
+      consumerAddress
     }
 
     if (typeof signerOrAuthToken === 'string') {
       payload.authorization = signerOrAuthToken
     } else {
-      const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
-        nodeUri,
-        signerOrAuthToken,
-        PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
-      )
       payload.nonce = nonce
       payload.signature = signature
-      payload.consumerAddress = consumerAddress
     }
 
     const { lp, firstBytes } = await this.dialAndStream(nodeUri, payload)
@@ -1414,7 +1414,7 @@ export class P2pProvider {
       nodeUri,
       PROTOCOL_COMMANDS.VALIDATE_DDO,
       { ddo, publisherAddress, nonce, signature },
-      null,
+      signerOrAuthToken,
       signal
     )
     if (!result || result.error) return null

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -497,7 +497,6 @@ export class P2pProvider {
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
     const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
     const signature = await this.getSignature(signerOrAuthToken, nonce, command)
-    if (!signature) throw new Error(`Could not sign command ${command}.`)
     return { consumerAddress, nonce, signature }
   }
 

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -533,10 +533,8 @@ export class P2pProvider {
     }
     if (typeof signerOrAuthToken === 'string') {
       return {
-        consumerAddress: await getConsumerAddress(signerOrAuthToken),
-        nonce: undefined,
-        signature: undefined
-      }
+        consumerAddress: await getConsumerAddress(signerOrAuthToken)
+      } as CompleteSignature
     }
     const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -43,12 +43,18 @@ import {
   PersistentStorageFileEntry,
   PersistentStorageObject,
   OceanNode,
-  NodeP2P
+  NodeP2P,
+  signerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS, NodeLogsParams, NodeLogEntry } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
 import { signRequest } from '../../utils/SignatureUtils.js'
-import { getConsumerAddress, getSignature, getAuthorization } from './BaseProvider.js'
+import {
+  getConsumerAddress,
+  getSignature,
+  getAuthorization,
+  isAgentSignature
+} from './BaseProvider.js'
 import { eciesencrypt } from '../../utils/eciesencrypt.js'
 
 export const OCEAN_P2P_PROTOCOL = '/ocean/nodes/1.0.0'
@@ -421,7 +427,7 @@ export class P2pProvider {
       if (!includeP2PCircuit && afterPFilter < beforePFilter) {
         // we have some p2p-circuit addrs, let's try them
         return this.getConnection(
-          { nodeId: peerId.toString(), multiaddress: addrs },
+          { nodeId: peerId?.toString(), multiaddress: addrs },
           signal,
           true
         )
@@ -453,11 +459,16 @@ export class P2pProvider {
     }
   }
 
-  protected getConsumerAddress(s: Signer | string) {
+  protected getConsumerAddress(s: signerOrAuthTokenOrSignature) {
+    if (isAgentSignature(s)) return s.consumerAddress
     return getConsumerAddress(s)
   }
 
-  protected getSignature(s: Signer | string, nonce: string, command: string) {
+  protected getSignature(
+    s: signerOrAuthTokenOrSignature,
+    nonce: string,
+    command: string
+  ) {
     return getSignature(s, nonce, command)
   }
 
@@ -466,7 +477,7 @@ export class P2pProvider {
     return endpoints?.nodePublicKey
   }
 
-  protected getAuthorization(s: Signer | string) {
+  protected getAuthorization(s: signerOrAuthTokenOrSignature) {
     return getAuthorization(s)
   }
 
@@ -520,7 +531,7 @@ export class P2pProvider {
     nodeUri: OceanNode,
     command: string,
     body: Record<string, any>,
-    signerOrAuthToken?: Signer | string | null,
+    signerOrAuthToken?: signerOrAuthTokenOrSignature | null,
     signal?: AbortSignal,
     retrialNumber: number = 0,
     requestBody?: P2PRequestBodyStream
@@ -729,17 +740,17 @@ export class P2pProvider {
     data: any,
     chainId: number,
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     _policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.ENCRYPT
-    )
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.ENCRYPT)
     const result = await this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.ENCRYPT,
@@ -901,17 +912,17 @@ export class P2pProvider {
     fileIndex: number,
     transferTxId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<DownloadResponse> {
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress)) + 1).toString()
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.DOWNLOAD
-    )
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress)) + 1).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.DOWNLOAD)
 
     const payload: Record<string, any> = {
       command: PROTOCOL_COMMANDS.DOWNLOAD,
@@ -975,7 +986,7 @@ export class P2pProvider {
    */
   public async computeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -992,13 +1003,13 @@ export class P2pProvider {
     dockerRegistryAuth?: dockerRegistryAuth
   ): Promise<ComputeJob | ComputeJob[]> {
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
 
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.COMPUTE_START
-    )
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_START)
 
     const body: Record<string, any> = {
       environment: computeEnv,
@@ -1046,7 +1057,7 @@ export class P2pProvider {
    */
   public async freeComputeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -1060,13 +1071,17 @@ export class P2pProvider {
     dockerRegistryAuth?: dockerRegistryAuth
   ): Promise<ComputeJob | ComputeJob[]> {
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
 
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.FREE_COMPUTE_START
-    )
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(
+          signerOrAuthToken,
+          nonce,
+          PROTOCOL_COMMANDS.FREE_COMPUTE_START
+        )
 
     const body: Record<string, any> = {
       environment: computeEnv,
@@ -1110,7 +1125,7 @@ export class P2pProvider {
    */
   public async computeStreamableLogs(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -1126,12 +1141,16 @@ export class P2pProvider {
     }
 
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS
-    )
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(
+          signerOrAuthToken,
+          nonce,
+          PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS
+        )
     return this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS,
@@ -1147,18 +1166,18 @@ export class P2pProvider {
   public async computeStop(
     jobId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
 
-    const signature = await this.getSignature(
-      signerOrAuthToken,
-      nonce,
-      PROTOCOL_COMMANDS.COMPUTE_STOP
-    )
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_STOP)
 
     const body: Record<string, any> = { jobId, consumerAddress, nonce, signature }
     if (agreementId) body.agreementId = agreementId
@@ -1177,7 +1196,7 @@ export class P2pProvider {
    */
   public async computeStatus(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
     signal?: AbortSignal
@@ -1202,7 +1221,7 @@ export class P2pProvider {
    */
   public async getComputeResult(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     index: number,
     offset: number = 0
@@ -1219,13 +1238,17 @@ export class P2pProvider {
     if (typeof signerOrAuthToken === 'string') {
       payload.authorization = signerOrAuthToken
     } else {
-      const nonce = ((await this.getNonce(nodeUri, consumerAddress)) + 1).toString()
+      const nonce = isAgentSignature(signerOrAuthToken)
+        ? signerOrAuthToken.nonce
+        : ((await this.getNonce(nodeUri, consumerAddress)) + 1).toString()
       payload.nonce = nonce
-      payload.signature = await this.getSignature(
-        signerOrAuthToken,
-        nonce,
-        PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
-      )
+      payload.signature = isAgentSignature(signerOrAuthToken)
+        ? signerOrAuthToken.signature
+        : await this.getSignature(
+            signerOrAuthToken,
+            nonce,
+            PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
+          )
     }
 
     const { lp, firstBytes } = await this.dialAndStream(nodeUri, payload)
@@ -1251,7 +1274,7 @@ export class P2pProvider {
 
   public async getComputeResultUrl(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     jobId: string,
     index: number
   ): Promise<string> {
@@ -1334,15 +1357,21 @@ export class P2pProvider {
   public async validateDdo(
     nodeUri: OceanNode,
     ddo: DDO,
-    signer: Signer,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
-    const publisherAddress = await signer.getAddress()
-    const nonce = (
-      (await this.getNonce(nodeUri, publisherAddress, signal)) + 1
-    ).toString()
-    const message = publisherAddress + nonce + PROTOCOL_COMMANDS.VALIDATE_DDO
-    const sig = await signRequest(signer, message)
+    if (typeof signerOrAuthToken === 'string' && !isAgentSignature(signerOrAuthToken)) {
+      throw new Error(
+        'validateDdo requires a Signer or AgentSignature (nonce/signature).'
+      )
+    }
+    const publisherAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, publisherAddress, signal)) + 1).toString()
+    const sig = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.VALIDATE_DDO)
     const result = await this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.VALIDATE_DDO,
@@ -1449,7 +1478,7 @@ export class P2pProvider {
    */
   public async downloadNodeLogs(
     nodeUri: OceanNode,
-    signer: Signer,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     startTime: string,
     endTime: string,
     maxLogs?: number,
@@ -1458,9 +1487,18 @@ export class P2pProvider {
     page?: number,
     signal?: AbortSignal
   ): Promise<NodeLogEntry[]> {
-    const consumerAddress = await signer.getAddress()
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = await this.getSignature(signer, nonce, PROTOCOL_COMMANDS.GET_LOGS)
+    if (typeof signerOrAuthToken === 'string' && !isAgentSignature(signerOrAuthToken)) {
+      throw new Error(
+        'downloadNodeLogs requires a Signer or AgentSignature (nonce/signature).'
+      )
+    }
+    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const nonce = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.nonce
+      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const signature = isAgentSignature(signerOrAuthToken)
+      ? signerOrAuthToken.signature
+      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.GET_LOGS)
 
     const body: Record<string, any> = {
       startTime,
@@ -1474,26 +1512,13 @@ export class P2pProvider {
     if (level) body.level = level
     if (page) body.page = page
 
-    return this.sendP2pCommand(nodeUri, PROTOCOL_COMMANDS.GET_LOGS, body, signer, signal)
-  }
-
-  /**
-   * Fetch node logs via P2P with a pre-signed payload.
-   * P2P only — use downloadNodeLogs() for the auto-signed variant.
-   */
-  public async fetchNodeLogs(
-    nodeUri: OceanNode,
-    address: string,
-    signature: string,
-    nonce: string,
-    logParams?: NodeLogsParams
-  ): Promise<NodeLogEntry[]> {
-    return this.sendP2pCommand(nodeUri, PROTOCOL_COMMANDS.GET_LOGS, {
-      address,
-      signature,
-      nonce,
-      ...logParams
-    })
+    return this.sendP2pCommand(
+      nodeUri,
+      PROTOCOL_COMMANDS.GET_LOGS,
+      body,
+      signerOrAuthToken,
+      signal
+    )
   }
 
   /**
@@ -1520,12 +1545,21 @@ export class P2pProvider {
 
   private async getPersistentStorageSignaturePayload(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
-  ): Promise<{} | { consumerAddress: string; nonce: string; signature: string }> {
+  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+    if (isAgentSignature(signerOrAuthToken)) {
+      return {
+        consumerAddress: signerOrAuthToken.consumerAddress,
+        nonce: signerOrAuthToken.nonce,
+        signature: signerOrAuthToken.signature
+      }
+    }
     if (typeof signerOrAuthToken === 'string') {
-      return {}
+      throw new Error(
+        'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
+      )
     }
     const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
     const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
@@ -1538,7 +1572,7 @@ export class P2pProvider {
 
   public async createPersistentStorageBucket(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
   ): Promise<{
@@ -1566,7 +1600,7 @@ export class P2pProvider {
 
   public async getPersistentStorageBuckets(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
@@ -1588,7 +1622,7 @@ export class P2pProvider {
 
   public async listPersistentStorageFiles(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
@@ -1610,7 +1644,7 @@ export class P2pProvider {
 
   public async getPersistentStorageFileObject(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal
@@ -1632,7 +1666,7 @@ export class P2pProvider {
 
   public async uploadPersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     content: P2PRequestBodyStream,
@@ -1657,7 +1691,7 @@ export class P2pProvider {
 
   public async deletePersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: Signer | string,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -5,8 +5,8 @@ import { webSockets } from '@libp2p/websockets'
 import { tcp } from '@libp2p/tcp'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
 import { bootstrap } from '@libp2p/bootstrap'
-import { identify } from '@libp2p/identify'
-import { EventTypes, KadDHT, kadDHT } from '@libp2p/kad-dht'
+import { identify, identifyPush } from '@libp2p/identify'
+import { EventTypes, KadDHT, kadDHT, passthroughMapper } from '@libp2p/kad-dht'
 import { ping } from '@libp2p/ping'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { lpStream, UnexpectedEOFError } from '@libp2p/utils'
@@ -56,6 +56,11 @@ import {
   isAgentSignature
 } from './BaseProvider.js'
 import { eciesencrypt } from '../../utils/eciesencrypt.js'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as multiFormatRaw from 'multiformats/codecs/raw'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+
 
 export const OCEAN_P2P_PROTOCOL = '/ocean/nodes/1.0.0'
 const OCEAN_DHT_PROTOCOL = '/ocean/nodes/1.0.0/kad/1.0.0'
@@ -262,8 +267,15 @@ export class P2pProvider {
       ],
       services: {
         identify: identify(),
+        identifyPush: identifyPush(),
         ping: ping(),
-        dht: kadDHT({ protocol: OCEAN_DHT_PROTOCOL, clientMode: true })
+        dht: kadDHT({
+          peerInfoMapper: passthroughMapper,
+          allowQueryWithZeroPeers: false,
+          kBucketSize: 20,
+          protocol: OCEAN_DHT_PROTOCOL,
+          clientMode: false // Servers can better query the network
+        })
       },
       // Without this we are blocking connection to plain ws - the bundler thinks we are in a browser.
       // This also applies to local nodes.
@@ -307,6 +319,41 @@ export class P2pProvider {
 
   private toUint8Array(chunk: Uint8Array | { subarray(): Uint8Array }): Uint8Array {
     return chunk instanceof Uint8Array ? chunk : chunk.subarray()
+  }
+
+  public async cidFromRawString(data: string) {
+    const hash = await sha256.digest(uint8ArrayFromString(data))
+    const cid = CID.create(1, multiFormatRaw.code, hash)
+    return cid
+  }
+
+  async getProvidersForString(
+    input: string,
+    timeout?: number
+  ): Promise<Array<{ id: string; multiaddrs: any[] }>> {
+    const node = await this.getOrCreateLibp2pNode()
+    const cid = await this.cidFromRawString(input)
+    const peersFound = []
+    const effectiveTimeout = timeout ?? 20000
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout)
+    try {
+      for await (const result of node.contentRouting.findProviders(cid, {
+        signal: controller.signal,
+        useCache: false,
+        useNetwork: true
+      })) {
+        peersFound.push(result)
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError') console.error(err)
+    } finally {
+      clearTimeout(timeoutId)
+    }
+    return peersFound.map((peer) => ({
+      id: peer.id.toString(),
+      multiaddrs: peer.multiaddrs
+    }))
   }
 
   private isDialable(ma: Multiaddr): boolean {

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -427,7 +427,7 @@ export class P2pProvider {
       if (!includeP2PCircuit && afterPFilter < beforePFilter) {
         // we have some p2p-circuit addrs, let's try them
         return this.getConnection(
-          { nodeId: peerId?.toString(), multiaddress: addrs },
+          { nodeId: peerId ? peerId.toString() : null, multiaddress: addrs },
           signal,
           true
         )
@@ -1360,7 +1360,7 @@ export class P2pProvider {
     signerOrAuthToken: signerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
-    if (typeof signerOrAuthToken === 'string' && !isAgentSignature(signerOrAuthToken)) {
+    if (typeof signerOrAuthToken === 'string') {
       throw new Error(
         'validateDdo requires a Signer or AgentSignature (nonce/signature).'
       )
@@ -1487,7 +1487,7 @@ export class P2pProvider {
     page?: number,
     signal?: AbortSignal
   ): Promise<NodeLogEntry[]> {
-    if (typeof signerOrAuthToken === 'string' && !isAgentSignature(signerOrAuthToken)) {
+    if (typeof signerOrAuthToken === 'string') {
       throw new Error(
         'downloadNodeLogs requires a Signer or AgentSignature (nonce/signature).'
       )

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -61,7 +61,6 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import * as multiFormatRaw from 'multiformats/codecs/raw'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 
-
 export const OCEAN_P2P_PROTOCOL = '/ocean/nodes/1.0.0'
 const OCEAN_DHT_PROTOCOL = '/ocean/nodes/1.0.0/kad/1.0.0'
 const DEFAULT_MAX_RETRIES = 5

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -46,7 +46,7 @@ import {
   NodeP2P,
   signerOrAuthTokenOrSignature
 } from '../../@types/index.js'
-import { PROTOCOL_COMMANDS, NodeLogsParams, NodeLogEntry } from '../../@types/Provider.js'
+import { PROTOCOL_COMMANDS, NodeLogEntry } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
 import { signRequest } from '../../utils/SignatureUtils.js'
 import {
@@ -481,6 +481,26 @@ export class P2pProvider {
     return getAuthorization(s)
   }
 
+  private async getSignedCommandParams(
+    nodeUri: OceanNode,
+    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    command: string,
+    signal?: AbortSignal
+  ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
+    if (isAgentSignature(signerOrAuthToken)) {
+      return {
+        consumerAddress: signerOrAuthToken.consumerAddress,
+        nonce: signerOrAuthToken.nonce,
+        signature: signerOrAuthToken.signature
+      }
+    }
+    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
+    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
+    const signature = await this.getSignature(signerOrAuthToken, nonce, command)
+    if (!signature) throw new Error(`Could not sign command ${command}.`)
+    return { consumerAddress, nonce, signature }
+  }
+
   private async dialAndStream(
     nodeUri: OceanNode,
     payload: Record<string, any>,
@@ -744,13 +764,12 @@ export class P2pProvider {
     _policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.ENCRYPT)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.ENCRYPT,
+      signal
+    )
     const result = await this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.ENCRYPT,
@@ -916,13 +935,11 @@ export class P2pProvider {
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<DownloadResponse> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress)) + 1).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.DOWNLOAD)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.DOWNLOAD
+    )
 
     const payload: Record<string, any> = {
       command: PROTOCOL_COMMANDS.DOWNLOAD,
@@ -1002,14 +1019,12 @@ export class P2pProvider {
     queueMaxWaitTime?: number,
     dockerRegistryAuth?: dockerRegistryAuth
   ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_START)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_START,
+      signal
+    )
 
     const body: Record<string, any> = {
       environment: computeEnv,
@@ -1070,18 +1085,12 @@ export class P2pProvider {
     queueMaxWaitTime?: number,
     dockerRegistryAuth?: dockerRegistryAuth
   ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(
-          signerOrAuthToken,
-          nonce,
-          PROTOCOL_COMMANDS.FREE_COMPUTE_START
-        )
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.FREE_COMPUTE_START,
+      signal
+    )
 
     const body: Record<string, any> = {
       environment: computeEnv,
@@ -1140,17 +1149,12 @@ export class P2pProvider {
       )
     }
 
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(
-          signerOrAuthToken,
-          nonce,
-          PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS
-        )
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS,
+      signal
+    )
     return this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS,
@@ -1170,14 +1174,12 @@ export class P2pProvider {
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.COMPUTE_STOP)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.COMPUTE_STOP,
+      signal
+    )
 
     const body: Record<string, any> = { jobId, consumerAddress, nonce, signature }
     if (agreementId) body.agreementId = agreementId
@@ -1238,17 +1240,13 @@ export class P2pProvider {
     if (typeof signerOrAuthToken === 'string') {
       payload.authorization = signerOrAuthToken
     } else {
-      const nonce = isAgentSignature(signerOrAuthToken)
-        ? signerOrAuthToken.nonce
-        : ((await this.getNonce(nodeUri, consumerAddress)) + 1).toString()
+      const { nonce, signature } = await this.getSignedCommandParams(
+        nodeUri,
+        signerOrAuthToken,
+        PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
+      )
       payload.nonce = nonce
-      payload.signature = isAgentSignature(signerOrAuthToken)
-        ? signerOrAuthToken.signature
-        : await this.getSignature(
-            signerOrAuthToken,
-            nonce,
-            PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
-          )
+      payload.signature = signature
     }
 
     const { lp, firstBytes } = await this.dialAndStream(nodeUri, payload)
@@ -1360,22 +1358,20 @@ export class P2pProvider {
     signerOrAuthToken: signerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
-    if (typeof signerOrAuthToken === 'string') {
-      throw new Error(
-        'validateDdo requires a Signer or AgentSignature (nonce/signature).'
-      )
-    }
-    const publisherAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, publisherAddress, signal)) + 1).toString()
-    const sig = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.VALIDATE_DDO)
+    const {
+      consumerAddress: publisherAddress,
+      nonce,
+      signature
+    } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.VALIDATE_DDO,
+      signal
+    )
     const result = await this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.VALIDATE_DDO,
-      { ddo, publisherAddress, nonce, signature: sig },
+      { ddo, publisherAddress, nonce, signature },
       null,
       signal
     )
@@ -1487,18 +1483,12 @@ export class P2pProvider {
     page?: number,
     signal?: AbortSignal
   ): Promise<NodeLogEntry[]> {
-    if (typeof signerOrAuthToken === 'string') {
-      throw new Error(
-        'downloadNodeLogs requires a Signer or AgentSignature (nonce/signature).'
-      )
-    }
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.nonce
-      : ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = isAgentSignature(signerOrAuthToken)
-      ? signerOrAuthToken.signature
-      : await this.getSignature(signerOrAuthToken, nonce, PROTOCOL_COMMANDS.GET_LOGS)
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.GET_LOGS,
+      signal
+    )
 
     const body: Record<string, any> = {
       startTime,
@@ -1549,25 +1539,12 @@ export class P2pProvider {
     command: string,
     signal?: AbortSignal
   ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
-    if (isAgentSignature(signerOrAuthToken)) {
-      return {
-        consumerAddress: signerOrAuthToken.consumerAddress,
-        nonce: signerOrAuthToken.nonce,
-        signature: signerOrAuthToken.signature
-      }
-    }
     if (typeof signerOrAuthToken === 'string') {
       throw new Error(
         'Persistent storage operations require a Signer or AgentSignature (nonce/signature).'
       )
     }
-    const consumerAddress = await this.getConsumerAddress(signerOrAuthToken)
-    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
-    const signature = await this.getSignature(signerOrAuthToken, nonce, command)
-    if (!signature) {
-      throw new Error('Could not sign persistent storage request.')
-    }
-    return { consumerAddress, nonce, signature }
+    return this.getSignedCommandParams(nodeUri, signerOrAuthToken, command, signal)
   }
 
   public async createPersistentStorageBucket(

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -329,28 +329,23 @@ export class P2pProvider {
 
   async getProvidersForString(
     input: string,
-    timeout?: number,
+    signal?: AbortSignal,
     maxResults?: number
   ): Promise<Array<{ id: string; multiaddrs: any[] }>> {
     const node = await this.getOrCreateLibp2pNode()
     const cid = await this.cidFromRawString(input)
     const peersFound = []
-    const effectiveTimeout = timeout ?? 20000
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout)
     try {
       for await (const result of node.contentRouting.findProviders(cid, {
-        signal: controller.signal,
         useCache: false,
-        useNetwork: true
+        useNetwork: true,
+        signal
       })) {
         peersFound.push(result)
         if (maxResults !== undefined && peersFound.length >= maxResults) break
       }
     } catch (err) {
       if (err.name !== 'AbortError') console.error(err)
-    } finally {
-      clearTimeout(timeoutId)
     }
     return peersFound.map((peer) => ({
       id: peer.id.toString(),
@@ -453,8 +448,8 @@ export class P2pProvider {
     // if there are no dialable ma, search dht
     if (!hasDialable() && peerId) {
       try {
-        const dhtSignal = AbortSignal.timeout(this.p2pConfig.dhtLookupTimeout ?? 60_000)
-        const peerInfo = await node.peerRouting.findPeer(peerId, { signal: dhtSignal })
+        // const dhtSignal = AbortSignal.timeout(this.p2pConfig.dhtLookupTimeout ?? 60_000)
+        const peerInfo = await node.peerRouting.findPeer(peerId, { signal })
         for (const ma of peerInfo.multiaddrs) addrs.push(ma)
         LoggerInstance.debug(
           `[P2P] ${peerId.toString()}: DHT returned ${peerInfo.multiaddrs.length} addrs`

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -337,11 +337,15 @@ export class P2pProvider {
     const node = await this.getOrCreateLibp2pNode()
     const hasDialable = () => addrs.some((ma) => this.isDialable(ma))
     let peerId: PeerId | null = null
-    let addrs: Multiaddr[] = []
+    const addrs: Multiaddr[] = []
     if (nodeUri && typeof nodeUri === 'string') {
       try {
         const addr = multiaddr(nodeUri)
         addrs.push(addr)
+        if (!peerId) {
+          const pidStr = this.peerIdFromMultiaddr(addr)
+          if (pidStr) peerId = peerIdFromString(pidStr)
+        }
       } catch {}
       try {
         if (!peerId) peerId = peerIdFromString(nodeUri)
@@ -402,33 +406,37 @@ export class P2pProvider {
         )
       } catch (err: any) {
         LoggerInstance.debug(
-          `[P2P] ${peerId.toString}: DHT findPeer failed: ${err.message}`
+          `[P2P] ${peerId.toString()}: DHT findPeer failed: ${err.message}`
         )
       }
     }
-    addrs = addrs.filter((ma) => this.isDialable(ma))
-    const beforePFilter = addrs.length
-    if (!includeP2PCircuit) addrs = addrs.filter((ma) => this.isNotP2PCircuit(ma))
+    let dialable = addrs.filter((ma) => this.isDialable(ma))
+    const beforePFilter = dialable.length
+    if (!includeP2PCircuit) dialable = dialable.filter((ma) => this.isNotP2PCircuit(ma))
 
-    const afterPFilter = addrs.length
+    const afterPFilter = dialable.length
 
-    if (addrs.length < 1) {
+    if (dialable.length < 1) {
       // try with p2p-circuits if available
       if (!includeP2PCircuit && afterPFilter < beforePFilter) {
         // we have some p2p-circuit addrs, let's try them
-        return this.getConnection(nodeUri, signal, true)
+        return this.getConnection(
+          { nodeId: peerId.toString(), multiaddress: addrs },
+          signal,
+          true
+        )
       }
       throw new Error('No valid multiaddresses, cannot connect')
     }
     // normalize all mas if we have peerId
     if (peerId) {
-      addrs = addrs.map((ma) => {
+      dialable = dialable.map((ma) => {
         const str = ma.toString()
         return str.includes('/p2p/') ? ma : multiaddr(`${str}/p2p/${peerId.toString()}`)
       })
     }
     try {
-      const conn = await node.dial(addrs, { signal })
+      const conn = await node.dial(dialable, { signal })
       LoggerInstance.debug(
         `[P2P] Dial SUCCESS via ${conn.remoteAddr} (limited=${conn.limits != null})`
       )

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -427,7 +427,7 @@ export class P2pProvider {
       if (!includeP2PCircuit && afterPFilter < beforePFilter) {
         // we have some p2p-circuit addrs, let's try them
         return this.getConnection(
-          { nodeId: peerId ? peerId.toString() : null, multiaddress: addrs },
+          { nodeId: peerId ? peerId.toString() : '', multiaddress: addrs } as NodeP2P,
           signal,
           true
         )

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -44,7 +44,7 @@ import {
   PersistentStorageObject,
   OceanNode,
   NodeP2P,
-  signerOrAuthTokenOrSignature
+  SignerOrAuthTokenOrSignature
 } from '../../@types/index.js'
 import { PROTOCOL_COMMANDS, NodeLogEntry } from '../../@types/Provider.js'
 import { type DDO, type ValidateMetadata } from '@oceanprotocol/ddo-js'
@@ -469,13 +469,12 @@ export class P2pProvider {
     }
   }
 
-  protected getConsumerAddress(s: signerOrAuthTokenOrSignature) {
-    if (isAgentSignature(s)) return s.consumerAddress
+  protected getConsumerAddress(s: SignerOrAuthTokenOrSignature) {
     return getConsumerAddress(s)
   }
 
   protected getSignature(
-    s: signerOrAuthTokenOrSignature,
+    s: SignerOrAuthTokenOrSignature,
     nonce: string,
     command: string
   ) {
@@ -487,13 +486,13 @@ export class P2pProvider {
     return endpoints?.nodePublicKey
   }
 
-  protected getAuthorization(s: signerOrAuthTokenOrSignature) {
+  protected getAuthorization(s: SignerOrAuthTokenOrSignature) {
     return getAuthorization(s)
   }
 
   private async getSignedCommandParams(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
   ): Promise<{ consumerAddress: string; nonce: string; signature: string | null }> {
@@ -560,7 +559,7 @@ export class P2pProvider {
     nodeUri: OceanNode,
     command: string,
     body: Record<string, any>,
-    signerOrAuthToken?: signerOrAuthTokenOrSignature | null,
+    signerOrAuthToken?: SignerOrAuthTokenOrSignature | null,
     signal?: AbortSignal,
     retrialNumber: number = 0,
     requestBody?: P2PRequestBodyStream
@@ -769,7 +768,7 @@ export class P2pProvider {
     data: any,
     chainId: number,
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     _policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
@@ -940,7 +939,7 @@ export class P2pProvider {
     fileIndex: number,
     transferTxId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<DownloadResponse> {
@@ -1012,7 +1011,7 @@ export class P2pProvider {
    */
   public async computeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -1081,7 +1080,7 @@ export class P2pProvider {
    */
   public async freeComputeStart(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     computeEnv: string,
     datasets: ComputeAsset[],
     algorithm: ComputeAlgorithm,
@@ -1143,7 +1142,7 @@ export class P2pProvider {
    */
   public async computeStreamableLogs(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
@@ -1179,7 +1178,7 @@ export class P2pProvider {
   public async computeStop(
     jobId: string,
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
@@ -1207,7 +1206,7 @@ export class P2pProvider {
    */
   public async computeStatus(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
     signal?: AbortSignal
@@ -1232,7 +1231,7 @@ export class P2pProvider {
    */
   public async getComputeResult(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     index: number,
     offset: number = 0
@@ -1281,7 +1280,7 @@ export class P2pProvider {
 
   public async getComputeResultUrl(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId: string,
     index: number
   ): Promise<string> {
@@ -1364,7 +1363,7 @@ export class P2pProvider {
   public async validateDdo(
     nodeUri: OceanNode,
     ddo: DDO,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     signal?: AbortSignal
   ): Promise<ValidateMetadata> {
     const {
@@ -1483,7 +1482,7 @@ export class P2pProvider {
    */
   public async downloadNodeLogs(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     startTime: string,
     endTime: string,
     maxLogs?: number,
@@ -1544,7 +1543,7 @@ export class P2pProvider {
 
   private async getPersistentStorageSignaturePayload(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
     signal?: AbortSignal
   ): Promise<{ consumerAddress: string; nonce: string; signature: string }> {
@@ -1558,7 +1557,7 @@ export class P2pProvider {
 
   public async createPersistentStorageBucket(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     payload: PersistentStorageCreateBucketRequest,
     signal?: AbortSignal
   ): Promise<{
@@ -1586,7 +1585,7 @@ export class P2pProvider {
 
   public async getPersistentStorageBuckets(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
@@ -1608,7 +1607,7 @@ export class P2pProvider {
 
   public async listPersistentStorageFiles(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
@@ -1630,7 +1629,7 @@ export class P2pProvider {
 
   public async getPersistentStorageFileObject(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal
@@ -1652,7 +1651,7 @@ export class P2pProvider {
 
   public async uploadPersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     content: P2PRequestBodyStream,
@@ -1677,7 +1676,7 @@ export class P2pProvider {
 
   public async deletePersistentStorageFile(
     nodeUri: OceanNode,
-    signerOrAuthToken: signerOrAuthTokenOrSignature,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     bucketId: string,
     fileName: string,
     signal?: AbortSignal


### PR DESCRIPTION
# PR Description

## Summary

This PR refactors provider endpoint typing and P2P connection handling to support richer node identifiers and more reliable dialing behavior.

The core change is introducing a unified `OceanNode` type (`string | NodeP2P | PeerId`) and propagating it through `BaseProvider` and `P2pProvider`, while also improving P2P address filtering and signature handling for string-based auth/signature inputs.

## What Changed

### 1) New shared endpoint types

In `src/@types/Provider.ts`:

- Added `NodeP2P`:
  - `nodeId: string`
  - `multiaddress?: Multiaddr[]`
- Added `OceanNode = string | NodeP2P | PeerId`
- Added required imports for `Multiaddr` and `PeerId`

This enables callers to pass:
- a plain URL/peer string,
- a structured P2P object, or
- a native libp2p `PeerId`.

### 2) Dialing p2p nodes filters out p2p-circuits, and only enables them in a retry, if needed
Fix DHT settings

### 3) Allow signatures to be passed directly (instead of just authToken/Signer flow)

 Use SignerOrAuthTokenOrSignature everywhere where auth is needed

### 4) Removed fetchNodeLogs in favor of expanding downloadNodeLogs