### PR TITLE
*Tx functions for all write fn  in contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "run": "ts-node",
     "release": "release-it --non-interactive",
     "changelog": "auto-changelog -p",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "mocha": "TS_NODE_PROJECT='./test/tsconfig.json' mocha --config=test/.mocharc.json --node-env=test --exit",
     "test": "npm run lint && npm run test:unit:cover && npm run test:integration:cover",

--- a/scripts/get-metadata.js
+++ b/scripts/get-metadata.js
@@ -3,11 +3,17 @@
 
 import { execSync } from 'child_process';
 import packageInfo from '../package.json' with { type: 'json' };
+let commitHash = 'unknown';
+try {
+  commitHash = execSync('git rev-parse HEAD').toString().trim();
+} catch (e) {
+  console.warn('Not a git repository, skipping commit hash metadata.');
+}
 process.stdout.write(
   JSON.stringify(
     {
       version: packageInfo.version,
-      commit: execSync('git rev-parse HEAD').toString().trim(),
+      commit: commitHash
     },
     null,
     2

--- a/src/@types/Assets.ts
+++ b/src/@types/Assets.ts
@@ -1,0 +1,1 @@
+export type { DDO } from '@oceanprotocol/ddo-js'

--- a/src/@types/NFT.ts
+++ b/src/@types/NFT.ts
@@ -1,4 +1,4 @@
-import { MetadataProof } from '@oceanprotocol/ddo-js'
+import type { MetadataProof } from '@oceanprotocol/ddo-js'
 
 export interface MetadataAndTokenURI {
   metaDataState: number

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,3 +1,4 @@
+export * from './Assets.js'
 export * from './Contracts.js'
 export * from './File.js'
 export * from './FileInfo.js'

--- a/src/contracts/AccessList.ts
+++ b/src/contracts/AccessList.ts
@@ -100,6 +100,7 @@ export class AccessListContract extends SmartContractWithAddress {
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
     const tx = await this.mintTx(user, tokenUri)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }

--- a/src/contracts/AccessList.ts
+++ b/src/contracts/AccessList.ts
@@ -99,17 +99,19 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenUri: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (estimateGas) {
-      const estGas = await this.contract.mint.estimateGas(user, tokenUri)
-      return <ReceiptOrEstimate<G>>estGas
-    }
-    const tx = await this.mintTx(user, tokenUri)
+    const estGas = await this.contract.mint.estimateGas(user, tokenUri)
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.mintTx(user, tokenUri, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async mintTx(user: string, tokenUri: string): Promise<TransactionRequest> {
-    const estGas = await this.contract.mint.estimateGas(user, tokenUri)
+  public async mintTx(
+    user: string,
+    tokenUri: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
+    const estGas = estimatedGas ?? (await this.contract.mint.estimateGas(user, tokenUri))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -130,20 +132,20 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenUris: Array<string>,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (estimateGas) {
-      const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
-      return <ReceiptOrEstimate<G>>estGas
-    }
-    const tx = await this.batchMintTx(users, tokenUris)
+    const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.batchMintTx(users, tokenUris, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async batchMintTx(
     users: Array<string>,
-    tokenUris: Array<string>
+    tokenUris: Array<string>,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
-    const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
+    const estGas =
+      estimatedGas ?? (await this.contract.batchMint.estimateGas(users, tokenUris))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -162,17 +164,18 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenId: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (estimateGas) {
-      const estGas = await this.contract.burn.estimateGas(tokenId)
-      return <ReceiptOrEstimate<G>>estGas
-    }
-    const tx = await this.burnTx(tokenId)
+    const estGas = await this.contract.burn.estimateGas(tokenId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.burnTx(tokenId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async burnTx(tokenId: number): Promise<TransactionRequest> {
-    const estGas = await this.contract.burn.estimateGas(tokenId)
+  public async burnTx(
+    tokenId: number,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
+    const estGas = estimatedGas ?? (await this.contract.burn.estimateGas(tokenId))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -191,17 +194,19 @@ export class AccessListContract extends SmartContractWithAddress {
     newOwner: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (estimateGas) {
-      const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
-      return <ReceiptOrEstimate<G>>estGas
-    }
-    const tx = await this.transferOwnershipTx(newOwner)
+    const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.transferOwnershipTx(newOwner, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async transferOwnershipTx(newOwner: string): Promise<TransactionRequest> {
-    const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
+  public async transferOwnershipTx(
+    newOwner: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
+    const estGas =
+      estimatedGas ?? (await this.contract.transferOwnership.estimateGas(newOwner))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -218,17 +223,15 @@ export class AccessListContract extends SmartContractWithAddress {
   public async renounceOwnership<G extends boolean = false>(
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (estimateGas) {
-      const estGas = await this.contract.renounceOwnership.estimateGas()
-      return <ReceiptOrEstimate<G>>estGas
-    }
-    const tx = await this.renounceOwnershipTx()
+    const estGas = await this.contract.renounceOwnership.estimateGas()
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.renounceOwnershipTx(estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async renounceOwnershipTx(): Promise<TransactionRequest> {
-    const estGas = await this.contract.renounceOwnership.estimateGas()
+  public async renounceOwnershipTx(estimatedGas?: bigint): Promise<TransactionRequest> {
+    const estGas = estimatedGas ?? (await this.contract.renounceOwnership.estimateGas())
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/AccessList.ts
+++ b/src/contracts/AccessList.ts
@@ -1,6 +1,10 @@
-import { Signer } from 'ethers'
+import { Signer, TransactionRequest } from 'ethers'
 import AccessList from '@oceanprotocol/contracts/artifacts/contracts/accesslists/AccessList.sol/AccessList.json'
-import { sendTx } from '../utils/ContractUtils.js'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 import { AbiItem, ReceiptOrEstimate } from '../@types/index.js'
 import { Config } from '../config/index.js'
 import { SmartContractWithAddress } from './SmartContractWithAddress.js'
@@ -95,17 +99,23 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenUri: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    if (estimateGas) {
+      const estGas = await this.contract.mint.estimateGas(user, tokenUri)
+      return <ReceiptOrEstimate<G>>estGas
+    }
+    const tx = await this.mintTx(user, tokenUri)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async mintTx(user: string, tokenUri: string): Promise<TransactionRequest> {
     const estGas = await this.contract.mint.estimateGas(user, tokenUri)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.mint,
-      user,
-      tokenUri
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.mint, [user, tokenUri], overrides)
   }
 
   /**
@@ -120,17 +130,26 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenUris: Array<string>,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    if (estimateGas) {
+      const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
+      return <ReceiptOrEstimate<G>>estGas
+    }
+    const tx = await this.batchMintTx(users, tokenUris)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async batchMintTx(
+    users: Array<string>,
+    tokenUris: Array<string>
+  ): Promise<TransactionRequest> {
     const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.batchMint,
-      users,
-      tokenUris
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.batchMint, [users, tokenUris], overrides)
   }
 
   /**
@@ -143,16 +162,23 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenId: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    if (estimateGas) {
+      const estGas = await this.contract.burn.estimateGas(tokenId)
+      return <ReceiptOrEstimate<G>>estGas
+    }
+    const tx = await this.burnTx(tokenId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async burnTx(tokenId: number): Promise<TransactionRequest> {
     const estGas = await this.contract.burn.estimateGas(tokenId)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.burn,
-      tokenId
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.burn, [tokenId], overrides)
   }
 
   /**
@@ -165,16 +191,23 @@ export class AccessListContract extends SmartContractWithAddress {
     newOwner: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    if (estimateGas) {
+      const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
+      return <ReceiptOrEstimate<G>>estGas
+    }
+    const tx = await this.transferOwnershipTx(newOwner)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async transferOwnershipTx(newOwner: string): Promise<TransactionRequest> {
     const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.transferOwnership,
-      newOwner
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.transferOwnership, [newOwner], overrides)
   }
 
   /**
@@ -185,14 +218,22 @@ export class AccessListContract extends SmartContractWithAddress {
   public async renounceOwnership<G extends boolean = false>(
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    if (estimateGas) {
+      const estGas = await this.contract.renounceOwnership.estimateGas()
+      return <ReceiptOrEstimate<G>>estGas
+    }
+    const tx = await this.renounceOwnershipTx()
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async renounceOwnershipTx(): Promise<TransactionRequest> {
     const estGas = await this.contract.renounceOwnership.estimateGas()
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.renounceOwnership
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.renounceOwnership, [], overrides)
   }
 }

--- a/src/contracts/AccessList.ts
+++ b/src/contracts/AccessList.ts
@@ -99,19 +99,13 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenUri: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.mint.estimateGas(user, tokenUri)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.mintTx(user, tokenUri, estGas)
+    const tx = await this.mintTx(user, tokenUri)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async mintTx(
-    user: string,
-    tokenUri: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const estGas = estimatedGas ?? (await this.contract.mint.estimateGas(user, tokenUri))
+  public async mintTx(user: string, tokenUri: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.mint.estimateGas(user, tokenUri)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -132,20 +126,17 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenUris: Array<string>,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.batchMintTx(users, tokenUris, estGas)
+    const tx = await this.batchMintTx(users, tokenUris)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async batchMintTx(
     users: Array<string>,
-    tokenUris: Array<string>,
-    estimatedGas?: bigint
+    tokenUris: Array<string>
   ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ?? (await this.contract.batchMint.estimateGas(users, tokenUris))
+    const estGas = await this.contract.batchMint.estimateGas(users, tokenUris)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -164,18 +155,14 @@ export class AccessListContract extends SmartContractWithAddress {
     tokenId: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.burn.estimateGas(tokenId)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.burnTx(tokenId, estGas)
+    const tx = await this.burnTx(tokenId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async burnTx(
-    tokenId: number,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const estGas = estimatedGas ?? (await this.contract.burn.estimateGas(tokenId))
+  public async burnTx(tokenId: number): Promise<TransactionRequest> {
+    const estGas = await this.contract.burn.estimateGas(tokenId)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -194,19 +181,14 @@ export class AccessListContract extends SmartContractWithAddress {
     newOwner: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.transferOwnershipTx(newOwner, estGas)
+    const tx = await this.transferOwnershipTx(newOwner)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async transferOwnershipTx(
-    newOwner: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ?? (await this.contract.transferOwnership.estimateGas(newOwner))
+  public async transferOwnershipTx(newOwner: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.transferOwnership.estimateGas(newOwner)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -223,15 +205,14 @@ export class AccessListContract extends SmartContractWithAddress {
   public async renounceOwnership<G extends boolean = false>(
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.renounceOwnership.estimateGas()
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.renounceOwnershipTx(estGas)
+    const tx = await this.renounceOwnershipTx()
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async renounceOwnershipTx(estimatedGas?: bigint): Promise<TransactionRequest> {
-    const estGas = estimatedGas ?? (await this.contract.renounceOwnership.estimateGas())
+  public async renounceOwnershipTx(): Promise<TransactionRequest> {
+    const estGas = await this.contract.renounceOwnership.estimateGas()
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/AccessListFactory.ts
+++ b/src/contracts/AccessListFactory.ts
@@ -4,8 +4,7 @@ import AccessListFactory from '@oceanprotocol/contracts/artifacts/contracts/acce
 import {
   buildTxOverrides,
   buildUnsignedTx,
-  sendPreparedTransaction,
-  getEventFromTx
+  sendPreparedTransaction
 } from '../utils/ContractUtils.js'
 import { ZERO_ADDRESS } from '../utils/Constants.js'
 import { AbiItem, ReceiptOrEstimate } from '../@types/index.js'
@@ -84,7 +83,8 @@ export class AccesslistFactory extends SmartContractWithAddress {
         tokenURI,
         transferable,
         owner,
-        user
+        user,
+        estGas
       )
       const tx = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
       if (!tx) {
@@ -93,8 +93,16 @@ export class AccesslistFactory extends SmartContractWithAddress {
         throw e
       }
       const trxReceipt = await tx.wait()
-      const events = getEventFromTx(trxReceipt, 'NewAccessList')
-      return events.args[0]
+      const parsedEvent = trxReceipt.logs
+        .map((log) => {
+          try {
+            return this.contract.interface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .find((event) => event?.name === 'NewAccessList')
+      return parsedEvent?.args?.[0]
     } catch (e) {
       console.error(`Creation of AccessList failed: ${e}`)
     }
@@ -106,7 +114,8 @@ export class AccesslistFactory extends SmartContractWithAddress {
     tokenURI: string[],
     transferable: boolean = false,
     owner: string,
-    user: string[]
+    user: string[],
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const normalized = this.normalizeDeployAccessListInput(
       nameAccessList,
@@ -116,14 +125,16 @@ export class AccesslistFactory extends SmartContractWithAddress {
       owner,
       user
     )
-    const estGas = await this.contract.deployAccessListContract.estimateGas(
-      normalized.nameAccessList,
-      normalized.symbolAccessList,
-      normalized.transferable,
-      normalized.owner,
-      normalized.user,
-      normalized.tokenURI
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.deployAccessListContract.estimateGas(
+        normalized.nameAccessList,
+        normalized.symbolAccessList,
+        normalized.transferable,
+        normalized.owner,
+        normalized.user,
+        normalized.tokenURI
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -194,7 +205,7 @@ export class AccesslistFactory extends SmartContractWithAddress {
 
     const estGas = await this.contract.changeTemplateAddress.estimateGas(templateAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const txReq = await this.changeTemplateAddressTx(owner, templateAddress)
+    const txReq = await this.changeTemplateAddressTx(owner, templateAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -202,7 +213,8 @@ export class AccesslistFactory extends SmartContractWithAddress {
 
   public async changeTemplateAddressTx(
     owner: string,
-    templateAddress: string
+    templateAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== owner) {
       throw new Error(`Caller is not Factory Owner`)
@@ -212,7 +224,9 @@ export class AccesslistFactory extends SmartContractWithAddress {
       throw new Error(`Template address cannot be ZERO address`)
     }
 
-    const estGas = await this.contract.changeTemplateAddress.estimateGas(templateAddress)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.changeTemplateAddress.estimateGas(templateAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/AccessListFactory.ts
+++ b/src/contracts/AccessListFactory.ts
@@ -58,7 +58,7 @@ export class AccesslistFactory extends SmartContractWithAddress {
     user: string[],
     estimateGas?: G
   ): Promise<G extends false ? string : BigNumberish> {
-    const normalized = this.normalizeDeployAccessListInput(
+    const txReq = await this.deployAccessListContractTx(
       nameAccessList,
       symbolAccessList,
       tokenURI,
@@ -66,26 +66,9 @@ export class AccesslistFactory extends SmartContractWithAddress {
       owner,
       user
     )
-    const estGas = await this.contract.deployAccessListContract.estimateGas(
-      normalized.nameAccessList,
-      normalized.symbolAccessList,
-      normalized.transferable,
-      normalized.owner,
-      normalized.user,
-      normalized.tokenURI
-    )
-    if (estimateGas) return <G extends false ? string : BigNumberish>estGas
+    if (estimateGas) return <G extends false ? string : BigNumberish>txReq.gasLimit
     // Invoke createToken function of the contract
     try {
-      const txReq = await this.deployAccessListContractTx(
-        nameAccessList,
-        symbolAccessList,
-        tokenURI,
-        transferable,
-        owner,
-        user,
-        estGas
-      )
       const tx = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
       if (!tx) {
         const e = 'Tx for deploying new access list was not processed on chain.'
@@ -114,8 +97,7 @@ export class AccesslistFactory extends SmartContractWithAddress {
     tokenURI: string[],
     transferable: boolean = false,
     owner: string,
-    user: string[],
-    estimatedGas?: bigint
+    user: string[]
   ): Promise<TransactionRequest> {
     const normalized = this.normalizeDeployAccessListInput(
       nameAccessList,
@@ -125,16 +107,14 @@ export class AccesslistFactory extends SmartContractWithAddress {
       owner,
       user
     )
-    const estGas =
-      estimatedGas ??
-      (await this.contract.deployAccessListContract.estimateGas(
-        normalized.nameAccessList,
-        normalized.symbolAccessList,
-        normalized.transferable,
-        normalized.owner,
-        normalized.user,
-        normalized.tokenURI
-      ))
+    const estGas = await this.contract.deployAccessListContract.estimateGas(
+      normalized.nameAccessList,
+      normalized.symbolAccessList,
+      normalized.transferable,
+      normalized.owner,
+      normalized.user,
+      normalized.tokenURI
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -195,17 +175,8 @@ export class AccesslistFactory extends SmartContractWithAddress {
     templateAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== owner) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-
-    if (templateAddress === ZERO_ADDRESS) {
-      throw new Error(`Template address cannot be ZERO address`)
-    }
-
-    const estGas = await this.contract.changeTemplateAddress.estimateGas(templateAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const txReq = await this.changeTemplateAddressTx(owner, templateAddress, estGas)
+    const txReq = await this.changeTemplateAddressTx(owner, templateAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>txReq.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -213,8 +184,7 @@ export class AccesslistFactory extends SmartContractWithAddress {
 
   public async changeTemplateAddressTx(
     owner: string,
-    templateAddress: string,
-    estimatedGas?: bigint
+    templateAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== owner) {
       throw new Error(`Caller is not Factory Owner`)
@@ -224,9 +194,7 @@ export class AccesslistFactory extends SmartContractWithAddress {
       throw new Error(`Template address cannot be ZERO address`)
     }
 
-    const estGas =
-      estimatedGas ??
-      (await this.contract.changeTemplateAddress.estimateGas(templateAddress))
+    const estGas = await this.contract.changeTemplateAddress.estimateGas(templateAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/AccessListFactory.ts
+++ b/src/contracts/AccessListFactory.ts
@@ -1,7 +1,12 @@
-import { BigNumberish, Signer } from 'ethers'
+import { BigNumberish, Signer, TransactionRequest } from 'ethers'
 import { Config } from '../config/index.js'
 import AccessListFactory from '@oceanprotocol/contracts/artifacts/contracts/accesslists/AccessListFactory.sol/AccessListFactory.json'
-import { sendTx, getEventFromTx } from '../utils/ContractUtils.js'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction,
+  getEventFromTx
+} from '../utils/ContractUtils.js'
 import { ZERO_ADDRESS } from '../utils/Constants.js'
 import { AbiItem, ReceiptOrEstimate } from '../@types/index.js'
 import { SmartContractWithAddress } from './SmartContractWithAddress.js'
@@ -54,34 +59,34 @@ export class AccesslistFactory extends SmartContractWithAddress {
     user: string[],
     estimateGas?: G
   ): Promise<G extends false ? string : BigNumberish> {
-    if (!nameAccessList || !symbolAccessList) {
-      const { name, symbol } = generateDtName()
-      nameAccessList = name
-      symbolAccessList = symbol
-    }
-    const estGas = await this.contract.deployAccessListContract.estimateGas(
+    const normalized = this.normalizeDeployAccessListInput(
       nameAccessList,
       symbolAccessList,
+      tokenURI,
       transferable,
       owner,
-      user,
-      tokenURI
+      user
+    )
+    const estGas = await this.contract.deployAccessListContract.estimateGas(
+      normalized.nameAccessList,
+      normalized.symbolAccessList,
+      normalized.transferable,
+      normalized.owner,
+      normalized.user,
+      normalized.tokenURI
     )
     if (estimateGas) return <G extends false ? string : BigNumberish>estGas
     // Invoke createToken function of the contract
     try {
-      const tx = await sendTx(
-        estGas,
-        this.getSignerAccordingSdk(),
-        this.config?.gasFeeMultiplier,
-        this.contract.deployAccessListContract,
+      const txReq = await this.deployAccessListContractTx(
         nameAccessList,
         symbolAccessList,
+        tokenURI,
         transferable,
         owner,
-        user,
-        tokenURI
+        user
       )
+      const tx = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
       if (!tx) {
         const e = 'Tx for deploying new access list was not processed on chain.'
         console.error(e)
@@ -93,6 +98,49 @@ export class AccesslistFactory extends SmartContractWithAddress {
     } catch (e) {
       console.error(`Creation of AccessList failed: ${e}`)
     }
+  }
+
+  public async deployAccessListContractTx(
+    nameAccessList: string,
+    symbolAccessList: string,
+    tokenURI: string[],
+    transferable: boolean = false,
+    owner: string,
+    user: string[]
+  ): Promise<TransactionRequest> {
+    const normalized = this.normalizeDeployAccessListInput(
+      nameAccessList,
+      symbolAccessList,
+      tokenURI,
+      transferable,
+      owner,
+      user
+    )
+    const estGas = await this.contract.deployAccessListContract.estimateGas(
+      normalized.nameAccessList,
+      normalized.symbolAccessList,
+      normalized.transferable,
+      normalized.owner,
+      normalized.user,
+      normalized.tokenURI
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.deployAccessListContract,
+      [
+        normalized.nameAccessList,
+        normalized.symbolAccessList,
+        normalized.transferable,
+        normalized.owner,
+        normalized.user,
+        normalized.tokenURI
+      ],
+      overrides
+    )
   }
 
   /**
@@ -146,14 +194,59 @@ export class AccesslistFactory extends SmartContractWithAddress {
 
     const estGas = await this.contract.changeTemplateAddress.estimateGas(templateAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.changeTemplateAddress,
-      templateAddress
-    )
+    const txReq = await this.changeTemplateAddressTx(owner, templateAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async changeTemplateAddressTx(
+    owner: string,
+    templateAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== owner) {
+      throw new Error(`Caller is not Factory Owner`)
+    }
+
+    if (templateAddress === ZERO_ADDRESS) {
+      throw new Error(`Template address cannot be ZERO address`)
+    }
+
+    const estGas = await this.contract.changeTemplateAddress.estimateGas(templateAddress)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.changeTemplateAddress,
+      [templateAddress],
+      overrides
+    )
+  }
+
+  private normalizeDeployAccessListInput(
+    nameAccessList: string,
+    symbolAccessList: string,
+    tokenURI: string[],
+    transferable: boolean,
+    owner: string,
+    user: string[]
+  ) {
+    let normalizedName = nameAccessList
+    let normalizedSymbol = symbolAccessList
+    if (!normalizedName || !normalizedSymbol) {
+      const { name, symbol } = generateDtName()
+      normalizedName = name
+      normalizedSymbol = symbol
+    }
+    return {
+      nameAccessList: normalizedName,
+      symbolAccessList: normalizedSymbol,
+      tokenURI,
+      transferable,
+      owner,
+      user
+    }
   }
 }

--- a/src/contracts/Datatoken.ts
+++ b/src/contracts/Datatoken.ts
@@ -68,6 +68,7 @@ export class Datatoken extends SmartContract {
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
     const tx = await this.approveTx(dtAddress, spender, amount)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -691,6 +692,7 @@ export class Datatoken extends SmartContract {
       orderParams,
       dispenserContract
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }

--- a/src/contracts/Datatoken.ts
+++ b/src/contracts/Datatoken.ts
@@ -67,13 +67,7 @@ export class Datatoken extends SmartContract {
     amount: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.approve.estimateGas(
-      spender,
-      await amountToUnits(null, null, amount, 18)
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.approveTx(dtAddress, spender, amount, estGas)
+    const tx = await this.approveTx(dtAddress, spender, amount)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -81,13 +75,11 @@ export class Datatoken extends SmartContract {
   public async approveTx(
     dtAddress: string,
     spender: string,
-    amount: string,
-    estimatedGas?: bigint
+    amount: string
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     const amountUnits = await amountToUnits(null, null, amount, 18)
-    const estGas =
-      estimatedGas ?? (await dtContract.approve.estimateGas(spender, amountUnits))
+    const estGas = await dtContract.approve.estimateGas(spender, amountUnits)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -110,34 +102,8 @@ export class Datatoken extends SmartContract {
     fixedRateParams: FreCreationParams,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
-    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
-      throw new Error(`User is not Datatoken Deployer`)
-    }
-    if (!fixedRateParams.allowedConsumer) fixedRateParams.allowedConsumer = ZERO_ADDRESS
-
-    const withMint = fixedRateParams.withMint === false ? 0 : 1
-
-    // should check DatatokenDeployer role using NFT level ..
-
-    const estGas = await dtContract.createFixedRate.estimateGas(
-      fixedRateParams.fixedRateAddress,
-      [
-        fixedRateParams.baseTokenAddress,
-        fixedRateParams.owner,
-        fixedRateParams.marketFeeCollector,
-        fixedRateParams.allowedConsumer
-      ],
-      [
-        fixedRateParams.baseTokenDecimals,
-        fixedRateParams.datatokenDecimals,
-        fixedRateParams.fixedRate,
-        fixedRateParams.marketFee,
-        withMint
-      ]
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.createFixedRateTx(dtAddress, address, fixedRateParams, estGas)
+    const tx = await this.createFixedRateTx(dtAddress, address, fixedRateParams)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -145,35 +111,32 @@ export class Datatoken extends SmartContract {
   public async createFixedRateTx(
     dtAddress: string,
     address: string,
-    fixedRateParams: FreCreationParams,
-    estimatedGas?: bigint
+    fixedRateParams: FreCreationParams
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
-    if (!fixedRateParams.allowedConsumer) fixedRateParams.allowedConsumer = ZERO_ADDRESS
-    const withMint = fixedRateParams.withMint === false ? 0 : 1
+    const safeAllowedConsumer = fixedRateParams.allowedConsumer || ZERO_ADDRESS
+    const safeWithMint = fixedRateParams.withMint === false ? 0 : 1
     const addressArgs = [
       fixedRateParams.baseTokenAddress,
       fixedRateParams.owner,
       fixedRateParams.marketFeeCollector,
-      fixedRateParams.allowedConsumer
+      safeAllowedConsumer
     ]
     const uintArgs = [
       fixedRateParams.baseTokenDecimals,
       fixedRateParams.datatokenDecimals,
       fixedRateParams.fixedRate,
       fixedRateParams.marketFee,
-      withMint
+      safeWithMint
     ]
-    const estGas =
-      estimatedGas ??
-      (await dtContract.createFixedRate.estimateGas(
-        fixedRateParams.fixedRateAddress,
-        addressArgs,
-        uintArgs
-      ))
+    const estGas = await dtContract.createFixedRate.estimateGas(
+      fixedRateParams.fixedRateAddress,
+      addressArgs,
+      uintArgs
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -202,32 +165,13 @@ export class Datatoken extends SmartContract {
     dispenserParams: DispenserParams,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
-      throw new Error(`User is not Datatoken Deployer`)
-    }
-
-    const dtContract = this.getContract(dtAddress)
-    if (!dispenserParams.allowedSwapper) dispenserParams.allowedSwapper = ZERO_ADDRESS
-
-    dispenserParams.withMint = dispenserParams.withMint !== false
-
-    // should check DatatokenDeployer role using NFT level ..
-
-    const estGas = await dtContract.createDispenser.estimateGas(
-      dispenserAddress,
-      dispenserParams.maxTokens,
-      dispenserParams.maxBalance,
-      dispenserParams.withMint,
-      dispenserParams.allowedSwapper
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
     const tx = await this.createDispenserTx(
       dtAddress,
       address,
       dispenserAddress,
-      dispenserParams,
-      estGas
+      dispenserParams
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -236,24 +180,21 @@ export class Datatoken extends SmartContract {
     dtAddress: string,
     address: string,
     dispenserAddress: string,
-    dispenserParams: DispenserParams,
-    estimatedGas?: bigint
+    dispenserParams: DispenserParams
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    if (!dispenserParams.allowedSwapper) dispenserParams.allowedSwapper = ZERO_ADDRESS
-    dispenserParams.withMint = dispenserParams.withMint !== false
-    const estGas =
-      estimatedGas ??
-      (await dtContract.createDispenser.estimateGas(
-        dispenserAddress,
-        dispenserParams.maxTokens,
-        dispenserParams.maxBalance,
-        dispenserParams.withMint,
-        dispenserParams.allowedSwapper
-      ))
+    const safeAllowedSwapper = dispenserParams.allowedSwapper || ZERO_ADDRESS
+    const safeWithMint = dispenserParams.withMint !== false
+    const estGas = await dtContract.createDispenser.estimateGas(
+      dispenserAddress,
+      dispenserParams.maxTokens,
+      dispenserParams.maxBalance,
+      safeWithMint,
+      safeAllowedSwapper
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -265,8 +206,8 @@ export class Datatoken extends SmartContract {
         dispenserAddress,
         dispenserParams.maxTokens,
         dispenserParams.maxBalance,
-        dispenserParams.withMint,
-        dispenserParams.allowedSwapper
+        safeWithMint,
+        safeAllowedSwapper
       ],
       overrides
     )
@@ -288,30 +229,17 @@ export class Datatoken extends SmartContract {
     toAddress?: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getPermissions(dtAddress, address)).minter !== true) {
-      throw new Error(`Caller is not Minter`)
-    }
-
-    const capAvailble = await this.getCap(dtAddress)
-    if (new Decimal(capAvailble).gte(amount)) {
-      const dtContract = this.getContract(dtAddress)
-      const amountUnits = await amountToUnits(null, null, amount, 18)
-      const estGas = await dtContract.mint.estimateGas(toAddress || address, amountUnits)
-      if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-      const tx = await this.mintTx(dtAddress, address, amount, toAddress, estGas)
-      const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-      return <ReceiptOrEstimate<G>>trxReceipt
-    } else {
-      throw new Error(`Mint amount exceeds cap available`)
-    }
+    const tx = await this.mintTx(dtAddress, address, amount, toAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async mintTx(
     dtAddress: string,
     address: string,
     amount: string,
-    toAddress?: string,
-    estimatedGas?: bigint
+    toAddress?: string
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     if ((await this.getPermissions(dtAddress, address)).minter !== true) {
@@ -323,8 +251,7 @@ export class Datatoken extends SmartContract {
     }
     const amountUnits = await amountToUnits(null, null, amount, 18)
     const recipient = toAddress || address
-    const estGas =
-      estimatedGas ?? (await dtContract.mint.estimateGas(recipient, amountUnits))
+    const estGas = await dtContract.mint.estimateGas(recipient, amountUnits)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -348,14 +275,8 @@ export class Datatoken extends SmartContract {
     minter: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
-      throw new Error(`Caller is not DatatokenDeployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    // Estimate gas cost for addMinter method
-    const estGas = await dtContract.addMinter.estimateGas(minter)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.addMinterTx(dtAddress, address, minter, estGas)
+    const tx = await this.addMinterTx(dtAddress, address, minter)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -363,14 +284,13 @@ export class Datatoken extends SmartContract {
   public async addMinterTx(
     dtAddress: string,
     address: string,
-    minter: string,
-    estimatedGas?: bigint
+    minter: string
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = estimatedGas ?? (await dtContract.addMinter.estimateGas(minter))
+    const estGas = await dtContract.addMinter.estimateGas(minter)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -394,13 +314,8 @@ export class Datatoken extends SmartContract {
     minter: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
-      throw new Error(`Caller is not DatatokenDeployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.removeMinter.estimateGas(minter)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.removeMinterTx(dtAddress, address, minter, estGas)
+    const tx = await this.removeMinterTx(dtAddress, address, minter)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -408,14 +323,13 @@ export class Datatoken extends SmartContract {
   public async removeMinterTx(
     dtAddress: string,
     address: string,
-    minter: string,
-    estimatedGas?: bigint
+    minter: string
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = estimatedGas ?? (await dtContract.removeMinter.estimateGas(minter))
+    const estGas = await dtContract.removeMinter.estimateGas(minter)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -439,13 +353,8 @@ export class Datatoken extends SmartContract {
     paymentManager: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
-      throw new Error(`Caller is not DatatokenDeployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.addPaymentManager.estimateGas(paymentManager)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.addPaymentManagerTx(dtAddress, address, paymentManager, estGas)
+    const tx = await this.addPaymentManagerTx(dtAddress, address, paymentManager)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -453,15 +362,13 @@ export class Datatoken extends SmartContract {
   public async addPaymentManagerTx(
     dtAddress: string,
     address: string,
-    paymentManager: string,
-    estimatedGas?: bigint
+    paymentManager: string
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.addPaymentManager.estimateGas(paymentManager))
+    const estGas = await dtContract.addPaymentManager.estimateGas(paymentManager)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -485,18 +392,8 @@ export class Datatoken extends SmartContract {
     paymentManager: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
-      throw new Error(`Caller is not DatatokenDeployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.removePaymentManager.estimateGas(paymentManager)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.removePaymentManagerTx(
-      dtAddress,
-      address,
-      paymentManager,
-      estGas
-    )
+    const tx = await this.removePaymentManagerTx(dtAddress, address, paymentManager)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -504,15 +401,13 @@ export class Datatoken extends SmartContract {
   public async removePaymentManagerTx(
     dtAddress: string,
     address: string,
-    paymentManager: string,
-    estimatedGas?: bigint
+    paymentManager: string
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.removePaymentManager.estimateGas(paymentManager))
+    const estGas = await dtContract.removePaymentManager.estimateGas(paymentManager)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -537,26 +432,8 @@ export class Datatoken extends SmartContract {
     paymentCollector: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
-    const isPaymentManager = (await this.getPermissions(dtAddress, address))
-      .paymentManager
-    const nftAddress = !isPaymentManager && (await this.getNFTAddress(dtAddress))
-    const isNftOwner = nftAddress && (await this.nft.getNftOwner(nftAddress)) === address
-    const nftPermissions =
-      nftAddress && !isNftOwner && (await this.nft.getNftPermissions(nftAddress, address))
-    const isDatatokenDeployer = nftPermissions?.deployERC20
-    if (!isPaymentManager && !isNftOwner && !isDatatokenDeployer) {
-      throw new Error(`Caller is not Fee Manager, owner or Datatoken Deployer`)
-    }
-
-    const estGas = await dtContract.setPaymentCollector.estimateGas(paymentCollector)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setPaymentCollectorTx(
-      dtAddress,
-      address,
-      paymentCollector,
-      estGas
-    )
+    const tx = await this.setPaymentCollectorTx(dtAddress, address, paymentCollector)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -564,8 +441,7 @@ export class Datatoken extends SmartContract {
   public async setPaymentCollectorTx(
     dtAddress: string,
     address: string,
-    paymentCollector: string,
-    estimatedGas?: bigint
+    paymentCollector: string
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     const isPaymentManager = (await this.getPermissions(dtAddress, address))
@@ -578,8 +454,7 @@ export class Datatoken extends SmartContract {
     if (!isPaymentManager && !isNftOwner && !isDatatokenDeployer) {
       throw new Error(`Caller is not Fee Manager, owner or Datatoken Deployer`)
     }
-    const estGas =
-      estimatedGas ?? (await dtContract.setPaymentCollector.estimateGas(paymentCollector))
+    const estGas = await dtContract.setPaymentCollector.estimateGas(paymentCollector)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -635,10 +510,8 @@ export class Datatoken extends SmartContract {
     amount: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.transfer.estimateGas(toAddress, amount)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.transferWeiTx(dtAddress, toAddress, amount, estGas)
+    const tx = await this.transferWeiTx(dtAddress, toAddress, amount)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -646,12 +519,10 @@ export class Datatoken extends SmartContract {
   public async transferWeiTx(
     dtAddress: string,
     toAddress: string,
-    amount: string,
-    estimatedGas?: bigint
+    amount: string
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.transfer.estimateGas(toAddress, amount))
+    const estGas = await dtContract.transfer.estimateGas(toAddress, amount)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -678,30 +549,14 @@ export class Datatoken extends SmartContract {
     consumeMarketFee?: ConsumeMarketFee,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress, this.abi)
-    if (!consumeMarketFee) {
-      consumeMarketFee = {
-        consumeMarketFeeAddress: ZERO_ADDRESS,
-        consumeMarketFeeToken: ZERO_ADDRESS,
-        consumeMarketFeeAmount: '0'
-      }
-    }
-
-    const estGas = await dtContract.startOrder.estimateGas(
-      consumer,
-      serviceIndex,
-      providerFees,
-      consumeMarketFee
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
     const tx = await this.startOrderTx(
       dtAddress,
       consumer,
       serviceIndex,
       providerFees,
-      consumeMarketFee,
-      estGas
+      consumeMarketFee
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -711,8 +566,7 @@ export class Datatoken extends SmartContract {
     consumer: string,
     serviceIndex: number,
     providerFees: ProviderFees,
-    consumeMarketFee?: ConsumeMarketFee,
-    estimatedGas?: bigint
+    consumeMarketFee?: ConsumeMarketFee
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress, this.abi)
     const safeConsumeMarketFee = consumeMarketFee || {
@@ -720,14 +574,12 @@ export class Datatoken extends SmartContract {
       consumeMarketFeeToken: ZERO_ADDRESS,
       consumeMarketFeeAmount: '0'
     }
-    const estGas =
-      estimatedGas ??
-      (await dtContract.startOrder.estimateGas(
-        consumer,
-        serviceIndex,
-        providerFees,
-        safeConsumeMarketFee
-      ))
+    const estGas = await dtContract.startOrder.estimateGas(
+      consumer,
+      serviceIndex,
+      providerFees,
+      safeConsumeMarketFee
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -756,11 +608,8 @@ export class Datatoken extends SmartContract {
     providerFees: ProviderFees,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
-
-    const estGas = await dtContract.reuseOrder.estimateGas(orderTxId, providerFees)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.reuseOrderTx(dtAddress, orderTxId, providerFees, estGas)
+    const tx = await this.reuseOrderTx(dtAddress, orderTxId, providerFees)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -768,12 +617,10 @@ export class Datatoken extends SmartContract {
   public async reuseOrderTx(
     dtAddress: string,
     orderTxId: string,
-    providerFees: ProviderFees,
-    estimatedGas?: bigint
+    providerFees: ProviderFees
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.reuseOrder.estimateGas(orderTxId, providerFees))
+    const estGas = await dtContract.reuseOrder.estimateGas(orderTxId, providerFees)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -796,16 +643,8 @@ export class Datatoken extends SmartContract {
     freParams: FreOrderParams,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress, this.abiEnterprise)
-
-    const freContractParams = await this.getFreOrderParams(freParams)
-
-    const estGas = await dtContract.buyFromFreAndOrder.estimateGas(
-      orderParams,
-      freContractParams
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.buyFromFreAndOrderTx(dtAddress, orderParams, freParams, estGas)
+    const tx = await this.buyFromFreAndOrderTx(dtAddress, orderParams, freParams)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -813,14 +652,14 @@ export class Datatoken extends SmartContract {
   public async buyFromFreAndOrderTx(
     dtAddress: string,
     orderParams: OrderParams,
-    freParams: FreOrderParams,
-    estimatedGas?: bigint
+    freParams: FreOrderParams
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress, this.abiEnterprise)
     const freContractParams = await this.getFreOrderParams(freParams)
-    const estGas =
-      estimatedGas ??
-      (await dtContract.buyFromFreAndOrder.estimateGas(orderParams, freContractParams))
+    const estGas = await dtContract.buyFromFreAndOrder.estimateGas(
+      orderParams,
+      freContractParams
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -847,18 +686,10 @@ export class Datatoken extends SmartContract {
     dispenserContract: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress, this.abiEnterprise)
-
-    const estGas = await dtContract.buyFromDispenserAndOrder.estimateGas(
-      orderParams,
-      dispenserContract
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
     const tx = await this.buyFromDispenserAndOrderTx(
       dtAddress,
       orderParams,
-      dispenserContract,
-      estGas
+      dispenserContract
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -867,16 +698,13 @@ export class Datatoken extends SmartContract {
   public async buyFromDispenserAndOrderTx(
     dtAddress: string,
     orderParams: OrderParams,
-    dispenserContract: string,
-    estimatedGas?: bigint
+    dispenserContract: string
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress, this.abiEnterprise)
-    const estGas =
-      estimatedGas ??
-      (await dtContract.buyFromDispenserAndOrder.estimateGas(
-        orderParams,
-        dispenserContract
-      ))
+    const estGas = await dtContract.buyFromDispenserAndOrder.estimateGas(
+      orderParams,
+      dispenserContract
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -904,14 +732,8 @@ export class Datatoken extends SmartContract {
     value: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
-      throw new Error(`User is not Datatoken Deployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    const valueHex = hexlify(toUtf8Bytes(value))
-    const estGas = await dtContract.setData.estimateGas(valueHex)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setDataTx(dtAddress, address, value, estGas)
+    const tx = await this.setDataTx(dtAddress, address, value)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -919,15 +741,14 @@ export class Datatoken extends SmartContract {
   public async setDataTx(
     dtAddress: string,
     address: string,
-    value: string,
-    estimatedGas?: bigint
+    value: string
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
     const dtContract = this.getContract(dtAddress)
     const valueHex = hexlify(toUtf8Bytes(value))
-    const estGas = estimatedGas ?? (await dtContract.setData.estimateGas(valueHex))
+    const estGas = await dtContract.setData.estimateGas(valueHex)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -949,27 +770,21 @@ export class Datatoken extends SmartContract {
     address: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.nft.getNftOwner(await this.getNFTAddress(dtAddress))) !== address) {
-      throw new Error('Caller is NOT Nft Owner')
-    }
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.cleanPermissions.estimateGas()
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.cleanPermissionsTx(dtAddress, address, estGas)
+    const tx = await this.cleanPermissionsTx(dtAddress, address)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async cleanPermissionsTx(
     dtAddress: string,
-    address: string,
-    estimatedGas?: bigint
+    address: string
   ): Promise<TransactionRequest> {
     if ((await this.nft.getNftOwner(await this.getNFTAddress(dtAddress))) !== address) {
       throw new Error('Caller is NOT Nft Owner')
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = estimatedGas ?? (await dtContract.cleanPermissions.estimateGas())
+    const estGas = await dtContract.cleanPermissions.estimateGas()
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1142,6 +957,25 @@ export class Datatoken extends SmartContract {
     address: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const tx = await this.setPublishingMarketFeeTx(
+      datatokenAddress,
+      publishMarketFeeAddress,
+      publishMarketFeeToken,
+      publishMarketFeeAmount,
+      address
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setPublishingMarketFeeTx(
+    datatokenAddress: string,
+    publishMarketFeeAddress: string,
+    publishMarketFeeToken: string,
+    publishMarketFeeAmount: string,
+    address: string
+  ): Promise<TransactionRequest> {
     const dtContract = this.getContract(datatokenAddress)
     const mktFeeAddress = (await dtContract.getPublishingMarketFee())[0]
     if (mktFeeAddress !== address) {
@@ -1152,39 +986,6 @@ export class Datatoken extends SmartContract {
       publishMarketFeeToken,
       publishMarketFeeAmount
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setPublishingMarketFeeTx(
-      datatokenAddress,
-      publishMarketFeeAddress,
-      publishMarketFeeToken,
-      publishMarketFeeAmount,
-      address,
-      estGas
-    )
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async setPublishingMarketFeeTx(
-    datatokenAddress: string,
-    publishMarketFeeAddress: string,
-    publishMarketFeeToken: string,
-    publishMarketFeeAmount: string,
-    address: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const dtContract = this.getContract(datatokenAddress)
-    const mktFeeAddress = (await dtContract.getPublishingMarketFee())[0]
-    if (mktFeeAddress !== address) {
-      throw new Error(`Caller is not the Publishing Market Fee Address`)
-    }
-    const estGas =
-      estimatedGas ??
-      (await dtContract.setPublishingMarketFee.estimateGas(
-        publishMarketFeeAddress,
-        publishMarketFeeToken,
-        publishMarketFeeAmount
-      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Datatoken.ts
+++ b/src/contracts/Datatoken.ts
@@ -70,10 +70,10 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.approve.estimateGas(
       spender,
-      amountToUnits(null, null, amount, 18)
+      await amountToUnits(null, null, amount, 18)
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.approveTx(dtAddress, spender, amount)
+    const tx = await this.approveTx(dtAddress, spender, amount, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -81,11 +81,13 @@ export class Datatoken extends SmartContract {
   public async approveTx(
     dtAddress: string,
     spender: string,
-    amount: string
+    amount: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     const amountUnits = await amountToUnits(null, null, amount, 18)
-    const estGas = await dtContract.approve.estimateGas(spender, amountUnits)
+    const estGas =
+      estimatedGas ?? (await dtContract.approve.estimateGas(spender, amountUnits))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -135,7 +137,7 @@ export class Datatoken extends SmartContract {
       ]
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.createFixedRateTx(dtAddress, address, fixedRateParams)
+    const tx = await this.createFixedRateTx(dtAddress, address, fixedRateParams, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -143,7 +145,8 @@ export class Datatoken extends SmartContract {
   public async createFixedRateTx(
     dtAddress: string,
     address: string,
-    fixedRateParams: FreCreationParams
+    fixedRateParams: FreCreationParams,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
@@ -164,11 +167,13 @@ export class Datatoken extends SmartContract {
       fixedRateParams.marketFee,
       withMint
     ]
-    const estGas = await dtContract.createFixedRate.estimateGas(
-      fixedRateParams.fixedRateAddress,
-      addressArgs,
-      uintArgs
-    )
+    const estGas =
+      estimatedGas ??
+      (await dtContract.createFixedRate.estimateGas(
+        fixedRateParams.fixedRateAddress,
+        addressArgs,
+        uintArgs
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -220,7 +225,8 @@ export class Datatoken extends SmartContract {
       dtAddress,
       address,
       dispenserAddress,
-      dispenserParams
+      dispenserParams,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -230,7 +236,8 @@ export class Datatoken extends SmartContract {
     dtAddress: string,
     address: string,
     dispenserAddress: string,
-    dispenserParams: DispenserParams
+    dispenserParams: DispenserParams,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
@@ -238,13 +245,15 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     if (!dispenserParams.allowedSwapper) dispenserParams.allowedSwapper = ZERO_ADDRESS
     dispenserParams.withMint = dispenserParams.withMint !== false
-    const estGas = await dtContract.createDispenser.estimateGas(
-      dispenserAddress,
-      dispenserParams.maxTokens,
-      dispenserParams.maxBalance,
-      dispenserParams.withMint,
-      dispenserParams.allowedSwapper
-    )
+    const estGas =
+      estimatedGas ??
+      (await dtContract.createDispenser.estimateGas(
+        dispenserAddress,
+        dispenserParams.maxTokens,
+        dispenserParams.maxBalance,
+        dispenserParams.withMint,
+        dispenserParams.allowedSwapper
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -289,7 +298,7 @@ export class Datatoken extends SmartContract {
       const amountUnits = await amountToUnits(null, null, amount, 18)
       const estGas = await dtContract.mint.estimateGas(toAddress || address, amountUnits)
       if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-      const tx = await this.mintTx(dtAddress, address, amount, toAddress)
+      const tx = await this.mintTx(dtAddress, address, amount, toAddress, estGas)
       const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
       return <ReceiptOrEstimate<G>>trxReceipt
     } else {
@@ -301,7 +310,8 @@ export class Datatoken extends SmartContract {
     dtAddress: string,
     address: string,
     amount: string,
-    toAddress?: string
+    toAddress?: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     if ((await this.getPermissions(dtAddress, address)).minter !== true) {
@@ -313,7 +323,8 @@ export class Datatoken extends SmartContract {
     }
     const amountUnits = await amountToUnits(null, null, amount, 18)
     const recipient = toAddress || address
-    const estGas = await dtContract.mint.estimateGas(recipient, amountUnits)
+    const estGas =
+      estimatedGas ?? (await dtContract.mint.estimateGas(recipient, amountUnits))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -344,7 +355,7 @@ export class Datatoken extends SmartContract {
     // Estimate gas cost for addMinter method
     const estGas = await dtContract.addMinter.estimateGas(minter)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.addMinterTx(dtAddress, address, minter)
+    const tx = await this.addMinterTx(dtAddress, address, minter, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -352,13 +363,14 @@ export class Datatoken extends SmartContract {
   public async addMinterTx(
     dtAddress: string,
     address: string,
-    minter: string
+    minter: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.addMinter.estimateGas(minter)
+    const estGas = estimatedGas ?? (await dtContract.addMinter.estimateGas(minter))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -388,7 +400,7 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.removeMinter.estimateGas(minter)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.removeMinterTx(dtAddress, address, minter)
+    const tx = await this.removeMinterTx(dtAddress, address, minter, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -396,13 +408,14 @@ export class Datatoken extends SmartContract {
   public async removeMinterTx(
     dtAddress: string,
     address: string,
-    minter: string
+    minter: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.removeMinter.estimateGas(minter)
+    const estGas = estimatedGas ?? (await dtContract.removeMinter.estimateGas(minter))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -432,7 +445,7 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.addPaymentManager.estimateGas(paymentManager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.addPaymentManagerTx(dtAddress, address, paymentManager)
+    const tx = await this.addPaymentManagerTx(dtAddress, address, paymentManager, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -440,13 +453,15 @@ export class Datatoken extends SmartContract {
   public async addPaymentManagerTx(
     dtAddress: string,
     address: string,
-    paymentManager: string
+    paymentManager: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.addPaymentManager.estimateGas(paymentManager)
+    const estGas =
+      estimatedGas ?? (await dtContract.addPaymentManager.estimateGas(paymentManager))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -476,7 +491,12 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.removePaymentManager.estimateGas(paymentManager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.removePaymentManagerTx(dtAddress, address, paymentManager)
+    const tx = await this.removePaymentManagerTx(
+      dtAddress,
+      address,
+      paymentManager,
+      estGas
+    )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -484,13 +504,15 @@ export class Datatoken extends SmartContract {
   public async removePaymentManagerTx(
     dtAddress: string,
     address: string,
-    paymentManager: string
+    paymentManager: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.removePaymentManager.estimateGas(paymentManager)
+    const estGas =
+      estimatedGas ?? (await dtContract.removePaymentManager.estimateGas(paymentManager))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -529,7 +551,12 @@ export class Datatoken extends SmartContract {
 
     const estGas = await dtContract.setPaymentCollector.estimateGas(paymentCollector)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setPaymentCollectorTx(dtAddress, address, paymentCollector)
+    const tx = await this.setPaymentCollectorTx(
+      dtAddress,
+      address,
+      paymentCollector,
+      estGas
+    )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -537,7 +564,8 @@ export class Datatoken extends SmartContract {
   public async setPaymentCollectorTx(
     dtAddress: string,
     address: string,
-    paymentCollector: string
+    paymentCollector: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
     const isPaymentManager = (await this.getPermissions(dtAddress, address))
@@ -550,7 +578,8 @@ export class Datatoken extends SmartContract {
     if (!isPaymentManager && !isNftOwner && !isDatatokenDeployer) {
       throw new Error(`Caller is not Fee Manager, owner or Datatoken Deployer`)
     }
-    const estGas = await dtContract.setPaymentCollector.estimateGas(paymentCollector)
+    const estGas =
+      estimatedGas ?? (await dtContract.setPaymentCollector.estimateGas(paymentCollector))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -609,7 +638,7 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.transfer.estimateGas(toAddress, amount)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.transferWeiTx(dtAddress, toAddress, amount)
+    const tx = await this.transferWeiTx(dtAddress, toAddress, amount, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -617,10 +646,12 @@ export class Datatoken extends SmartContract {
   public async transferWeiTx(
     dtAddress: string,
     toAddress: string,
-    amount: string
+    amount: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.transfer.estimateGas(toAddress, amount)
+    const estGas =
+      estimatedGas ?? (await dtContract.transfer.estimateGas(toAddress, amount))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -668,7 +699,8 @@ export class Datatoken extends SmartContract {
       consumer,
       serviceIndex,
       providerFees,
-      consumeMarketFee
+      consumeMarketFee,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -679,7 +711,8 @@ export class Datatoken extends SmartContract {
     consumer: string,
     serviceIndex: number,
     providerFees: ProviderFees,
-    consumeMarketFee?: ConsumeMarketFee
+    consumeMarketFee?: ConsumeMarketFee,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress, this.abi)
     const safeConsumeMarketFee = consumeMarketFee || {
@@ -687,12 +720,14 @@ export class Datatoken extends SmartContract {
       consumeMarketFeeToken: ZERO_ADDRESS,
       consumeMarketFeeAmount: '0'
     }
-    const estGas = await dtContract.startOrder.estimateGas(
-      consumer,
-      serviceIndex,
-      providerFees,
-      safeConsumeMarketFee
-    )
+    const estGas =
+      estimatedGas ??
+      (await dtContract.startOrder.estimateGas(
+        consumer,
+        serviceIndex,
+        providerFees,
+        safeConsumeMarketFee
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -725,7 +760,7 @@ export class Datatoken extends SmartContract {
 
     const estGas = await dtContract.reuseOrder.estimateGas(orderTxId, providerFees)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.reuseOrderTx(dtAddress, orderTxId, providerFees)
+    const tx = await this.reuseOrderTx(dtAddress, orderTxId, providerFees, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -733,10 +768,12 @@ export class Datatoken extends SmartContract {
   public async reuseOrderTx(
     dtAddress: string,
     orderTxId: string,
-    providerFees: ProviderFees
+    providerFees: ProviderFees,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.reuseOrder.estimateGas(orderTxId, providerFees)
+    const estGas =
+      estimatedGas ?? (await dtContract.reuseOrder.estimateGas(orderTxId, providerFees))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -768,7 +805,7 @@ export class Datatoken extends SmartContract {
       freContractParams
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.buyFromFreAndOrderTx(dtAddress, orderParams, freParams)
+    const tx = await this.buyFromFreAndOrderTx(dtAddress, orderParams, freParams, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -776,14 +813,14 @@ export class Datatoken extends SmartContract {
   public async buyFromFreAndOrderTx(
     dtAddress: string,
     orderParams: OrderParams,
-    freParams: FreOrderParams
+    freParams: FreOrderParams,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress, this.abiEnterprise)
     const freContractParams = await this.getFreOrderParams(freParams)
-    const estGas = await dtContract.buyFromFreAndOrder.estimateGas(
-      orderParams,
-      freContractParams
-    )
+    const estGas =
+      estimatedGas ??
+      (await dtContract.buyFromFreAndOrder.estimateGas(orderParams, freContractParams))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -820,7 +857,8 @@ export class Datatoken extends SmartContract {
     const tx = await this.buyFromDispenserAndOrderTx(
       dtAddress,
       orderParams,
-      dispenserContract
+      dispenserContract,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -829,13 +867,16 @@ export class Datatoken extends SmartContract {
   public async buyFromDispenserAndOrderTx(
     dtAddress: string,
     orderParams: OrderParams,
-    dispenserContract: string
+    dispenserContract: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(dtAddress, this.abiEnterprise)
-    const estGas = await dtContract.buyFromDispenserAndOrder.estimateGas(
-      orderParams,
-      dispenserContract
-    )
+    const estGas =
+      estimatedGas ??
+      (await dtContract.buyFromDispenserAndOrder.estimateGas(
+        orderParams,
+        dispenserContract
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -870,7 +911,7 @@ export class Datatoken extends SmartContract {
     const valueHex = hexlify(toUtf8Bytes(value))
     const estGas = await dtContract.setData.estimateGas(valueHex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setDataTx(dtAddress, address, value)
+    const tx = await this.setDataTx(dtAddress, address, value, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -878,14 +919,15 @@ export class Datatoken extends SmartContract {
   public async setDataTx(
     dtAddress: string,
     address: string,
-    value: string
+    value: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
     const dtContract = this.getContract(dtAddress)
     const valueHex = hexlify(toUtf8Bytes(value))
-    const estGas = await dtContract.setData.estimateGas(valueHex)
+    const estGas = estimatedGas ?? (await dtContract.setData.estimateGas(valueHex))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -913,20 +955,21 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.cleanPermissions.estimateGas()
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.cleanPermissionsTx(dtAddress, address)
+    const tx = await this.cleanPermissionsTx(dtAddress, address, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async cleanPermissionsTx(
     dtAddress: string,
-    address: string
+    address: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.nft.getNftOwner(await this.getNFTAddress(dtAddress))) !== address) {
       throw new Error('Caller is NOT Nft Owner')
     }
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.cleanPermissions.estimateGas()
+    const estGas = estimatedGas ?? (await dtContract.cleanPermissions.estimateGas())
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1115,7 +1158,8 @@ export class Datatoken extends SmartContract {
       publishMarketFeeAddress,
       publishMarketFeeToken,
       publishMarketFeeAmount,
-      address
+      address,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -1126,18 +1170,21 @@ export class Datatoken extends SmartContract {
     publishMarketFeeAddress: string,
     publishMarketFeeToken: string,
     publishMarketFeeAmount: string,
-    address: string
+    address: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const dtContract = this.getContract(datatokenAddress)
     const mktFeeAddress = (await dtContract.getPublishingMarketFee())[0]
     if (mktFeeAddress !== address) {
       throw new Error(`Caller is not the Publishing Market Fee Address`)
     }
-    const estGas = await dtContract.setPublishingMarketFee.estimateGas(
-      publishMarketFeeAddress,
-      publishMarketFeeToken,
-      publishMarketFeeAmount
-    )
+    const estGas =
+      estimatedGas ??
+      (await dtContract.setPublishingMarketFee.estimateGas(
+        publishMarketFeeAddress,
+        publishMarketFeeToken,
+        publishMarketFeeAmount
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Datatoken.ts
+++ b/src/contracts/Datatoken.ts
@@ -1,8 +1,13 @@
-import { hexlify, Signer, toUtf8Bytes } from 'ethers'
+import { TransactionRequest, hexlify, Signer, toUtf8Bytes } from 'ethers'
 import Decimal from 'decimal.js'
 import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template.sol/ERC20Template.json'
 import ERC20TemplateEnterprise from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20TemplateEnterprise.sol/ERC20TemplateEnterprise.json'
-import { amountToUnits, sendTx } from '../utils/ContractUtils.js'
+import {
+  amountToUnits,
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 import { ZERO_ADDRESS } from '../utils/Constants.js'
 import {
   AbiItem,
@@ -68,16 +73,25 @@ export class Datatoken extends SmartContract {
       amountToUnits(null, null, amount, 18)
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.approveTx(dtAddress, spender, amount)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async approveTx(
+    dtAddress: string,
+    spender: string,
+    amount: string
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress)
+    const amountUnits = await amountToUnits(null, null, amount, 18)
+    const estGas = await dtContract.approve.estimateGas(spender, amountUnits)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.approve,
-      spender,
-      amountToUnits(null, null, amount, 18)
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.approve, [spender, amountUnits], overrides)
   }
 
   /**
@@ -121,28 +135,50 @@ export class Datatoken extends SmartContract {
       ]
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.createFixedRateTx(dtAddress, address, fixedRateParams)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async createFixedRateTx(
+    dtAddress: string,
+    address: string,
+    fixedRateParams: FreCreationParams
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress)
+    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
+      throw new Error(`User is not Datatoken Deployer`)
+    }
+    if (!fixedRateParams.allowedConsumer) fixedRateParams.allowedConsumer = ZERO_ADDRESS
+    const withMint = fixedRateParams.withMint === false ? 0 : 1
+    const addressArgs = [
+      fixedRateParams.baseTokenAddress,
+      fixedRateParams.owner,
+      fixedRateParams.marketFeeCollector,
+      fixedRateParams.allowedConsumer
+    ]
+    const uintArgs = [
+      fixedRateParams.baseTokenDecimals,
+      fixedRateParams.datatokenDecimals,
+      fixedRateParams.fixedRate,
+      fixedRateParams.marketFee,
+      withMint
+    ]
+    const estGas = await dtContract.createFixedRate.estimateGas(
+      fixedRateParams.fixedRateAddress,
+      addressArgs,
+      uintArgs
+    )
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.createFixedRate,
-      fixedRateParams.fixedRateAddress,
-      [
-        fixedRateParams.baseTokenAddress,
-        fixedRateParams.owner,
-        fixedRateParams.marketFeeCollector,
-        fixedRateParams.allowedConsumer
-      ],
-      [
-        fixedRateParams.baseTokenDecimals,
-        fixedRateParams.datatokenDecimals,
-        fixedRateParams.fixedRate,
-        fixedRateParams.marketFee,
-        withMint
-      ]
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      dtContract.createFixedRate,
+      [fixedRateParams.fixedRateAddress, addressArgs, uintArgs],
+      overrides
+    )
   }
 
   /**
@@ -180,19 +216,51 @@ export class Datatoken extends SmartContract {
       dispenserParams.allowedSwapper
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.createDispenserTx(
+      dtAddress,
+      address,
+      dispenserAddress,
+      dispenserParams
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.createDispenser,
+  public async createDispenserTx(
+    dtAddress: string,
+    address: string,
+    dispenserAddress: string,
+    dispenserParams: DispenserParams
+  ): Promise<TransactionRequest> {
+    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
+      throw new Error(`User is not Datatoken Deployer`)
+    }
+    const dtContract = this.getContract(dtAddress)
+    if (!dispenserParams.allowedSwapper) dispenserParams.allowedSwapper = ZERO_ADDRESS
+    dispenserParams.withMint = dispenserParams.withMint !== false
+    const estGas = await dtContract.createDispenser.estimateGas(
       dispenserAddress,
       dispenserParams.maxTokens,
       dispenserParams.maxBalance,
       dispenserParams.withMint,
       dispenserParams.allowedSwapper
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      dtContract.createDispenser,
+      [
+        dispenserAddress,
+        dispenserParams.maxTokens,
+        dispenserParams.maxBalance,
+        dispenserParams.withMint,
+        dispenserParams.allowedSwapper
+      ],
+      overrides
+    )
   }
 
   /**
@@ -211,31 +279,47 @@ export class Datatoken extends SmartContract {
     toAddress?: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
     if ((await this.getPermissions(dtAddress, address)).minter !== true) {
       throw new Error(`Caller is not Minter`)
     }
 
     const capAvailble = await this.getCap(dtAddress)
     if (new Decimal(capAvailble).gte(amount)) {
-      const estGas = await dtContract.mint.estimateGas(
-        toAddress || address,
-        amountToUnits(null, null, amount, 18)
-      )
+      const dtContract = this.getContract(dtAddress)
+      const amountUnits = await amountToUnits(null, null, amount, 18)
+      const estGas = await dtContract.mint.estimateGas(toAddress || address, amountUnits)
       if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-      const trxReceipt = await sendTx(
-        estGas,
-        this.getSignerAccordingSdk(),
-        this.config?.gasFeeMultiplier,
-        dtContract.mint,
-        toAddress || address,
-        amountToUnits(null, null, amount, 18)
-      )
+      const tx = await this.mintTx(dtAddress, address, amount, toAddress)
+      const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
       return <ReceiptOrEstimate<G>>trxReceipt
     } else {
       throw new Error(`Mint amount exceeds cap available`)
     }
+  }
+
+  public async mintTx(
+    dtAddress: string,
+    address: string,
+    amount: string,
+    toAddress?: string
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress)
+    if ((await this.getPermissions(dtAddress, address)).minter !== true) {
+      throw new Error(`Caller is not Minter`)
+    }
+    const capAvailble = await this.getCap(dtAddress)
+    if (!new Decimal(capAvailble).gte(amount)) {
+      throw new Error(`Mint amount exceeds cap available`)
+    }
+    const amountUnits = await amountToUnits(null, null, amount, 18)
+    const recipient = toAddress || address
+    const estGas = await dtContract.mint.estimateGas(recipient, amountUnits)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(dtContract.mint, [recipient, amountUnits], overrides)
   }
 
   /**
@@ -253,23 +337,34 @@ export class Datatoken extends SmartContract {
     minter: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
+    const dtContract = this.getContract(dtAddress)
     // Estimate gas cost for addMinter method
     const estGas = await dtContract.addMinter.estimateGas(minter)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.addMinterTx(dtAddress, address, minter)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async addMinterTx(
+    dtAddress: string,
+    address: string,
+    minter: string
+  ): Promise<TransactionRequest> {
+    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
+      throw new Error(`Caller is not DatatokenDeployer`)
+    }
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.addMinter.estimateGas(minter)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.addMinter,
-      minter
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.addMinter, [minter], overrides)
   }
 
   /**
@@ -287,23 +382,33 @@ export class Datatoken extends SmartContract {
     minter: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
-
+    const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.removeMinter.estimateGas(minter)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.removeMinterTx(dtAddress, address, minter)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async removeMinterTx(
+    dtAddress: string,
+    address: string,
+    minter: string
+  ): Promise<TransactionRequest> {
+    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
+      throw new Error(`Caller is not DatatokenDeployer`)
+    }
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.removeMinter.estimateGas(minter)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.removeMinter,
-      minter
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.removeMinter, [minter], overrides)
   }
 
   /**
@@ -321,23 +426,33 @@ export class Datatoken extends SmartContract {
     paymentManager: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
-
+    const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.addPaymentManager.estimateGas(paymentManager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.addPaymentManagerTx(dtAddress, address, paymentManager)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async addPaymentManagerTx(
+    dtAddress: string,
+    address: string,
+    paymentManager: string
+  ): Promise<TransactionRequest> {
+    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
+      throw new Error(`Caller is not DatatokenDeployer`)
+    }
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.addPaymentManager.estimateGas(paymentManager)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.addPaymentManager,
-      paymentManager
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.addPaymentManager, [paymentManager], overrides)
   }
 
   /**
@@ -355,23 +470,33 @@ export class Datatoken extends SmartContract {
     paymentManager: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const dtContract = this.getContract(dtAddress)
     if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
     }
-
+    const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.removePaymentManager.estimateGas(paymentManager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.removePaymentManagerTx(dtAddress, address, paymentManager)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async removePaymentManagerTx(
+    dtAddress: string,
+    address: string,
+    paymentManager: string
+  ): Promise<TransactionRequest> {
+    if ((await this.isDatatokenDeployer(dtAddress, address)) !== true) {
+      throw new Error(`Caller is not DatatokenDeployer`)
+    }
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.removePaymentManager.estimateGas(paymentManager)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.removePaymentManager,
-      paymentManager
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.removePaymentManager, [paymentManager], overrides)
   }
 
   /**
@@ -404,15 +529,34 @@ export class Datatoken extends SmartContract {
 
     const estGas = await dtContract.setPaymentCollector.estimateGas(paymentCollector)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.setPaymentCollectorTx(dtAddress, address, paymentCollector)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async setPaymentCollectorTx(
+    dtAddress: string,
+    address: string,
+    paymentCollector: string
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress)
+    const isPaymentManager = (await this.getPermissions(dtAddress, address))
+      .paymentManager
+    const nftAddress = !isPaymentManager && (await this.getNFTAddress(dtAddress))
+    const isNftOwner = nftAddress && (await this.nft.getNftOwner(nftAddress)) === address
+    const nftPermissions =
+      nftAddress && !isNftOwner && (await this.nft.getNftPermissions(nftAddress, address))
+    const isDatatokenDeployer = nftPermissions?.deployERC20
+    if (!isPaymentManager && !isNftOwner && !isDatatokenDeployer) {
+      throw new Error(`Caller is not Fee Manager, owner or Datatoken Deployer`)
+    }
+    const estGas = await dtContract.setPaymentCollector.estimateGas(paymentCollector)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.setPaymentCollector,
-      paymentCollector
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.setPaymentCollector, [paymentCollector], overrides)
   }
 
   /**
@@ -465,16 +609,24 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.transfer.estimateGas(toAddress, amount)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.transferWeiTx(dtAddress, toAddress, amount)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async transferWeiTx(
+    dtAddress: string,
+    toAddress: string,
+    amount: string
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.transfer.estimateGas(toAddress, amount)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.transfer,
-      toAddress,
-      amount
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.transfer, [toAddress, amount], overrides)
   }
 
   /**
@@ -511,17 +663,46 @@ export class Datatoken extends SmartContract {
       consumeMarketFee
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.startOrder,
+    const tx = await this.startOrderTx(
+      dtAddress,
       consumer,
       serviceIndex,
       providerFees,
       consumeMarketFee
     )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async startOrderTx(
+    dtAddress: string,
+    consumer: string,
+    serviceIndex: number,
+    providerFees: ProviderFees,
+    consumeMarketFee?: ConsumeMarketFee
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress, this.abi)
+    const safeConsumeMarketFee = consumeMarketFee || {
+      consumeMarketFeeAddress: ZERO_ADDRESS,
+      consumeMarketFeeToken: ZERO_ADDRESS,
+      consumeMarketFeeAmount: '0'
+    }
+    const estGas = await dtContract.startOrder.estimateGas(
+      consumer,
+      serviceIndex,
+      providerFees,
+      safeConsumeMarketFee
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      dtContract.startOrder,
+      [consumer, serviceIndex, providerFees, safeConsumeMarketFee],
+      overrides
+    )
   }
 
   /**
@@ -544,15 +725,24 @@ export class Datatoken extends SmartContract {
 
     const estGas = await dtContract.reuseOrder.estimateGas(orderTxId, providerFees)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.reuseOrderTx(dtAddress, orderTxId, providerFees)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async reuseOrderTx(
+    dtAddress: string,
+    orderTxId: string,
+    providerFees: ProviderFees
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.reuseOrder.estimateGas(orderTxId, providerFees)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.reuseOrder,
-      orderTxId,
-      providerFees
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.reuseOrder, [orderTxId, providerFees], overrides)
   }
 
   /**
@@ -578,15 +768,32 @@ export class Datatoken extends SmartContract {
       freContractParams
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.buyFromFreAndOrder,
+    const tx = await this.buyFromFreAndOrderTx(dtAddress, orderParams, freParams)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async buyFromFreAndOrderTx(
+    dtAddress: string,
+    orderParams: OrderParams,
+    freParams: FreOrderParams
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress, this.abiEnterprise)
+    const freContractParams = await this.getFreOrderParams(freParams)
+    const estGas = await dtContract.buyFromFreAndOrder.estimateGas(
       orderParams,
       freContractParams
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      dtContract.buyFromFreAndOrder,
+      [orderParams, freContractParams],
+      overrides
+    )
   }
 
   /**
@@ -610,15 +817,35 @@ export class Datatoken extends SmartContract {
       dispenserContract
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.buyFromDispenserAndOrder,
+    const tx = await this.buyFromDispenserAndOrderTx(
+      dtAddress,
       orderParams,
       dispenserContract
     )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async buyFromDispenserAndOrderTx(
+    dtAddress: string,
+    orderParams: OrderParams,
+    dispenserContract: string
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(dtAddress, this.abiEnterprise)
+    const estGas = await dtContract.buyFromDispenserAndOrder.estimateGas(
+      orderParams,
+      dispenserContract
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      dtContract.buyFromDispenserAndOrder,
+      [orderParams, dispenserContract],
+      overrides
+    )
   }
 
   /** setData
@@ -639,22 +866,32 @@ export class Datatoken extends SmartContract {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
-
     const dtContract = this.getContract(dtAddress)
     const valueHex = hexlify(toUtf8Bytes(value))
-
     const estGas = await dtContract.setData.estimateGas(valueHex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.setDataTx(dtAddress, address, value)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async setDataTx(
+    dtAddress: string,
+    address: string,
+    value: string
+  ): Promise<TransactionRequest> {
+    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
+      throw new Error(`User is not Datatoken Deployer`)
+    }
+    const dtContract = this.getContract(dtAddress)
+    const valueHex = hexlify(toUtf8Bytes(value))
+    const estGas = await dtContract.setData.estimateGas(valueHex)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.setData,
-      valueHex
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.setData, [valueHex], overrides)
   }
 
   /**
@@ -676,15 +913,26 @@ export class Datatoken extends SmartContract {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.cleanPermissions.estimateGas()
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.cleanPermissionsTx(dtAddress, address)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async cleanPermissionsTx(
+    dtAddress: string,
+    address: string
+  ): Promise<TransactionRequest> {
+    if ((await this.nft.getNftOwner(await this.getNFTAddress(dtAddress))) !== address) {
+      throw new Error('Caller is NOT Nft Owner')
+    }
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.cleanPermissions.estimateGas()
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.cleanPermissions
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.cleanPermissions, [], overrides)
   }
 
   /**
@@ -862,17 +1110,44 @@ export class Datatoken extends SmartContract {
       publishMarketFeeAmount
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.setPublishingMarketFee,
+    const tx = await this.setPublishingMarketFeeTx(
+      datatokenAddress,
+      publishMarketFeeAddress,
+      publishMarketFeeToken,
+      publishMarketFeeAmount,
+      address
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setPublishingMarketFeeTx(
+    datatokenAddress: string,
+    publishMarketFeeAddress: string,
+    publishMarketFeeToken: string,
+    publishMarketFeeAmount: string,
+    address: string
+  ): Promise<TransactionRequest> {
+    const dtContract = this.getContract(datatokenAddress)
+    const mktFeeAddress = (await dtContract.getPublishingMarketFee())[0]
+    if (mktFeeAddress !== address) {
+      throw new Error(`Caller is not the Publishing Market Fee Address`)
+    }
+    const estGas = await dtContract.setPublishingMarketFee.estimateGas(
       publishMarketFeeAddress,
       publishMarketFeeToken,
       publishMarketFeeAmount
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      dtContract.setPublishingMarketFee,
+      [publishMarketFeeAddress, publishMarketFeeToken, publishMarketFeeAmount],
+      overrides
+    )
   }
 
   /**

--- a/src/contracts/Datatoken4.ts
+++ b/src/contracts/Datatoken4.ts
@@ -1,11 +1,15 @@
 /* eslint-disable lines-between-class-members */
 import { Datatoken } from './Datatoken.js'
-import { Signer } from 'ethers'
+import { Signer, TransactionRequest } from 'ethers'
 import ERC20Template4 from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template4.sol/ERC20Template4.json'
 import { AbiItem, ReceiptOrEstimate } from '../@types/index.js'
 import { AccessListContract } from './AccessList.js'
 import { Config } from '../config/index.js'
-import { sendTx } from '../utils/ContractUtils.js'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 
 export class Datatoken4 extends Datatoken {
   public accessList: AccessListContract
@@ -77,20 +81,31 @@ export class Datatoken4 extends Datatoken {
     if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
-
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.setAllowListContract.estimateGas(address)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.setAllowListContractTx(dtAddress, address, consumer)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async setAllowListContractTx(
+    dtAddress: string,
+    address: string,
+    consumer: string
+  ): Promise<TransactionRequest> {
+    if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
+      throw new Error(`User is not Datatoken Deployer`)
+    }
+
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.setAllowListContract.estimateGas(address)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.setAllowListContract,
-      address
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.setAllowListContract, [address], overrides)
   }
 
   /** setDenyListContract
@@ -111,20 +126,31 @@ export class Datatoken4 extends Datatoken {
     if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
-
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.setDenyListContract.estimateGas(address)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.setDenyListContractTx(dtAddress, address, consumer)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async setDenyListContractTx(
+    dtAddress: string,
+    address: string,
+    consumer: string
+  ): Promise<TransactionRequest> {
+    if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
+      throw new Error(`User is not Datatoken Deployer`)
+    }
+
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.setDenyListContract.estimateGas(address)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.setDenyListContract,
-      address
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.setDenyListContract, [address], overrides)
   }
   /** setFileObject
    * This function allows to set file object in ecnrypted format, only by datatoken deployer
@@ -147,15 +173,27 @@ export class Datatoken4 extends Datatoken {
     const estGas = await dtContract.setFilesObject.estimateGas(this.fileObject)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.setFileObjectTx(dtAddress, address)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setFileObjectTx(
+    dtAddress: string,
+    address: string
+  ): Promise<TransactionRequest> {
+    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
+      throw new Error(`User is not Datatoken Deployer`)
+    }
+
+    const dtContract = this.getContract(dtAddress)
+    const estGas = await dtContract.setFilesObject.estimateGas(this.fileObject)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      dtContract.setFilesObject,
-      this.fileObject
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(dtContract.setFilesObject, [this.fileObject], overrides)
   }
 
   /**

--- a/src/contracts/Datatoken4.ts
+++ b/src/contracts/Datatoken4.ts
@@ -78,13 +78,8 @@ export class Datatoken4 extends Datatoken {
     consumer: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
-      throw new Error(`User is not Datatoken Deployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.setAllowListContract.estimateGas(address)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setAllowListContractTx(dtAddress, address, consumer, estGas)
+    const tx = await this.setAllowListContractTx(dtAddress, address, consumer)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -92,16 +87,14 @@ export class Datatoken4 extends Datatoken {
   public async setAllowListContractTx(
     dtAddress: string,
     address: string,
-    consumer: string,
-    estimatedGas?: bigint
+    consumer: string
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
 
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.setAllowListContract.estimateGas(address))
+    const estGas = await dtContract.setAllowListContract.estimateGas(address)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -125,13 +118,8 @@ export class Datatoken4 extends Datatoken {
     consumer: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
-      throw new Error(`User is not Datatoken Deployer`)
-    }
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.setDenyListContract.estimateGas(address)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setDenyListContractTx(dtAddress, address, consumer, estGas)
+    const tx = await this.setDenyListContractTx(dtAddress, address, consumer)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -139,16 +127,14 @@ export class Datatoken4 extends Datatoken {
   public async setDenyListContractTx(
     dtAddress: string,
     address: string,
-    consumer: string,
-    estimatedGas?: bigint
+    consumer: string
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
 
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.setDenyListContract.estimateGas(address))
+    const estGas = await dtContract.setDenyListContract.estimateGas(address)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -169,31 +155,22 @@ export class Datatoken4 extends Datatoken {
     address: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (!(await this.isDatatokenDeployer(dtAddress, address))) {
-      throw new Error(`User is not Datatoken Deployer`)
-    }
-
-    const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.setFilesObject.estimateGas(this.fileObject)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.setFileObjectTx(dtAddress, address, estGas)
+    const tx = await this.setFileObjectTx(dtAddress, address)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setFileObjectTx(
     dtAddress: string,
-    address: string,
-    estimatedGas?: bigint
+    address: string
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
 
     const dtContract = this.getContract(dtAddress)
-    const estGas =
-      estimatedGas ?? (await dtContract.setFilesObject.estimateGas(this.fileObject))
+    const estGas = await dtContract.setFilesObject.estimateGas(this.fileObject)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Datatoken4.ts
+++ b/src/contracts/Datatoken4.ts
@@ -84,7 +84,7 @@ export class Datatoken4 extends Datatoken {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.setAllowListContract.estimateGas(address)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setAllowListContractTx(dtAddress, address, consumer)
+    const tx = await this.setAllowListContractTx(dtAddress, address, consumer, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -92,14 +92,16 @@ export class Datatoken4 extends Datatoken {
   public async setAllowListContractTx(
     dtAddress: string,
     address: string,
-    consumer: string
+    consumer: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
 
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.setAllowListContract.estimateGas(address)
+    const estGas =
+      estimatedGas ?? (await dtContract.setAllowListContract.estimateGas(address))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -129,7 +131,7 @@ export class Datatoken4 extends Datatoken {
     const dtContract = this.getContract(dtAddress)
     const estGas = await dtContract.setDenyListContract.estimateGas(address)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setDenyListContractTx(dtAddress, address, consumer)
+    const tx = await this.setDenyListContractTx(dtAddress, address, consumer, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -137,14 +139,16 @@ export class Datatoken4 extends Datatoken {
   public async setDenyListContractTx(
     dtAddress: string,
     address: string,
-    consumer: string
+    consumer: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, consumer))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
 
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.setDenyListContract.estimateGas(address)
+    const estGas =
+      estimatedGas ?? (await dtContract.setDenyListContract.estimateGas(address))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -173,21 +177,23 @@ export class Datatoken4 extends Datatoken {
     const estGas = await dtContract.setFilesObject.estimateGas(this.fileObject)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.setFileObjectTx(dtAddress, address)
+    const tx = await this.setFileObjectTx(dtAddress, address, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setFileObjectTx(
     dtAddress: string,
-    address: string
+    address: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if (!(await this.isDatatokenDeployer(dtAddress, address))) {
       throw new Error(`User is not Datatoken Deployer`)
     }
 
     const dtContract = this.getContract(dtAddress)
-    const estGas = await dtContract.setFilesObject.estimateGas(this.fileObject)
+    const estGas =
+      estimatedGas ?? (await dtContract.setFilesObject.estimateGas(this.fileObject))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Dispenser.ts
+++ b/src/contracts/Dispenser.ts
@@ -1,9 +1,14 @@
 import Decimal from 'decimal.js'
+import { TransactionRequest } from 'ethers'
 import DispenserAbi from '@oceanprotocol/contracts/artifacts/contracts/pools/dispenser/Dispenser.sol/Dispenser.json'
 import { Datatoken } from './Datatoken.js'
 import { SmartContractWithAddress } from './SmartContractWithAddress.js'
 import { DispenserToken, ReceiptOrEstimate, AbiItem } from '../@types/index.js'
-import { sendTx } from '../utils/ContractUtils.js'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 
 export class Dispenser extends SmartContractWithAddress {
   getDefaultAbi() {
@@ -50,28 +55,53 @@ export class Dispenser extends SmartContractWithAddress {
     allowedSwapper: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const maxTokensUnits = this.amountToUnits(null, maxTokens, 18)
+    const maxBalanceUnits = this.amountToUnits(null, maxBalance, 18)
     const estGas = await this.contract.create.estimateGas(
       dtAddress,
-      this.amountToUnits(null, maxTokens, 18),
-      this.amountToUnits(null, maxBalance, 18),
+      maxTokensUnits,
+      maxBalanceUnits,
       address,
       allowedSwapper
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    // Call createFixedRate contract method
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.create,
+    const tx = await this.createTx(
       dtAddress,
-      this.amountToUnits(null, maxTokens, 18),
-      this.amountToUnits(null, maxBalance, 18),
+      address,
+      maxTokens,
+      maxBalance,
+      allowedSwapper
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async createTx(
+    dtAddress: string,
+    address: string,
+    maxTokens: string,
+    maxBalance: string,
+    allowedSwapper: string
+  ): Promise<TransactionRequest> {
+    const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
+    const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
+    const estGas = await this.contract.create.estimateGas(
+      dtAddress,
+      maxTokensUnits,
+      maxBalanceUnits,
       address,
       allowedSwapper
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.create,
+      [dtAddress, maxTokensUnits, maxBalanceUnits, address, allowedSwapper],
+      overrides
+    )
   }
 
   /**
@@ -88,23 +118,41 @@ export class Dispenser extends SmartContractWithAddress {
     maxBalance: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
+    const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
     const estGas = await this.contract.activate.estimateGas(
       dtAddress,
-      this.amountToUnits(null, maxTokens, 18),
-      this.amountToUnits(null, maxBalance, 18)
+      maxTokensUnits,
+      maxBalanceUnits
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.activateTx(dtAddress, maxTokens, maxBalance)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async activateTx(
+    dtAddress: string,
+    maxTokens: string,
+    maxBalance: string
+  ): Promise<TransactionRequest> {
+    const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
+    const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
+    const estGas = await this.contract.activate.estimateGas(
+      dtAddress,
+      maxTokensUnits,
+      maxBalanceUnits
+    )
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.activate,
-      dtAddress,
-      this.amountToUnits(null, maxTokens, 18),
-      this.amountToUnits(null, maxBalance, 18)
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      this.contract.activate,
+      [dtAddress, maxTokensUnits, maxBalanceUnits],
+      overrides
+    )
   }
 
   /**
@@ -119,15 +167,19 @@ export class Dispenser extends SmartContractWithAddress {
   ): Promise<ReceiptOrEstimate<G>> {
     const estGas = await this.contract.deactivate.estimateGas(dtAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.deactivateTx(dtAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async deactivateTx(dtAddress: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.deactivate.estimateGas(dtAddress)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.deactivate,
-      dtAddress
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.deactivate, [dtAddress], overrides)
   }
 
   /**
@@ -147,15 +199,29 @@ export class Dispenser extends SmartContractWithAddress {
       newAllowedSwapper
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.setAllowedSwapper,
+    const tx = await this.setAllowedSwapperTx(dtAddress, newAllowedSwapper)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setAllowedSwapperTx(
+    dtAddress: string,
+    newAllowedSwapper: string
+  ): Promise<TransactionRequest> {
+    const estGas = await this.contract.setAllowedSwapper.estimateGas(
       dtAddress,
       newAllowedSwapper
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.setAllowedSwapper,
+      [dtAddress, newAllowedSwapper],
+      overrides
+    )
   }
 
   /**
@@ -174,22 +240,39 @@ export class Dispenser extends SmartContractWithAddress {
     destination: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const amountUnits = await this.amountToUnits(null, amount, 18)
     const estGas = await this.contract.dispense.estimateGas(
       dtAddress,
-      this.amountToUnits(null, amount, 18),
+      amountUnits,
       destination
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.dispense,
+    const tx = await this.dispenseTx(dtAddress, amount, destination)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async dispenseTx(
+    dtAddress: string,
+    amount: string = '1',
+    destination: string
+  ): Promise<TransactionRequest> {
+    const amountUnits = await this.amountToUnits(null, amount, 18)
+    const estGas = await this.contract.dispense.estimateGas(
       dtAddress,
-      this.amountToUnits(null, amount, 18),
+      amountUnits,
       destination
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.dispense,
+      [dtAddress, amountUnits, destination],
+      overrides
+    )
   }
 
   /**
@@ -204,15 +287,19 @@ export class Dispenser extends SmartContractWithAddress {
   ): Promise<ReceiptOrEstimate<G>> {
     const estGas = await this.contract.ownerWithdraw.estimateGas(dtAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.ownerWithdrawTx(dtAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async ownerWithdrawTx(dtAddress: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.ownerWithdraw.estimateGas(dtAddress)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.ownerWithdraw,
-      dtAddress
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.ownerWithdraw, [dtAddress], overrides)
   }
 
   /**

--- a/src/contracts/Dispenser.ts
+++ b/src/contracts/Dispenser.ts
@@ -55,23 +55,12 @@ export class Dispenser extends SmartContractWithAddress {
     allowedSwapper: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
-    const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
-    const estGas = await this.contract.create.estimateGas(
-      dtAddress,
-      maxTokensUnits,
-      maxBalanceUnits,
-      address,
-      allowedSwapper
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
     const tx = await this.createTx(
       dtAddress,
       address,
       maxTokens,
       maxBalance,
-      allowedSwapper,
-      estGas
+      allowedSwapper
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -82,20 +71,17 @@ export class Dispenser extends SmartContractWithAddress {
     address: string,
     maxTokens: string,
     maxBalance: string,
-    allowedSwapper: string,
-    estimatedGas?: bigint
+    allowedSwapper: string
   ): Promise<TransactionRequest> {
     const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
     const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.create.estimateGas(
-        dtAddress,
-        maxTokensUnits,
-        maxBalanceUnits,
-        address,
-        allowedSwapper
-      ))
+    const estGas = await this.contract.create.estimateGas(
+      dtAddress,
+      maxTokensUnits,
+      maxBalanceUnits,
+      address,
+      allowedSwapper
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -122,15 +108,8 @@ export class Dispenser extends SmartContractWithAddress {
     maxBalance: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
-    const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
-    const estGas = await this.contract.activate.estimateGas(
-      dtAddress,
-      maxTokensUnits,
-      maxBalanceUnits
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.activateTx(dtAddress, maxTokens, maxBalance, estGas)
+    const tx = await this.activateTx(dtAddress, maxTokens, maxBalance)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -138,18 +117,15 @@ export class Dispenser extends SmartContractWithAddress {
   public async activateTx(
     dtAddress: string,
     maxTokens: string,
-    maxBalance: string,
-    estimatedGas?: bigint
+    maxBalance: string
   ): Promise<TransactionRequest> {
     const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
     const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.activate.estimateGas(
-        dtAddress,
-        maxTokensUnits,
-        maxBalanceUnits
-      ))
+    const estGas = await this.contract.activate.estimateGas(
+      dtAddress,
+      maxTokensUnits,
+      maxBalanceUnits
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -172,18 +148,14 @@ export class Dispenser extends SmartContractWithAddress {
     dtAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.deactivate.estimateGas(dtAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.deactivateTx(dtAddress, estGas)
+    const tx = await this.deactivateTx(dtAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async deactivateTx(
-    dtAddress: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const estGas = estimatedGas ?? (await this.contract.deactivate.estimateGas(dtAddress))
+  public async deactivateTx(dtAddress: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.deactivate.estimateGas(dtAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -204,24 +176,20 @@ export class Dispenser extends SmartContractWithAddress {
     newAllowedSwapper: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.setAllowedSwapper.estimateGas(
-      dtAddress,
-      newAllowedSwapper
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setAllowedSwapperTx(dtAddress, newAllowedSwapper, estGas)
+    const tx = await this.setAllowedSwapperTx(dtAddress, newAllowedSwapper)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setAllowedSwapperTx(
     dtAddress: string,
-    newAllowedSwapper: string,
-    estimatedGas?: bigint
+    newAllowedSwapper: string
   ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ??
-      (await this.contract.setAllowedSwapper.estimateGas(dtAddress, newAllowedSwapper))
+    const estGas = await this.contract.setAllowedSwapper.estimateGas(
+      dtAddress,
+      newAllowedSwapper
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -250,14 +218,8 @@ export class Dispenser extends SmartContractWithAddress {
     destination: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const amountUnits = await this.amountToUnits(null, amount, 18)
-    const estGas = await this.contract.dispense.estimateGas(
-      dtAddress,
-      amountUnits,
-      destination
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.dispenseTx(dtAddress, amount, destination, estGas)
+    const tx = await this.dispenseTx(dtAddress, amount, destination)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -265,13 +227,14 @@ export class Dispenser extends SmartContractWithAddress {
   public async dispenseTx(
     dtAddress: string,
     amount: string = '1',
-    destination: string,
-    estimatedGas?: bigint
+    destination: string
   ): Promise<TransactionRequest> {
     const amountUnits = await this.amountToUnits(null, amount, 18)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.dispense.estimateGas(dtAddress, amountUnits, destination))
+    const estGas = await this.contract.dispense.estimateGas(
+      dtAddress,
+      amountUnits,
+      destination
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -294,19 +257,14 @@ export class Dispenser extends SmartContractWithAddress {
     dtAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.ownerWithdraw.estimateGas(dtAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.ownerWithdrawTx(dtAddress, estGas)
+    const tx = await this.ownerWithdrawTx(dtAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async ownerWithdrawTx(
-    dtAddress: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ?? (await this.contract.ownerWithdraw.estimateGas(dtAddress))
+  public async ownerWithdrawTx(dtAddress: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.ownerWithdraw.estimateGas(dtAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Dispenser.ts
+++ b/src/contracts/Dispenser.ts
@@ -55,8 +55,8 @@ export class Dispenser extends SmartContractWithAddress {
     allowedSwapper: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const maxTokensUnits = this.amountToUnits(null, maxTokens, 18)
-    const maxBalanceUnits = this.amountToUnits(null, maxBalance, 18)
+    const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
+    const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
     const estGas = await this.contract.create.estimateGas(
       dtAddress,
       maxTokensUnits,
@@ -70,7 +70,8 @@ export class Dispenser extends SmartContractWithAddress {
       address,
       maxTokens,
       maxBalance,
-      allowedSwapper
+      allowedSwapper,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -81,17 +82,20 @@ export class Dispenser extends SmartContractWithAddress {
     address: string,
     maxTokens: string,
     maxBalance: string,
-    allowedSwapper: string
+    allowedSwapper: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
     const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
-    const estGas = await this.contract.create.estimateGas(
-      dtAddress,
-      maxTokensUnits,
-      maxBalanceUnits,
-      address,
-      allowedSwapper
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.create.estimateGas(
+        dtAddress,
+        maxTokensUnits,
+        maxBalanceUnits,
+        address,
+        allowedSwapper
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -126,7 +130,7 @@ export class Dispenser extends SmartContractWithAddress {
       maxBalanceUnits
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.activateTx(dtAddress, maxTokens, maxBalance)
+    const tx = await this.activateTx(dtAddress, maxTokens, maxBalance, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -134,15 +138,18 @@ export class Dispenser extends SmartContractWithAddress {
   public async activateTx(
     dtAddress: string,
     maxTokens: string,
-    maxBalance: string
+    maxBalance: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const maxTokensUnits = await this.amountToUnits(null, maxTokens, 18)
     const maxBalanceUnits = await this.amountToUnits(null, maxBalance, 18)
-    const estGas = await this.contract.activate.estimateGas(
-      dtAddress,
-      maxTokensUnits,
-      maxBalanceUnits
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.activate.estimateGas(
+        dtAddress,
+        maxTokensUnits,
+        maxBalanceUnits
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -167,13 +174,16 @@ export class Dispenser extends SmartContractWithAddress {
   ): Promise<ReceiptOrEstimate<G>> {
     const estGas = await this.contract.deactivate.estimateGas(dtAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.deactivateTx(dtAddress)
+    const tx = await this.deactivateTx(dtAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async deactivateTx(dtAddress: string): Promise<TransactionRequest> {
-    const estGas = await this.contract.deactivate.estimateGas(dtAddress)
+  public async deactivateTx(
+    dtAddress: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
+    const estGas = estimatedGas ?? (await this.contract.deactivate.estimateGas(dtAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -199,19 +209,19 @@ export class Dispenser extends SmartContractWithAddress {
       newAllowedSwapper
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setAllowedSwapperTx(dtAddress, newAllowedSwapper)
+    const tx = await this.setAllowedSwapperTx(dtAddress, newAllowedSwapper, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setAllowedSwapperTx(
     dtAddress: string,
-    newAllowedSwapper: string
+    newAllowedSwapper: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
-    const estGas = await this.contract.setAllowedSwapper.estimateGas(
-      dtAddress,
-      newAllowedSwapper
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.setAllowedSwapper.estimateGas(dtAddress, newAllowedSwapper))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -247,7 +257,7 @@ export class Dispenser extends SmartContractWithAddress {
       destination
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.dispenseTx(dtAddress, amount, destination)
+    const tx = await this.dispenseTx(dtAddress, amount, destination, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -255,14 +265,13 @@ export class Dispenser extends SmartContractWithAddress {
   public async dispenseTx(
     dtAddress: string,
     amount: string = '1',
-    destination: string
+    destination: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const amountUnits = await this.amountToUnits(null, amount, 18)
-    const estGas = await this.contract.dispense.estimateGas(
-      dtAddress,
-      amountUnits,
-      destination
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.dispense.estimateGas(dtAddress, amountUnits, destination))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -287,13 +296,17 @@ export class Dispenser extends SmartContractWithAddress {
   ): Promise<ReceiptOrEstimate<G>> {
     const estGas = await this.contract.ownerWithdraw.estimateGas(dtAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.ownerWithdrawTx(dtAddress)
+    const tx = await this.ownerWithdrawTx(dtAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async ownerWithdrawTx(dtAddress: string): Promise<TransactionRequest> {
-    const estGas = await this.contract.ownerWithdraw.estimateGas(dtAddress)
+  public async ownerWithdrawTx(
+    dtAddress: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
+    const estGas =
+      estimatedGas ?? (await this.contract.ownerWithdraw.estimateGas(dtAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Dispenser.ts
+++ b/src/contracts/Dispenser.ts
@@ -62,6 +62,7 @@ export class Dispenser extends SmartContractWithAddress {
       maxBalance,
       allowedSwapper
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }

--- a/src/contracts/EnterpriseFeeCollector.ts
+++ b/src/contracts/EnterpriseFeeCollector.ts
@@ -56,7 +56,7 @@ export class EnterpriseFeeCollectorContract extends SmartContractWithAddress {
     amount: number,
     tokenDecimals?: number
   ): Promise<any> {
-    const weiAmount = this.amountToUnits(token, amount.toString(), tokenDecimals)
+    const weiAmount = await this.amountToUnits(token, amount.toString(), tokenDecimals)
     const amountWithFee = await this.contract.calculateFee(token, weiAmount)
     return this.unitsToAmount(token, amountWithFee, tokenDecimals)
   }

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -205,12 +205,10 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if (estimateGas) {
-      const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
-      const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
-      return <ReceiptOrEstimate<G>>estGas
-    }
-    const tx = await this.depositTx(token, amount, tokenDecimals)
+    const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
+    const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.depositTx(token, amount, tokenDecimals, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -218,10 +216,12 @@ export class EscrowContract extends SmartContractWithAddress {
   public async depositTx(
     token: string,
     amount: string,
-    tokenDecimals?: number
+    tokenDecimals?: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
-    const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
+    const estGas =
+      estimatedGas ?? (await this.contract.deposit.estimateGas(token, amountParsed))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -254,7 +254,7 @@ export class EscrowContract extends SmartContractWithAddress {
       amountsParsed
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.withdrawTx(tokens, amounts, tokenDecimals)
+    const tx = await this.withdrawTx(tokens, amounts, tokenDecimals, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -262,17 +262,17 @@ export class EscrowContract extends SmartContractWithAddress {
   public async withdrawTx(
     tokens: string[],
     amounts: string[],
-    tokenDecimals?: number
+    tokenDecimals?: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const { tokensWithSufficientFunds, amountsParsed } = await this.prepareWithdrawInputs(
       tokens,
       amounts,
       tokenDecimals
     )
-    const estGas = await this.contract.withdraw.estimateGas(
-      tokensWithSufficientFunds,
-      amountsParsed
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.withdraw.estimateGas(tokensWithSufficientFunds, amountsParsed))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -371,7 +371,8 @@ export class EscrowContract extends SmartContractWithAddress {
       maxLockedAmount,
       maxLockSeconds,
       maxLockCounts,
-      tokenDecimals
+      tokenDecimals,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -383,7 +384,8 @@ export class EscrowContract extends SmartContractWithAddress {
     maxLockedAmount: string,
     maxLockSeconds: string,
     maxLockCounts: string,
-    tokenDecimals?: number
+    tokenDecimals?: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const {
       tokenArg,
@@ -399,13 +401,15 @@ export class EscrowContract extends SmartContractWithAddress {
       maxLockCounts,
       tokenDecimals
     )
-    const estGas = await this.contract.authorize.estimateGas(
-      tokenArg,
-      payeeArg,
-      maxLockedAmountParsed,
-      maxLockSecondsParsed,
-      maxLockCountsParsed
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.authorize.estimateGas(
+        tokenArg,
+        payeeArg,
+        maxLockedAmountParsed,
+        maxLockSecondsParsed,
+        maxLockCountsParsed
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -432,15 +436,6 @@ export class EscrowContract extends SmartContractWithAddress {
     maxLockCounts: string,
     tokenDecimals?: number
   ) {
-    const auths = await this.getAuthorizations(
-      token,
-      await this.signer.getAddress(),
-      payee
-    )
-    if (auths.length !== 0) {
-      console.log(`Payee ${payee} already authorized`)
-      throw new Error(`Payee ${payee} already authorized`)
-    }
     const maxLockedAmountParsed = await this.amountToUnits(
       token,
       maxLockedAmount,
@@ -488,7 +483,7 @@ export class EscrowContract extends SmartContractWithAddress {
       payees
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.cancelExpiredLocksTx(jobIds, tokens, payers, payees)
+    const tx = await this.cancelExpiredLocksTx(jobIds, tokens, payers, payees, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -497,14 +492,12 @@ export class EscrowContract extends SmartContractWithAddress {
     jobIds: string[],
     tokens: string[],
     payers: string[],
-    payees: string[]
+    payees: string[],
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
-    const estGas = await this.contract.cancelExpiredLocks.estimateGas(
-      jobIds,
-      tokens,
-      payers,
-      payees
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.cancelExpiredLocks.estimateGas(jobIds, tokens, payers, payees))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -354,7 +354,16 @@ export class EscrowContract extends SmartContractWithAddress {
     maxLockSeconds: string,
     maxLockCounts: string,
     tokenDecimals?: number
-  ): Promise<TransactionRequest> {
+  ): Promise<TransactionRequest | null> {
+    const auths = await this.getAuthorizations(
+      token,
+      await this.signer.getAddress(),
+      payee
+    )
+    if (auths.length !== 0) {
+      console.log(`Payee ${payee} already authorized`)
+      return null
+    }
     const {
       tokenArg,
       payeeArg,

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -1,6 +1,10 @@
-import { Signer, getAddress, parseEther } from 'ethers'
+import { Signer, TransactionRequest, getAddress, parseEther } from 'ethers'
 import Escrow from '@oceanprotocol/contracts/artifacts/contracts/escrow/Escrow.sol/Escrow.json'
-import { sendTx } from '../utils/ContractUtils'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils'
 import { AbiItem, ReceiptOrEstimate, ValidationResponse } from '../@types'
 import { Config } from '../config'
 import { SmartContractWithAddress } from './SmartContractWithAddress'
@@ -201,18 +205,29 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    if (estimateGas) {
+      const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
+      const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
+      return <ReceiptOrEstimate<G>>estGas
+    }
+    const tx = await this.depositTx(token, amount, tokenDecimals)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async depositTx(
+    token: string,
+    amount: string,
+    tokenDecimals?: number
+  ): Promise<TransactionRequest> {
     const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
     const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.deposit,
-      token,
-      amountParsed
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.deposit, [token, amountParsed], overrides)
   }
 
   /**
@@ -229,9 +244,55 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const { tokensWithSufficientFunds, amountsParsed } = await this.prepareWithdrawInputs(
+      tokens,
+      amounts,
+      tokenDecimals
+    )
+    const estGas = await this.contract.withdraw.estimateGas(
+      tokensWithSufficientFunds,
+      amountsParsed
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.withdrawTx(tokens, amounts, tokenDecimals)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async withdrawTx(
+    tokens: string[],
+    amounts: string[],
+    tokenDecimals?: number
+  ): Promise<TransactionRequest> {
+    const { tokensWithSufficientFunds, amountsParsed } = await this.prepareWithdrawInputs(
+      tokens,
+      amounts,
+      tokenDecimals
+    )
+    const estGas = await this.contract.withdraw.estimateGas(
+      tokensWithSufficientFunds,
+      amountsParsed
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.withdraw,
+      [tokensWithSufficientFunds, amountsParsed],
+      overrides
+    )
+  }
+
+  private async prepareWithdrawInputs(
+    tokens: string[],
+    amounts: string[],
+    tokenDecimals?: number
+  ) {
     // check if funds exist in escrow in order to be withdrawed
-    const tokensWithSufficientFunds = []
-    const amountsWithSufficientFunds = []
+    const tokensWithSufficientFunds: string[] = []
+    const amountsWithSufficientFunds: string[] = []
 
     if (tokens.length !== amounts.length) {
       throw new Error('Tokens and amounts arrays must have the same length')
@@ -259,18 +320,7 @@ export class EscrowContract extends SmartContractWithAddress {
       )
     )
 
-    const estGas = await this.contract.withdraw.estimateGas(tokens, amountsParsed)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.withdraw,
-      tokensWithSufficientFunds,
-      amountsParsed
-    )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return { tokensWithSufficientFunds, amountsWithSufficientFunds, amountsParsed }
   }
 
   /**
@@ -293,6 +343,95 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const {
+      tokenArg,
+      payeeArg,
+      maxLockedAmountParsed,
+      maxLockSecondsParsed,
+      maxLockCountsParsed
+    } = await this.prepareAuthorizeInputs(
+      token,
+      payee,
+      maxLockedAmount,
+      maxLockSeconds,
+      maxLockCounts,
+      tokenDecimals
+    )
+    const estGas = await this.contract.authorize.estimateGas(
+      tokenArg,
+      payeeArg,
+      maxLockedAmountParsed,
+      maxLockSecondsParsed,
+      maxLockCountsParsed
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.authorizeTx(
+      token,
+      payee,
+      maxLockedAmount,
+      maxLockSeconds,
+      maxLockCounts,
+      tokenDecimals
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async authorizeTx(
+    token: string,
+    payee: string,
+    maxLockedAmount: string,
+    maxLockSeconds: string,
+    maxLockCounts: string,
+    tokenDecimals?: number
+  ): Promise<TransactionRequest> {
+    const {
+      tokenArg,
+      payeeArg,
+      maxLockedAmountParsed,
+      maxLockSecondsParsed,
+      maxLockCountsParsed
+    } = await this.prepareAuthorizeInputs(
+      token,
+      payee,
+      maxLockedAmount,
+      maxLockSeconds,
+      maxLockCounts,
+      tokenDecimals
+    )
+    const estGas = await this.contract.authorize.estimateGas(
+      tokenArg,
+      payeeArg,
+      maxLockedAmountParsed,
+      maxLockSecondsParsed,
+      maxLockCountsParsed
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.authorize,
+      [
+        tokenArg,
+        payeeArg,
+        maxLockedAmountParsed,
+        maxLockSecondsParsed,
+        maxLockCountsParsed
+      ],
+      overrides
+    )
+  }
+
+  private async prepareAuthorizeInputs(
+    token: string,
+    payee: string,
+    maxLockedAmount: string,
+    maxLockSeconds: string,
+    maxLockCounts: string,
+    tokenDecimals?: number
+  ) {
     const auths = await this.getAuthorizations(
       token,
       await this.signer.getAddress(),
@@ -300,7 +439,7 @@ export class EscrowContract extends SmartContractWithAddress {
     )
     if (auths.length !== 0) {
       console.log(`Payee ${payee} already authorized`)
-      return null
+      throw new Error(`Payee ${payee} already authorized`)
     }
     const maxLockedAmountParsed = await this.amountToUnits(
       token,
@@ -317,26 +456,13 @@ export class EscrowContract extends SmartContractWithAddress {
       maxLockCounts,
       tokenDecimals
     )
-    const estGas = await this.contract.authorize.estimateGas(
-      token,
-      payee,
+    return {
+      tokenArg: token,
+      payeeArg: payee,
       maxLockedAmountParsed,
       maxLockSecondsParsed,
       maxLockCountsParsed
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.authorize,
-      token,
-      payee,
-      maxLockedAmountParsed,
-      maxLockSecondsParsed,
-      maxLockCountsParsed
-    )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    }
   }
 
   /**
@@ -362,16 +488,32 @@ export class EscrowContract extends SmartContractWithAddress {
       payees
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.cancelExpiredLocks,
+    const tx = await this.cancelExpiredLocksTx(jobIds, tokens, payers, payees)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async cancelExpiredLocksTx(
+    jobIds: string[],
+    tokens: string[],
+    payers: string[],
+    payees: string[]
+  ): Promise<TransactionRequest> {
+    const estGas = await this.contract.cancelExpiredLocks.estimateGas(
       jobIds,
       tokens,
       payers,
       payees
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.cancelExpiredLocks,
+      [jobIds, tokens, payers, payees],
+      overrides
+    )
   }
 }

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -290,37 +290,41 @@ export class EscrowContract extends SmartContractWithAddress {
     amounts: string[],
     tokenDecimals?: number
   ) {
-    // check if funds exist in escrow in order to be withdrawed
-    const tokensWithSufficientFunds: string[] = []
-    const amountsWithSufficientFunds: string[] = []
-
     if (tokens.length !== amounts.length) {
       throw new Error('Tokens and amounts arrays must have the same length')
     }
 
+    // Validate all requested withdrawals up front. We fail fast instead of silently
+    // filtering entries to avoid unexpected partial withdrawals.
     const userAddress = await this.signer.getAddress()
-
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]
       const amount = new BigNumber(amounts[i])
-
       const funds = await this.getUserFunds(userAddress, token)
       const available = new BigNumber(funds[0])
 
-      if (amount.isGreaterThan(0) && amount.isLessThanOrEqualTo(available)) {
-        tokensWithSufficientFunds.push(token)
-        amountsWithSufficientFunds.push(amounts[i])
-      } else {
-        console.log(`Insufficient funds for token ${token}`)
+      if (!amount.isGreaterThan(0)) {
+        throw new Error(
+          `Invalid withdraw amount for token ${token}: requested ${amounts[i]}, expected > 0`
+        )
+      }
+      if (amount.isGreaterThan(available)) {
+        throw new Error(
+          `Insufficient funds for token ${token}: requested ${
+            amounts[i]
+          }, available ${available.toString()}`
+        )
       }
     }
+
+    const tokensWithSufficientFunds = [...tokens]
     const amountsParsed = await Promise.all(
-      amountsWithSufficientFunds.map((amount, i) =>
+      amounts.map((amount, i) =>
         this.amountToUnits(tokensWithSufficientFunds[i], amount, tokenDecimals)
       )
     )
 
-    return { tokensWithSufficientFunds, amountsWithSufficientFunds, amountsParsed }
+    return { tokensWithSufficientFunds, amountsParsed }
   }
 
   /**

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -206,6 +206,7 @@ export class EscrowContract extends SmartContractWithAddress {
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
     const tx = await this.depositTx(token, amount, tokenDecimals)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -341,6 +342,7 @@ export class EscrowContract extends SmartContractWithAddress {
       maxLockCounts,
       tokenDecimals
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }

--- a/src/contracts/Escrow.ts
+++ b/src/contracts/Escrow.ts
@@ -205,10 +205,7 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
-    const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.depositTx(token, amount, tokenDecimals, estGas)
+    const tx = await this.depositTx(token, amount, tokenDecimals)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -216,12 +213,10 @@ export class EscrowContract extends SmartContractWithAddress {
   public async depositTx(
     token: string,
     amount: string,
-    tokenDecimals?: number,
-    estimatedGas?: bigint
+    tokenDecimals?: number
   ): Promise<TransactionRequest> {
     const amountParsed = await this.amountToUnits(token, amount, tokenDecimals)
-    const estGas =
-      estimatedGas ?? (await this.contract.deposit.estimateGas(token, amountParsed))
+    const estGas = await this.contract.deposit.estimateGas(token, amountParsed)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -244,6 +239,17 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const tx = await this.withdrawTx(tokens, amounts, tokenDecimals)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async withdrawTx(
+    tokens: string[],
+    amounts: string[],
+    tokenDecimals?: number
+  ): Promise<TransactionRequest> {
     const { tokensWithSufficientFunds, amountsParsed } = await this.prepareWithdrawInputs(
       tokens,
       amounts,
@@ -253,26 +259,6 @@ export class EscrowContract extends SmartContractWithAddress {
       tokensWithSufficientFunds,
       amountsParsed
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.withdrawTx(tokens, amounts, tokenDecimals, estGas)
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async withdrawTx(
-    tokens: string[],
-    amounts: string[],
-    tokenDecimals?: number,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const { tokensWithSufficientFunds, amountsParsed } = await this.prepareWithdrawInputs(
-      tokens,
-      amounts,
-      tokenDecimals
-    )
-    const estGas =
-      estimatedGas ??
-      (await this.contract.withdraw.estimateGas(tokensWithSufficientFunds, amountsParsed))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -347,6 +333,26 @@ export class EscrowContract extends SmartContractWithAddress {
     tokenDecimals?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const tx = await this.authorizeTx(
+      token,
+      payee,
+      maxLockedAmount,
+      maxLockSeconds,
+      maxLockCounts,
+      tokenDecimals
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async authorizeTx(
+    token: string,
+    payee: string,
+    maxLockedAmount: string,
+    maxLockSeconds: string,
+    maxLockCounts: string,
+    tokenDecimals?: number
+  ): Promise<TransactionRequest> {
     const {
       tokenArg,
       payeeArg,
@@ -368,52 +374,6 @@ export class EscrowContract extends SmartContractWithAddress {
       maxLockSecondsParsed,
       maxLockCountsParsed
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.authorizeTx(
-      token,
-      payee,
-      maxLockedAmount,
-      maxLockSeconds,
-      maxLockCounts,
-      tokenDecimals,
-      estGas
-    )
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async authorizeTx(
-    token: string,
-    payee: string,
-    maxLockedAmount: string,
-    maxLockSeconds: string,
-    maxLockCounts: string,
-    tokenDecimals?: number,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const {
-      tokenArg,
-      payeeArg,
-      maxLockedAmountParsed,
-      maxLockSecondsParsed,
-      maxLockCountsParsed
-    } = await this.prepareAuthorizeInputs(
-      token,
-      payee,
-      maxLockedAmount,
-      maxLockSeconds,
-      maxLockCounts,
-      tokenDecimals
-    )
-    const estGas =
-      estimatedGas ??
-      (await this.contract.authorize.estimateGas(
-        tokenArg,
-        payeeArg,
-        maxLockedAmountParsed,
-        maxLockSecondsParsed,
-        maxLockCountsParsed
-      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -480,14 +440,8 @@ export class EscrowContract extends SmartContractWithAddress {
     payees: string[],
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.cancelExpiredLocks.estimateGas(
-      jobIds,
-      tokens,
-      payers,
-      payees
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.cancelExpiredLocksTx(jobIds, tokens, payers, payees, estGas)
+    const tx = await this.cancelExpiredLocksTx(jobIds, tokens, payers, payees)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -496,12 +450,14 @@ export class EscrowContract extends SmartContractWithAddress {
     jobIds: string[],
     tokens: string[],
     payers: string[],
-    payees: string[],
-    estimatedGas?: bigint
+    payees: string[]
   ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ??
-      (await this.contract.cancelExpiredLocks.estimateGas(jobIds, tokens, payers, payees))
+    const estGas = await this.contract.cancelExpiredLocks.estimateGas(
+      jobIds,
+      tokens,
+      payers,
+      payees
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/FixedRateExchange.ts
+++ b/src/contracts/FixedRateExchange.ts
@@ -1,5 +1,10 @@
 import FixedRateExchangeAbi from '@oceanprotocol/contracts/artifacts/contracts/pools/fixedRate/FixedRateExchange.sol/FixedRateExchange.json'
-import { sendTx } from '../utils/ContractUtils.js'
+import { TransactionRequest } from 'ethers'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 import {
   PriceAndFees,
   FeesInfo,
@@ -65,19 +70,59 @@ export class FixedRateExchange extends SmartContractWithAddress {
       consumeMarketFeeFormatted
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.buyDT,
+    const tx = await this.buyDatatokensTx(
+      exchangeId,
+      datatokenAmount,
+      maxBaseTokenAmount,
+      consumeMarketAddress,
+      consumeMarketFee
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async buyDatatokensTx(
+    exchangeId: string,
+    datatokenAmount: string,
+    maxBaseTokenAmount: string,
+    consumeMarketAddress: string = ZERO_ADDRESS,
+    consumeMarketFee: string = '0'
+  ): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
+    const dtAmountFormatted = await this.amountToUnits(
+      exchange.datatoken,
+      datatokenAmount,
+      Number(exchange.dtDecimals)
+    )
+    const maxBtFormatted = await this.amountToUnits(
+      exchange.baseToken,
+      maxBaseTokenAmount,
+      Number(exchange.btDecimals)
+    )
+    const estGas = await this.contract.buyDT.estimateGas(
       exchangeId,
       dtAmountFormatted,
       maxBtFormatted,
       consumeMarketAddress,
       consumeMarketFeeFormatted
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.buyDT,
+      [
+        exchangeId,
+        dtAmountFormatted,
+        maxBtFormatted,
+        consumeMarketAddress,
+        consumeMarketFeeFormatted
+      ],
+      overrides
+    )
   }
 
   /**
@@ -118,18 +163,59 @@ export class FixedRateExchange extends SmartContractWithAddress {
       consumeMarketFeeFormatted
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.sellDT,
+    const tx = await this.sellDatatokensTx(
+      exchangeId,
+      datatokenAmount,
+      minBaseTokenAmount,
+      consumeMarketAddress,
+      consumeMarketFee
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async sellDatatokensTx(
+    exchangeId: string,
+    datatokenAmount: string,
+    minBaseTokenAmount: string,
+    consumeMarketAddress: string = ZERO_ADDRESS,
+    consumeMarketFee: string = '0'
+  ): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
+    const dtAmountFormatted = await this.amountToUnits(
+      exchange.datatoken,
+      datatokenAmount,
+      Number(exchange.dtDecimals)
+    )
+    const minBtFormatted = await this.amountToUnits(
+      exchange.baseToken,
+      minBaseTokenAmount,
+      Number(exchange.btDecimals)
+    )
+    const estGas = await this.contract.sellDT.estimateGas(
       exchangeId,
       dtAmountFormatted,
       minBtFormatted,
       consumeMarketAddress,
       consumeMarketFeeFormatted
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.sellDT,
+      [
+        exchangeId,
+        dtAmountFormatted,
+        minBtFormatted,
+        consumeMarketAddress,
+        consumeMarketFeeFormatted
+      ],
+      overrides
+    )
   }
 
   /**
@@ -153,21 +239,27 @@ export class FixedRateExchange extends SmartContractWithAddress {
     newRate: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.setRate.estimateGas(
-      exchangeId,
-      await this.amountToUnits(null, newRate, 18)
-    )
+    const newRateUnits = await this.amountToUnits(null, newRate, 18)
+    const estGas = await this.contract.setRate.estimateGas(exchangeId, newRateUnits)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.setRate,
-      exchangeId,
-      await this.amountToUnits(null, newRate, 18)
-    )
+    const tx = await this.setRateTx(exchangeId, newRate)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setRateTx(
+    exchangeId: string,
+    newRate: string
+  ): Promise<TransactionRequest> {
+    const newRateUnits = await this.amountToUnits(null, newRate, 18)
+    const estGas = await this.contract.setRate.estimateGas(exchangeId, newRateUnits)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(this.contract.setRate, [exchangeId, newRateUnits], overrides)
   }
 
   /**
@@ -187,15 +279,29 @@ export class FixedRateExchange extends SmartContractWithAddress {
       newAllowedSwapper
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.setAllowedSwapper,
+    const tx = await this.setAllowedSwapperTx(exchangeId, newAllowedSwapper)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setAllowedSwapperTx(
+    exchangeId: string,
+    newAllowedSwapper: string
+  ): Promise<TransactionRequest> {
+    const estGas = await this.contract.setAllowedSwapper.estimateGas(
       exchangeId,
       newAllowedSwapper
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.setAllowedSwapper,
+      [exchangeId, newAllowedSwapper],
+      overrides
+    )
   }
 
   /**
@@ -213,14 +319,22 @@ export class FixedRateExchange extends SmartContractWithAddress {
     if (exchange.active === true) return null
     const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.activateTx(exchangeId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async activateTx(exchangeId: string): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    if (exchange.active === true) throw new Error('Exchange already active')
+    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.toggleExchangeState,
-      exchangeId
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.toggleExchangeState, [exchangeId], overrides)
   }
 
   /**
@@ -239,14 +353,22 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.deactivateTx(exchangeId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async deactivateTx(exchangeId: string): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    if (exchange.active === false) throw new Error('Exchange already inactive')
+    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.toggleExchangeState,
-      exchangeId
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.toggleExchangeState, [exchangeId], overrides)
   }
 
   /**
@@ -479,15 +601,22 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, true)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.activateMintTx(exchangeId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async activateMintTx(exchangeId: string): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    if (exchange.withMint === true) throw new Error('Mint already active')
+    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, true)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.toggleMintState,
-      exchangeId,
-      true
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.toggleMintState, [exchangeId, true], overrides)
   }
 
   /**
@@ -506,15 +635,22 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, false)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.deactivateMintTx(exchangeId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async deactivateMintTx(exchangeId: string): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    if (exchange.withMint === false) throw new Error('Mint already inactive')
+    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, false)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.toggleMintState,
-      exchangeId,
-      false
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.toggleMintState, [exchangeId, false], overrides)
   }
 
   /**
@@ -541,15 +677,30 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectBT.estimateGas(exchangeId, amountWei)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.collectBasetokensTx(exchangeId, amount)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async collectBasetokensTx(
+    exchangeId: string,
+    amount: string
+  ): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    const fixedrate: FixedPriceExchange = await this.contract.getExchange(exchangeId)
+    const amountWei = await this.amountToUnits(
+      fixedrate.baseToken,
+      amount,
+      Number(fixedrate.btDecimals)
+    )
+    const estGas = await this.contract.collectBT.estimateGas(exchangeId, amountWei)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.collectBT,
-      exchangeId,
-      amountWei
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.collectBT, [exchangeId, amountWei], overrides)
   }
 
   /**
@@ -576,15 +727,30 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectDT.estimateGas(exchangeId, amountWei)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.collectDatatokensTx(exchangeId, amount)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async collectDatatokensTx(
+    exchangeId: string,
+    amount: string
+  ): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    const fixedrate: FixedPriceExchange = await this.contract.getExchange(exchangeId)
+    const amountWei = await this.amountToUnits(
+      fixedrate.datatoken,
+      amount,
+      Number(fixedrate.dtDecimals)
+    )
+    const estGas = await this.contract.collectDT.estimateGas(exchangeId, amountWei)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.collectDT,
-      exchangeId,
-      amountWei
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.collectDT, [exchangeId, amountWei], overrides)
   }
 
   /**
@@ -602,15 +768,21 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectMarketFee.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.collectMarketFeeTx(exchangeId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async collectMarketFeeTx(exchangeId: string): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    const estGas = await this.contract.collectMarketFee.estimateGas(exchangeId)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.collectMarketFee,
-      exchangeId
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.collectMarketFee, [exchangeId], overrides)
   }
 
   /**
@@ -628,15 +800,21 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectOceanFee.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.collectOceanFeeTx(exchangeId)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async collectOceanFeeTx(exchangeId: string): Promise<TransactionRequest> {
+    const exchange = await this.getExchange(exchangeId)
+    if (!exchange) throw new Error('Exchange not found')
+    const estGas = await this.contract.collectOceanFee.estimateGas(exchangeId)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.collectOceanFee,
-      exchangeId
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.collectOceanFee, [exchangeId], overrides)
   }
 
   /**
@@ -679,21 +857,36 @@ export class FixedRateExchange extends SmartContractWithAddress {
     newMarketFee: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const newMarketFeeUnits = await this.amountToUnits(null, newMarketFee, 18)
     const estGas = await this.contract.updateMarketFee.estimateGas(
       exchangeId,
-      await this.amountToUnits(null, newMarketFee, 18)
+      newMarketFeeUnits
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
+    const tx = await this.updateMarketFeeTx(exchangeId, newMarketFee)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async updateMarketFeeTx(
+    exchangeId: string,
+    newMarketFee: string
+  ): Promise<TransactionRequest> {
+    const newMarketFeeUnits = await this.amountToUnits(null, newMarketFee, 18)
+    const estGas = await this.contract.updateMarketFee.estimateGas(
+      exchangeId,
+      newMarketFeeUnits
+    )
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.updateMarketFee,
-      exchangeId,
-      await this.amountToUnits(null, newMarketFee, 18)
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      this.contract.updateMarketFee,
+      [exchangeId, newMarketFeeUnits],
+      overrides
+    )
   }
 
   /**
@@ -713,15 +906,28 @@ export class FixedRateExchange extends SmartContractWithAddress {
       newMarketFeeCollector
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.updateMarketFeeCollector,
+    const tx = await this.updateMarketFeeCollectorTx(exchangeId, newMarketFeeCollector)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async updateMarketFeeCollectorTx(
+    exchangeId: string,
+    newMarketFeeCollector: string
+  ): Promise<TransactionRequest> {
+    const estGas = await this.contract.updateMarketFeeCollector.estimateGas(
       exchangeId,
       newMarketFeeCollector
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.updateMarketFeeCollector,
+      [exchangeId, newMarketFeeCollector],
+      overrides
+    )
   }
 }

--- a/src/contracts/FixedRateExchange.ts
+++ b/src/contracts/FixedRateExchange.ts
@@ -75,7 +75,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
       datatokenAmount,
       maxBaseTokenAmount,
       consumeMarketAddress,
-      consumeMarketFee
+      consumeMarketFee,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -86,7 +87,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
     datatokenAmount: string,
     maxBaseTokenAmount: string,
     consumeMarketAddress: string = ZERO_ADDRESS,
-    consumeMarketFee: string = '0'
+    consumeMarketFee: string = '0',
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
@@ -100,13 +102,15 @@ export class FixedRateExchange extends SmartContractWithAddress {
       maxBaseTokenAmount,
       Number(exchange.btDecimals)
     )
-    const estGas = await this.contract.buyDT.estimateGas(
-      exchangeId,
-      dtAmountFormatted,
-      maxBtFormatted,
-      consumeMarketAddress,
-      consumeMarketFeeFormatted
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.buyDT.estimateGas(
+        exchangeId,
+        dtAmountFormatted,
+        maxBtFormatted,
+        consumeMarketAddress,
+        consumeMarketFeeFormatted
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -168,7 +172,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
       datatokenAmount,
       minBaseTokenAmount,
       consumeMarketAddress,
-      consumeMarketFee
+      consumeMarketFee,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -179,7 +184,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
     datatokenAmount: string,
     minBaseTokenAmount: string,
     consumeMarketAddress: string = ZERO_ADDRESS,
-    consumeMarketFee: string = '0'
+    consumeMarketFee: string = '0',
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
@@ -193,13 +199,15 @@ export class FixedRateExchange extends SmartContractWithAddress {
       minBaseTokenAmount,
       Number(exchange.btDecimals)
     )
-    const estGas = await this.contract.sellDT.estimateGas(
-      exchangeId,
-      dtAmountFormatted,
-      minBtFormatted,
-      consumeMarketAddress,
-      consumeMarketFeeFormatted
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.sellDT.estimateGas(
+        exchangeId,
+        dtAmountFormatted,
+        minBtFormatted,
+        consumeMarketAddress,
+        consumeMarketFeeFormatted
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -242,7 +250,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
     const newRateUnits = await this.amountToUnits(null, newRate, 18)
     const estGas = await this.contract.setRate.estimateGas(exchangeId, newRateUnits)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setRateTx(exchangeId, newRate)
+    const tx = await this.setRateTx(exchangeId, newRate, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -250,10 +258,12 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
   public async setRateTx(
     exchangeId: string,
-    newRate: string
+    newRate: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const newRateUnits = await this.amountToUnits(null, newRate, 18)
-    const estGas = await this.contract.setRate.estimateGas(exchangeId, newRateUnits)
+    const estGas =
+      estimatedGas ?? (await this.contract.setRate.estimateGas(exchangeId, newRateUnits))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -279,19 +289,19 @@ export class FixedRateExchange extends SmartContractWithAddress {
       newAllowedSwapper
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setAllowedSwapperTx(exchangeId, newAllowedSwapper)
+    const tx = await this.setAllowedSwapperTx(exchangeId, newAllowedSwapper, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setAllowedSwapperTx(
     exchangeId: string,
-    newAllowedSwapper: string
+    newAllowedSwapper: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
-    const estGas = await this.contract.setAllowedSwapper.estimateGas(
-      exchangeId,
-      newAllowedSwapper
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.setAllowedSwapper.estimateGas(exchangeId, newAllowedSwapper))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -319,16 +329,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
     if (exchange.active === true) return null
     const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.activateTx(exchangeId)
+    const tx = await this.activateTx(exchangeId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async activateTx(exchangeId: string): Promise<TransactionRequest> {
+  public async activateTx(
+    exchangeId: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.active === true) throw new Error('Exchange already active')
-    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
+    const estGas =
+      estimatedGas ?? (await this.contract.toggleExchangeState.estimateGas(exchangeId))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -353,16 +367,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.deactivateTx(exchangeId)
+    const tx = await this.deactivateTx(exchangeId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async deactivateTx(exchangeId: string): Promise<TransactionRequest> {
+  public async deactivateTx(
+    exchangeId: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.active === false) throw new Error('Exchange already inactive')
-    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
+    const estGas =
+      estimatedGas ?? (await this.contract.toggleExchangeState.estimateGas(exchangeId))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -601,16 +619,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, true)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.activateMintTx(exchangeId)
+    const tx = await this.activateMintTx(exchangeId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async activateMintTx(exchangeId: string): Promise<TransactionRequest> {
+  public async activateMintTx(
+    exchangeId: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.withMint === true) throw new Error('Mint already active')
-    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, true)
+    const estGas =
+      estimatedGas ?? (await this.contract.toggleMintState.estimateGas(exchangeId, true))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -635,16 +657,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, false)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.deactivateMintTx(exchangeId)
+    const tx = await this.deactivateMintTx(exchangeId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async deactivateMintTx(exchangeId: string): Promise<TransactionRequest> {
+  public async deactivateMintTx(
+    exchangeId: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.withMint === false) throw new Error('Mint already inactive')
-    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, false)
+    const estGas =
+      estimatedGas ?? (await this.contract.toggleMintState.estimateGas(exchangeId, false))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -677,14 +703,15 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectBT.estimateGas(exchangeId, amountWei)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectBasetokensTx(exchangeId, amount)
+    const tx = await this.collectBasetokensTx(exchangeId, amount, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async collectBasetokensTx(
     exchangeId: string,
-    amount: string
+    amount: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
@@ -694,7 +721,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
       amount,
       Number(fixedrate.btDecimals)
     )
-    const estGas = await this.contract.collectBT.estimateGas(exchangeId, amountWei)
+    const estGas =
+      estimatedGas ?? (await this.contract.collectBT.estimateGas(exchangeId, amountWei))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -727,14 +755,15 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectDT.estimateGas(exchangeId, amountWei)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectDatatokensTx(exchangeId, amount)
+    const tx = await this.collectDatatokensTx(exchangeId, amount, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async collectDatatokensTx(
     exchangeId: string,
-    amount: string
+    amount: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
@@ -744,7 +773,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
       amount,
       Number(fixedrate.dtDecimals)
     )
-    const estGas = await this.contract.collectDT.estimateGas(exchangeId, amountWei)
+    const estGas =
+      estimatedGas ?? (await this.contract.collectDT.estimateGas(exchangeId, amountWei))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -768,15 +798,19 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectMarketFee.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectMarketFeeTx(exchangeId)
+    const tx = await this.collectMarketFeeTx(exchangeId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async collectMarketFeeTx(exchangeId: string): Promise<TransactionRequest> {
+  public async collectMarketFeeTx(
+    exchangeId: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
-    const estGas = await this.contract.collectMarketFee.estimateGas(exchangeId)
+    const estGas =
+      estimatedGas ?? (await this.contract.collectMarketFee.estimateGas(exchangeId))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -800,15 +834,19 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
     const estGas = await this.contract.collectOceanFee.estimateGas(exchangeId)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectOceanFeeTx(exchangeId)
+    const tx = await this.collectOceanFeeTx(exchangeId, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async collectOceanFeeTx(exchangeId: string): Promise<TransactionRequest> {
+  public async collectOceanFeeTx(
+    exchangeId: string,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
-    const estGas = await this.contract.collectOceanFee.estimateGas(exchangeId)
+    const estGas =
+      estimatedGas ?? (await this.contract.collectOceanFee.estimateGas(exchangeId))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -863,20 +901,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
       newMarketFeeUnits
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.updateMarketFeeTx(exchangeId, newMarketFee)
+    const tx = await this.updateMarketFeeTx(exchangeId, newMarketFee, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async updateMarketFeeTx(
     exchangeId: string,
-    newMarketFee: string
+    newMarketFee: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const newMarketFeeUnits = await this.amountToUnits(null, newMarketFee, 18)
-    const estGas = await this.contract.updateMarketFee.estimateGas(
-      exchangeId,
-      newMarketFeeUnits
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.updateMarketFee.estimateGas(exchangeId, newMarketFeeUnits))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -906,19 +944,26 @@ export class FixedRateExchange extends SmartContractWithAddress {
       newMarketFeeCollector
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.updateMarketFeeCollectorTx(exchangeId, newMarketFeeCollector)
+    const tx = await this.updateMarketFeeCollectorTx(
+      exchangeId,
+      newMarketFeeCollector,
+      estGas
+    )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async updateMarketFeeCollectorTx(
     exchangeId: string,
-    newMarketFeeCollector: string
+    newMarketFeeCollector: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
-    const estGas = await this.contract.updateMarketFeeCollector.estimateGas(
-      exchangeId,
-      newMarketFeeCollector
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.updateMarketFeeCollector.estimateGas(
+        exchangeId,
+        newMarketFeeCollector
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/FixedRateExchange.ts
+++ b/src/contracts/FixedRateExchange.ts
@@ -49,34 +49,12 @@ export class FixedRateExchange extends SmartContractWithAddress {
     consumeMarketFee: string = '0',
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const exchange = await this.getExchange(exchangeId)
-    const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
-    const dtAmountFormatted = await this.amountToUnits(
-      exchange.datatoken,
-      datatokenAmount,
-      Number(exchange.dtDecimals)
-    )
-    const maxBtFormatted = await this.amountToUnits(
-      exchange.baseToken,
-      maxBaseTokenAmount,
-      Number(exchange.btDecimals)
-    )
-
-    const estGas = await this.contract.buyDT.estimateGas(
-      exchangeId,
-      dtAmountFormatted,
-      maxBtFormatted,
-      consumeMarketAddress,
-      consumeMarketFeeFormatted
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
     const tx = await this.buyDatatokensTx(
       exchangeId,
       datatokenAmount,
       maxBaseTokenAmount,
       consumeMarketAddress,
-      consumeMarketFee,
-      estGas
+      consumeMarketFee
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -87,8 +65,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
     datatokenAmount: string,
     maxBaseTokenAmount: string,
     consumeMarketAddress: string = ZERO_ADDRESS,
-    consumeMarketFee: string = '0',
-    estimatedGas?: bigint
+    consumeMarketFee: string = '0'
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
@@ -102,15 +79,13 @@ export class FixedRateExchange extends SmartContractWithAddress {
       maxBaseTokenAmount,
       Number(exchange.btDecimals)
     )
-    const estGas =
-      estimatedGas ??
-      (await this.contract.buyDT.estimateGas(
-        exchangeId,
-        dtAmountFormatted,
-        maxBtFormatted,
-        consumeMarketAddress,
-        consumeMarketFeeFormatted
-      ))
+    const estGas = await this.contract.buyDT.estimateGas(
+      exchangeId,
+      dtAmountFormatted,
+      maxBtFormatted,
+      consumeMarketAddress,
+      consumeMarketFeeFormatted
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -147,6 +122,24 @@ export class FixedRateExchange extends SmartContractWithAddress {
     consumeMarketFee: string = '0',
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const tx = await this.sellDatatokensTx(
+      exchangeId,
+      datatokenAmount,
+      minBaseTokenAmount,
+      consumeMarketAddress,
+      consumeMarketFee
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async sellDatatokensTx(
+    exchangeId: string,
+    datatokenAmount: string,
+    minBaseTokenAmount: string,
+    consumeMarketAddress: string = ZERO_ADDRESS,
+    consumeMarketFee: string = '0'
+  ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
     const dtAmountFormatted = await this.amountToUnits(
@@ -166,48 +159,6 @@ export class FixedRateExchange extends SmartContractWithAddress {
       consumeMarketAddress,
       consumeMarketFeeFormatted
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.sellDatatokensTx(
-      exchangeId,
-      datatokenAmount,
-      minBaseTokenAmount,
-      consumeMarketAddress,
-      consumeMarketFee,
-      estGas
-    )
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async sellDatatokensTx(
-    exchangeId: string,
-    datatokenAmount: string,
-    minBaseTokenAmount: string,
-    consumeMarketAddress: string = ZERO_ADDRESS,
-    consumeMarketFee: string = '0',
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const exchange = await this.getExchange(exchangeId)
-    const consumeMarketFeeFormatted = await this.amountToUnits(null, consumeMarketFee, 18)
-    const dtAmountFormatted = await this.amountToUnits(
-      exchange.datatoken,
-      datatokenAmount,
-      Number(exchange.dtDecimals)
-    )
-    const minBtFormatted = await this.amountToUnits(
-      exchange.baseToken,
-      minBaseTokenAmount,
-      Number(exchange.btDecimals)
-    )
-    const estGas =
-      estimatedGas ??
-      (await this.contract.sellDT.estimateGas(
-        exchangeId,
-        dtAmountFormatted,
-        minBtFormatted,
-        consumeMarketAddress,
-        consumeMarketFeeFormatted
-      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -247,10 +198,8 @@ export class FixedRateExchange extends SmartContractWithAddress {
     newRate: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const newRateUnits = await this.amountToUnits(null, newRate, 18)
-    const estGas = await this.contract.setRate.estimateGas(exchangeId, newRateUnits)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setRateTx(exchangeId, newRate, estGas)
+    const tx = await this.setRateTx(exchangeId, newRate)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -258,12 +207,10 @@ export class FixedRateExchange extends SmartContractWithAddress {
 
   public async setRateTx(
     exchangeId: string,
-    newRate: string,
-    estimatedGas?: bigint
+    newRate: string
   ): Promise<TransactionRequest> {
     const newRateUnits = await this.amountToUnits(null, newRate, 18)
-    const estGas =
-      estimatedGas ?? (await this.contract.setRate.estimateGas(exchangeId, newRateUnits))
+    const estGas = await this.contract.setRate.estimateGas(exchangeId, newRateUnits)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -284,24 +231,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
     newAllowedSwapper: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.setAllowedSwapper.estimateGas(
-      exchangeId,
-      newAllowedSwapper
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setAllowedSwapperTx(exchangeId, newAllowedSwapper, estGas)
+    const tx = await this.setAllowedSwapperTx(exchangeId, newAllowedSwapper)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setAllowedSwapperTx(
     exchangeId: string,
-    newAllowedSwapper: string,
-    estimatedGas?: bigint
+    newAllowedSwapper: string
   ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ??
-      (await this.contract.setAllowedSwapper.estimateGas(exchangeId, newAllowedSwapper))
+    const estGas = await this.contract.setAllowedSwapper.estimateGas(
+      exchangeId,
+      newAllowedSwapper
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -327,22 +270,17 @@ export class FixedRateExchange extends SmartContractWithAddress {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) return null
     if (exchange.active === true) return null
-    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.activateTx(exchangeId, estGas)
+    const tx = await this.activateTx(exchangeId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async activateTx(
-    exchangeId: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
+  public async activateTx(exchangeId: string): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.active === true) throw new Error('Exchange already active')
-    const estGas =
-      estimatedGas ?? (await this.contract.toggleExchangeState.estimateGas(exchangeId))
+    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -365,22 +303,17 @@ export class FixedRateExchange extends SmartContractWithAddress {
     if (!exchange) return null
     if (exchange.active === false) return null
 
-    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.deactivateTx(exchangeId, estGas)
+    const tx = await this.deactivateTx(exchangeId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async deactivateTx(
-    exchangeId: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
+  public async deactivateTx(exchangeId: string): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.active === false) throw new Error('Exchange already inactive')
-    const estGas =
-      estimatedGas ?? (await this.contract.toggleExchangeState.estimateGas(exchangeId))
+    const estGas = await this.contract.toggleExchangeState.estimateGas(exchangeId)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -617,22 +550,17 @@ export class FixedRateExchange extends SmartContractWithAddress {
     if (!exchange) return null
     if (exchange.withMint === true) return null
 
-    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, true)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.activateMintTx(exchangeId, estGas)
+    const tx = await this.activateMintTx(exchangeId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async activateMintTx(
-    exchangeId: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
+  public async activateMintTx(exchangeId: string): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.withMint === true) throw new Error('Mint already active')
-    const estGas =
-      estimatedGas ?? (await this.contract.toggleMintState.estimateGas(exchangeId, true))
+    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, true)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -655,22 +583,17 @@ export class FixedRateExchange extends SmartContractWithAddress {
     if (!exchange) return null
     if (exchange.withMint === false) return null
 
-    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, false)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.deactivateMintTx(exchangeId, estGas)
+    const tx = await this.deactivateMintTx(exchangeId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async deactivateMintTx(
-    exchangeId: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
+  public async deactivateMintTx(exchangeId: string): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
     if (exchange.withMint === false) throw new Error('Mint already inactive')
-    const estGas =
-      estimatedGas ?? (await this.contract.toggleMintState.estimateGas(exchangeId, false))
+    const estGas = await this.contract.toggleMintState.estimateGas(exchangeId, false)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -691,27 +614,15 @@ export class FixedRateExchange extends SmartContractWithAddress {
     amount: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const exchange = await this.getExchange(exchangeId)
-    if (!exchange) return null
-
-    const fixedrate: FixedPriceExchange = await this.contract.getExchange(exchangeId)
-    const amountWei = await this.amountToUnits(
-      fixedrate.baseToken,
-      amount,
-      Number(fixedrate.btDecimals)
-    )
-
-    const estGas = await this.contract.collectBT.estimateGas(exchangeId, amountWei)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectBasetokensTx(exchangeId, amount, estGas)
+    const tx = await this.collectBasetokensTx(exchangeId, amount)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async collectBasetokensTx(
     exchangeId: string,
-    amount: string,
-    estimatedGas?: bigint
+    amount: string
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
@@ -721,8 +632,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
       amount,
       Number(fixedrate.btDecimals)
     )
-    const estGas =
-      estimatedGas ?? (await this.contract.collectBT.estimateGas(exchangeId, amountWei))
+    const estGas = await this.contract.collectBT.estimateGas(exchangeId, amountWei)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -743,27 +653,15 @@ export class FixedRateExchange extends SmartContractWithAddress {
     amount: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const exchange = await this.getExchange(exchangeId)
-    if (!exchange) return null
-
-    const fixedrate: FixedPriceExchange = await this.contract.getExchange(exchangeId)
-    const amountWei = await this.amountToUnits(
-      fixedrate.datatoken,
-      amount,
-      Number(fixedrate.dtDecimals)
-    )
-
-    const estGas = await this.contract.collectDT.estimateGas(exchangeId, amountWei)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectDatatokensTx(exchangeId, amount, estGas)
+    const tx = await this.collectDatatokensTx(exchangeId, amount)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async collectDatatokensTx(
     exchangeId: string,
-    amount: string,
-    estimatedGas?: bigint
+    amount: string
   ): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
@@ -773,8 +671,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
       amount,
       Number(fixedrate.dtDecimals)
     )
-    const estGas =
-      estimatedGas ?? (await this.contract.collectDT.estimateGas(exchangeId, amountWei))
+    const estGas = await this.contract.collectDT.estimateGas(exchangeId, amountWei)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -796,21 +693,14 @@ export class FixedRateExchange extends SmartContractWithAddress {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) return null
 
-    const estGas = await this.contract.collectMarketFee.estimateGas(exchangeId)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectMarketFeeTx(exchangeId, estGas)
+    const tx = await this.collectMarketFeeTx(exchangeId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async collectMarketFeeTx(
-    exchangeId: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const exchange = await this.getExchange(exchangeId)
-    if (!exchange) throw new Error('Exchange not found')
-    const estGas =
-      estimatedGas ?? (await this.contract.collectMarketFee.estimateGas(exchangeId))
+  public async collectMarketFeeTx(exchangeId: string): Promise<TransactionRequest> {
+    const estGas = await this.contract.collectMarketFee.estimateGas(exchangeId)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -829,24 +719,16 @@ export class FixedRateExchange extends SmartContractWithAddress {
     exchangeId: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const exchange = await this.getExchange(exchangeId)
-    if (!exchange) return null
-
-    const estGas = await this.contract.collectOceanFee.estimateGas(exchangeId)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.collectOceanFeeTx(exchangeId, estGas)
+    const tx = await this.collectOceanFeeTx(exchangeId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async collectOceanFeeTx(
-    exchangeId: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
+  public async collectOceanFeeTx(exchangeId: string): Promise<TransactionRequest> {
     const exchange = await this.getExchange(exchangeId)
     if (!exchange) throw new Error('Exchange not found')
-    const estGas =
-      estimatedGas ?? (await this.contract.collectOceanFee.estimateGas(exchangeId))
+    const estGas = await this.contract.collectOceanFee.estimateGas(exchangeId)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -895,26 +777,21 @@ export class FixedRateExchange extends SmartContractWithAddress {
     newMarketFee: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const newMarketFeeUnits = await this.amountToUnits(null, newMarketFee, 18)
-    const estGas = await this.contract.updateMarketFee.estimateGas(
-      exchangeId,
-      newMarketFeeUnits
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.updateMarketFeeTx(exchangeId, newMarketFee, estGas)
+    const tx = await this.updateMarketFeeTx(exchangeId, newMarketFee)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async updateMarketFeeTx(
     exchangeId: string,
-    newMarketFee: string,
-    estimatedGas?: bigint
+    newMarketFee: string
   ): Promise<TransactionRequest> {
     const newMarketFeeUnits = await this.amountToUnits(null, newMarketFee, 18)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.updateMarketFee.estimateGas(exchangeId, newMarketFeeUnits))
+    const estGas = await this.contract.updateMarketFee.estimateGas(
+      exchangeId,
+      newMarketFeeUnits
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -939,31 +816,20 @@ export class FixedRateExchange extends SmartContractWithAddress {
     newMarketFeeCollector: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.updateMarketFeeCollector.estimateGas(
-      exchangeId,
-      newMarketFeeCollector
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.updateMarketFeeCollectorTx(
-      exchangeId,
-      newMarketFeeCollector,
-      estGas
-    )
+    const tx = await this.updateMarketFeeCollectorTx(exchangeId, newMarketFeeCollector)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async updateMarketFeeCollectorTx(
     exchangeId: string,
-    newMarketFeeCollector: string,
-    estimatedGas?: bigint
+    newMarketFeeCollector: string
   ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ??
-      (await this.contract.updateMarketFeeCollector.estimateGas(
-        exchangeId,
-        newMarketFeeCollector
-      ))
+    const estGas = await this.contract.updateMarketFeeCollector.estimateGas(
+      exchangeId,
+      newMarketFeeCollector
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/FixedRateExchange.ts
+++ b/src/contracts/FixedRateExchange.ts
@@ -56,6 +56,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
       consumeMarketAddress,
       consumeMarketFee
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -129,6 +130,7 @@ export class FixedRateExchange extends SmartContractWithAddress {
       consumeMarketAddress,
       consumeMarketFee
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }

--- a/src/contracts/NFT.ts
+++ b/src/contracts/NFT.ts
@@ -1,4 +1,4 @@
-import { hexlify, keccak256, toUtf8Bytes, toUtf8String } from 'ethers'
+import { TransactionRequest, hexlify, keccak256, toUtf8Bytes, toUtf8String } from 'ethers'
 import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json'
 import {
   MetadataAndTokenURI,
@@ -10,7 +10,12 @@ import { SmartContract } from './SmartContract.js'
 
 import { generateDtName } from '../utils/DatatokenName.js'
 import { ZERO_ADDRESS } from '../utils/Constants.js'
-import { getEventFromTx, sendTx } from '../utils/ContractUtils.js'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  getEventFromTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 import {
   calculateActiveTemplateIndex,
   getOceanArtifactsAddressesByChainId
@@ -108,23 +113,98 @@ export class Nft extends SmartContract {
       }
     }
 
-    const tx = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.createERC20,
+    const tx = await this.createDatatokenTx(
+      nftAddress,
+      address,
+      minter,
+      paymentCollector,
+      mpFeeAddress,
+      feeToken,
+      feeAmount,
+      cap,
+      name,
+      symbol,
+      templateIndex,
+      filesObject,
+      accessListContract,
+      allowAccessList,
+      denyAccessList
+    )
+    const sentTx = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    if (!sentTx) {
+      throw new Error('Failed to send createDatatoken transaction')
+    }
+    const trxReceipt = await sentTx.wait()
+    const event = getEventFromTx(trxReceipt, 'TokenCreated')
+    return event?.args[0]
+  }
+
+  public async createDatatokenTx(
+    nftAddress: string,
+    address: string,
+    minter: string,
+    paymentCollector: string,
+    mpFeeAddress: string,
+    feeToken: string,
+    feeAmount: string,
+    cap: string,
+    name?: string,
+    symbol?: string,
+    templateIndex?: number,
+    filesObject?: string,
+    accessListContract?: string,
+    allowAccessList?: string,
+    denyAccessList?: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getNftPermissions(nftAddress, address)).deployERC20 !== true) {
+      throw new Error(`Caller is not DatatokenDeployer`)
+    }
+    if (!templateIndex) templateIndex = 1
+    if (!name || !symbol) {
+      ;({ name, symbol } = generateDtName())
+    }
+    const nftContract = this.getContract(nftAddress)
+    if (!this.signer.provider) {
+      throw new Error('Provider is required but not available')
+    }
+    const { chainId } = await this.signer.provider.getNetwork()
+    const artifacts = getOceanArtifactsAddressesByChainId(Number(chainId))
+    if (filesObject) {
+      templateIndex = await calculateActiveTemplateIndex(
+        this.signer,
+        artifacts.ERC721Factory,
+        4,
+        Number(chainId)
+      )
+    }
+    const addresses = [minter, paymentCollector, mpFeeAddress, feeToken]
+    if (accessListContract) {
+      addresses.push(accessListContract.toLowerCase())
+      addresses.push(allowAccessList ? allowAccessList.toLowerCase() : ZERO_ADDRESS)
+      addresses.push(denyAccessList || ZERO_ADDRESS)
+    }
+    const uintArgs = [
+      await this.amountToUnits(null, cap, 18),
+      await this.amountToUnits(null, feeAmount, 18)
+    ]
+    const bytesArgs = filesObject ? [toUtf8Bytes(filesObject)] : []
+    const estGas = await nftContract.createERC20.estimateGas(
       templateIndex,
       [name, symbol],
       addresses,
-      [
-        await this.amountToUnits(null, cap, 18),
-        await this.amountToUnits(null, feeAmount, 18)
-      ],
-      filesObject ? [toUtf8Bytes(filesObject)] : []
+      uintArgs,
+      bytesArgs
     )
-    const trxReceipt = await tx.wait()
-    const event = getEventFromTx(trxReceipt, 'TokenCreated')
-    return event?.args[0]
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      nftContract.createERC20,
+      [templateIndex, [name, symbol], addresses, uintArgs, bytesArgs],
+      overrides
+    )
   }
 
   /**
@@ -150,15 +230,27 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addManager.estimateGas(manager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.addManagerTx(nftAddress, address, manager)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addManagerTx(
+    nftAddress: string,
+    address: string,
+    manager: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftOwner(nftAddress)) !== address) {
+      throw new Error(`Caller is not NFT Owner`)
+    }
+    const estGas = await nftContract.addManager.estimateGas(manager)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.addManager,
-      manager
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.addManager, [manager], overrides)
   }
 
   /**
@@ -184,15 +276,27 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeManager.estimateGas(manager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.removeManagerTx(nftAddress, address, manager)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeManagerTx(
+    nftAddress: string,
+    address: string,
+    manager: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftOwner(nftAddress)) !== address) {
+      throw new Error(`Caller is not NFT Owner`)
+    }
+    const estGas = await nftContract.removeManager.estimateGas(manager)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.removeManager,
-      manager
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.removeManager, [manager], overrides)
   }
 
   /**
@@ -219,15 +323,31 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.addDatatokenDeployerTx(nftAddress, address, datatokenDeployer)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addDatatokenDeployerTx(
+    nftAddress: string,
+    address: string,
+    datatokenDeployer: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
+      throw new Error(`Caller is not Manager`)
+    }
+    const estGas = await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.addToCreateERC20List,
-      datatokenDeployer
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      nftContract.addToCreateERC20List,
+      [datatokenDeployer],
+      overrides
+    )
   }
 
   /**
@@ -258,15 +378,41 @@ export class Nft extends SmartContract {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.removeFromCreateERC20List,
+    const tx = await this.removeDatatokenDeployerTx(
+      nftAddress,
+      address,
       datatokenDeployer
     )
-
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeDatatokenDeployerTx(
+    nftAddress: string,
+    address: string,
+    datatokenDeployer: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if (
+      (await this.getNftPermissions(nftAddress, address)).manager !== true ||
+      (address === datatokenDeployer &&
+        (await this.getNftPermissions(nftAddress, address)).deployERC20 !== true)
+    ) {
+      throw new Error(`Caller is not Manager nor DatatokenDeployer`)
+    }
+    const estGas = await nftContract.removeFromCreateERC20List.estimateGas(
+      datatokenDeployer
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      nftContract.removeFromCreateERC20List,
+      [datatokenDeployer],
+      overrides
+    )
   }
 
   /**
@@ -292,14 +438,27 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addToMetadataList.estimateGas(metadataUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.addMetadataUpdaterTx(nftAddress, address, metadataUpdater)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addMetadataUpdaterTx(
+    nftAddress: string,
+    address: string,
+    metadataUpdater: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
+      throw new Error(`Caller is not Manager`)
+    }
+    const estGas = await nftContract.addToMetadataList.estimateGas(metadataUpdater)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.addToMetadataList,
-      metadataUpdater
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.addToMetadataList, [metadataUpdater], overrides)
   }
 
   /**
@@ -328,14 +487,35 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeFromMetadataList.estimateGas(metadataUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.removeMetadataUpdaterTx(nftAddress, address, metadataUpdater)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeMetadataUpdaterTx(
+    nftAddress: string,
+    address: string,
+    metadataUpdater: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if (
+      (await this.getNftPermissions(nftAddress, address)).manager !== true ||
+      (address !== metadataUpdater &&
+        (await this.getNftPermissions(nftAddress, address)).updateMetadata !== true)
+    ) {
+      throw new Error(`Caller is not Manager nor Metadata Updater`)
+    }
+    const estGas = await nftContract.removeFromMetadataList.estimateGas(metadataUpdater)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.removeFromMetadataList,
-      metadataUpdater
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      nftContract.removeFromMetadataList,
+      [metadataUpdater],
+      overrides
+    )
   }
 
   /**
@@ -361,15 +541,27 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addTo725StoreList.estimateGas(storeUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.addStoreUpdaterTx(nftAddress, address, storeUpdater)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addStoreUpdaterTx(
+    nftAddress: string,
+    address: string,
+    storeUpdater: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
+      throw new Error(`Caller is not Manager`)
+    }
+    const estGas = await nftContract.addTo725StoreList.estimateGas(storeUpdater)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.addTo725StoreList,
-      storeUpdater
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.addTo725StoreList, [storeUpdater], overrides)
   }
 
   /**
@@ -398,15 +590,31 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeFrom725StoreList.estimateGas(storeUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.removeStoreUpdaterTx(nftAddress, address, storeUpdater)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeStoreUpdaterTx(
+    nftAddress: string,
+    address: string,
+    storeUpdater: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if (
+      (await this.getNftPermissions(nftAddress, address)).manager !== true ||
+      (address !== storeUpdater &&
+        (await this.getNftPermissions(nftAddress, address)).store !== true)
+    ) {
+      throw new Error(`Caller is not Manager nor storeUpdater`)
+    }
+    const estGas = await nftContract.removeFrom725StoreList.estimateGas(storeUpdater)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.removeFrom725StoreList,
-      storeUpdater
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.removeFrom725StoreList, [storeUpdater], overrides)
   }
 
   /**
@@ -432,14 +640,26 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.cleanPermissions.estimateGas()
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.cleanPermissionsTx(nftAddress, address)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async cleanPermissionsTx(
+    nftAddress: string,
+    address: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftOwner(nftAddress)) !== address) {
+      throw new Error(`Caller is not NFT Owner`)
+    }
+    const estGas = await nftContract.cleanPermissions.estimateGas()
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.cleanPermissions
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.cleanPermissions, [], overrides)
   }
 
   /**
@@ -473,17 +693,42 @@ export class Nft extends SmartContract {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.transferFrom,
+    const tx = await this.transferNftTx(
+      nftAddress,
       nftOwner,
       nftReceiver,
       tokenIdentifier
     )
-
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async transferNftTx(
+    nftAddress: string,
+    nftOwner: string,
+    nftReceiver: string,
+    tokenId?: number
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
+      throw new Error(`Caller is not NFT Owner`)
+    }
+    const tokenIdentifier = tokenId || 1
+    const estGas = await nftContract.transferFrom.estimateGas(
+      nftOwner,
+      nftReceiver,
+      tokenIdentifier
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      nftContract.transferFrom,
+      [nftOwner, nftReceiver, tokenIdentifier],
+      overrides
+    )
   }
 
   /**
@@ -517,17 +762,42 @@ export class Nft extends SmartContract {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.safeTransferFrom,
+    const tx = await this.safeTransferNftTx(
+      nftAddress,
       nftOwner,
       nftReceiver,
       tokenIdentifier
     )
-
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async safeTransferNftTx(
+    nftAddress: string,
+    nftOwner: string,
+    nftReceiver: string,
+    tokenId?: number
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
+      throw new Error(`Caller is not NFT Owner`)
+    }
+    const tokenIdentifier = tokenId || 1
+    const estGas = await nftContract.safeTransferFrom.estimateGas(
+      nftOwner,
+      nftReceiver,
+      tokenIdentifier
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      nftContract.safeTransferFrom,
+      [nftOwner, nftReceiver, tokenIdentifier],
+      overrides
+    )
   }
 
   /**
@@ -578,11 +848,43 @@ export class Nft extends SmartContract {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.signer,
-      this.config?.gasFeeMultiplier,
-      nftContract.setMetaData,
+    const tx = await this.setMetadataTx(
+      nftAddress,
+      address,
+      metadataState,
+      metadataDecryptorUrl,
+      metadataDecryptorAddress,
+      flags,
+      data,
+      metadataHash,
+      metadataProofs
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setMetadataTx(
+    nftAddress: string,
+    address: string,
+    metadataState: number,
+    metadataDecryptorUrl: string,
+    metadataDecryptorAddress: string,
+    flags: string,
+    data: string,
+    metadataHash: string,
+    metadataProofs?: MetadataProof[]
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if (!metadataProofs) metadataProofs = []
+    if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
+      throw new Error(`Caller is not Metadata updater`)
+    }
+    let decryptorUrl = metadataDecryptorUrl
+    if (metadataDecryptorUrl?.includes('/p2p/')) {
+      const p2pMatch = metadataDecryptorUrl.match(/\/p2p\/([^/]+)/)
+      decryptorUrl = p2pMatch?.[1] ?? metadataDecryptorUrl
+    }
+    const estGas = await nftContract.setMetaData.estimateGas(
       metadataState,
       decryptorUrl,
       metadataDecryptorAddress,
@@ -591,8 +893,24 @@ export class Nft extends SmartContract {
       metadataHash,
       metadataProofs
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      nftContract.setMetaData,
+      [
+        metadataState,
+        decryptorUrl,
+        metadataDecryptorAddress,
+        flags,
+        data,
+        metadataHash,
+        metadataProofs
+      ],
+      overrides
+    )
   }
 
   /**
@@ -622,15 +940,41 @@ export class Nft extends SmartContract {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.signer,
-      this.config?.gasFeeMultiplier,
-      nftContract.setMetaDataAndTokenURI,
+    const tx = await this.setMetadataAndTokenURITx(
+      nftAddress,
+      metadataUpdater,
+      metadataAndTokenURI
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setMetadataAndTokenURITx(
+    nftAddress: string,
+    metadataUpdater: string,
+    metadataAndTokenURI: MetadataAndTokenURI
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if (!(await this.getNftPermissions(nftAddress, metadataUpdater)).updateMetadata) {
+      throw new Error(`Caller is not Metadata updater`)
+    }
+    const sanitizedMetadataAndTokenURI = {
+      ...metadataAndTokenURI,
+      metadataProofs: metadataAndTokenURI.metadataProofs || []
+    }
+    const estGas = await nftContract.setMetaDataAndTokenURI.estimateGas(
       sanitizedMetadataAndTokenURI
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      nftContract.setMetaDataAndTokenURI,
+      [sanitizedMetadataAndTokenURI],
+      overrides
+    )
   }
 
   /**
@@ -655,14 +999,27 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.setMetaDataState.estimateGas(metadataState)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.setMetadataStateTx(nftAddress, address, metadataState)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setMetadataStateTx(
+    nftAddress: string,
+    address: string,
+    metadataState: number
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
+      throw new Error(`Caller is not Metadata updater`)
+    }
+    const estGas = await nftContract.setMetaDataState.estimateGas(metadataState)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.setMetaDataState,
-      metadataState
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.setMetaDataState, [metadataState], overrides)
   }
 
   /**
@@ -681,15 +1038,23 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.setTokenURI.estimateGas('1', data)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.setTokenURITx(nftAddress, data)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setTokenURITx(
+    nftAddress: string,
+    data: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
+    const estGas = await nftContract.setTokenURI.estimateGas('1', data)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.setTokenURI,
-      '1',
-      data
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(nftContract.setTokenURI, ['1', data], overrides)
   }
 
   /**
@@ -767,16 +1132,31 @@ export class Nft extends SmartContract {
 
     const estGas = await nftContract.setNewData.estimateGas(keyHash, valueHex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      nftContract.setNewData,
-      keyHash,
-      valueHex
-    )
+    const tx = await this.setDataTx(nftAddress, address, key, value)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setDataTx(
+    nftAddress: string,
+    address: string,
+    key: string,
+    value: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getNftPermissions(nftAddress, address)).store !== true) {
+      throw new Error(`User is not ERC20 store updater`)
+    }
+    const nftContract = this.getContract(nftAddress)
+    const keyHash = keccak256(key)
+    const valueHex = hexlify(toUtf8Bytes(value))
+    const estGas = await nftContract.setNewData.estimateGas(keyHash, valueHex)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(nftContract.setNewData, [keyHash, valueHex], overrides)
   }
 
   /**

--- a/src/contracts/NFT.ts
+++ b/src/contracts/NFT.ts
@@ -824,6 +824,7 @@ export class Nft extends SmartContract {
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
     const tx = await this.setTokenURITx(nftAddress, data)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -952,8 +953,8 @@ export class Nft extends SmartContract {
    * Gets the token URI of an NFT.
    * @param {string} nftAddress - The address of the NFT.
    * @param {number} id - The ID of the token.
-   * @returns {Promise&lt;string&gt;}
-    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+   * @returns {Promise<string>}
+    
    */
   public async getTokenURI(nftAddress: string, id: number): Promise<string> {
     const nftContract = this.getContract(nftAddress)

--- a/src/contracts/NFT.ts
+++ b/src/contracts/NFT.ts
@@ -128,7 +128,8 @@ export class Nft extends SmartContract {
       filesObject,
       accessListContract,
       allowAccessList,
-      denyAccessList
+      denyAccessList,
+      estGas
     )
     const sentTx = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     if (!sentTx) {
@@ -154,7 +155,8 @@ export class Nft extends SmartContract {
     filesObject?: string,
     accessListContract?: string,
     allowAccessList?: string,
-    denyAccessList?: string
+    denyAccessList?: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getNftPermissions(nftAddress, address)).deployERC20 !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
@@ -188,13 +190,15 @@ export class Nft extends SmartContract {
       await this.amountToUnits(null, feeAmount, 18)
     ]
     const bytesArgs = filesObject ? [toUtf8Bytes(filesObject)] : []
-    const estGas = await nftContract.createERC20.estimateGas(
-      templateIndex,
-      [name, symbol],
-      addresses,
-      uintArgs,
-      bytesArgs
-    )
+    const estGas =
+      estimatedGas ??
+      (await nftContract.createERC20.estimateGas(
+        templateIndex,
+        [name, symbol],
+        addresses,
+        uintArgs,
+        bytesArgs
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -230,7 +234,7 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addManager.estimateGas(manager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addManagerTx(nftAddress, address, manager)
+    const tx = await this.addManagerTx(nftAddress, address, manager, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -238,13 +242,14 @@ export class Nft extends SmartContract {
   public async addManagerTx(
     nftAddress: string,
     address: string,
-    manager: string
+    manager: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== address) {
       throw new Error(`Caller is not NFT Owner`)
     }
-    const estGas = await nftContract.addManager.estimateGas(manager)
+    const estGas = estimatedGas ?? (await nftContract.addManager.estimateGas(manager))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -276,7 +281,7 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeManager.estimateGas(manager)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.removeManagerTx(nftAddress, address, manager)
+    const tx = await this.removeManagerTx(nftAddress, address, manager, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -284,13 +289,14 @@ export class Nft extends SmartContract {
   public async removeManagerTx(
     nftAddress: string,
     address: string,
-    manager: string
+    manager: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== address) {
       throw new Error(`Caller is not NFT Owner`)
     }
-    const estGas = await nftContract.removeManager.estimateGas(manager)
+    const estGas = estimatedGas ?? (await nftContract.removeManager.estimateGas(manager))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -323,7 +329,12 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addDatatokenDeployerTx(nftAddress, address, datatokenDeployer)
+    const tx = await this.addDatatokenDeployerTx(
+      nftAddress,
+      address,
+      datatokenDeployer,
+      estGas
+    )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -331,13 +342,16 @@ export class Nft extends SmartContract {
   public async addDatatokenDeployerTx(
     nftAddress: string,
     address: string,
-    datatokenDeployer: string
+    datatokenDeployer: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
       throw new Error(`Caller is not Manager`)
     }
-    const estGas = await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer)
+    const estGas =
+      estimatedGas ??
+      (await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -381,7 +395,8 @@ export class Nft extends SmartContract {
     const tx = await this.removeDatatokenDeployerTx(
       nftAddress,
       address,
-      datatokenDeployer
+      datatokenDeployer,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -390,7 +405,8 @@ export class Nft extends SmartContract {
   public async removeDatatokenDeployerTx(
     nftAddress: string,
     address: string,
-    datatokenDeployer: string
+    datatokenDeployer: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (
@@ -400,9 +416,9 @@ export class Nft extends SmartContract {
     ) {
       throw new Error(`Caller is not Manager nor DatatokenDeployer`)
     }
-    const estGas = await nftContract.removeFromCreateERC20List.estimateGas(
-      datatokenDeployer
-    )
+    const estGas =
+      estimatedGas ??
+      (await nftContract.removeFromCreateERC20List.estimateGas(datatokenDeployer))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -438,7 +454,12 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addToMetadataList.estimateGas(metadataUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addMetadataUpdaterTx(nftAddress, address, metadataUpdater)
+    const tx = await this.addMetadataUpdaterTx(
+      nftAddress,
+      address,
+      metadataUpdater,
+      estGas
+    )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -446,13 +467,15 @@ export class Nft extends SmartContract {
   public async addMetadataUpdaterTx(
     nftAddress: string,
     address: string,
-    metadataUpdater: string
+    metadataUpdater: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
       throw new Error(`Caller is not Manager`)
     }
-    const estGas = await nftContract.addToMetadataList.estimateGas(metadataUpdater)
+    const estGas =
+      estimatedGas ?? (await nftContract.addToMetadataList.estimateGas(metadataUpdater))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -487,7 +510,12 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeFromMetadataList.estimateGas(metadataUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.removeMetadataUpdaterTx(nftAddress, address, metadataUpdater)
+    const tx = await this.removeMetadataUpdaterTx(
+      nftAddress,
+      address,
+      metadataUpdater,
+      estGas
+    )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -495,7 +523,8 @@ export class Nft extends SmartContract {
   public async removeMetadataUpdaterTx(
     nftAddress: string,
     address: string,
-    metadataUpdater: string
+    metadataUpdater: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (
@@ -505,7 +534,9 @@ export class Nft extends SmartContract {
     ) {
       throw new Error(`Caller is not Manager nor Metadata Updater`)
     }
-    const estGas = await nftContract.removeFromMetadataList.estimateGas(metadataUpdater)
+    const estGas =
+      estimatedGas ??
+      (await nftContract.removeFromMetadataList.estimateGas(metadataUpdater))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -541,7 +572,7 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.addTo725StoreList.estimateGas(storeUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addStoreUpdaterTx(nftAddress, address, storeUpdater)
+    const tx = await this.addStoreUpdaterTx(nftAddress, address, storeUpdater, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -549,13 +580,15 @@ export class Nft extends SmartContract {
   public async addStoreUpdaterTx(
     nftAddress: string,
     address: string,
-    storeUpdater: string
+    storeUpdater: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
       throw new Error(`Caller is not Manager`)
     }
-    const estGas = await nftContract.addTo725StoreList.estimateGas(storeUpdater)
+    const estGas =
+      estimatedGas ?? (await nftContract.addTo725StoreList.estimateGas(storeUpdater))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -590,7 +623,7 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeFrom725StoreList.estimateGas(storeUpdater)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.removeStoreUpdaterTx(nftAddress, address, storeUpdater)
+    const tx = await this.removeStoreUpdaterTx(nftAddress, address, storeUpdater, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -598,7 +631,8 @@ export class Nft extends SmartContract {
   public async removeStoreUpdaterTx(
     nftAddress: string,
     address: string,
-    storeUpdater: string
+    storeUpdater: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (
@@ -608,7 +642,8 @@ export class Nft extends SmartContract {
     ) {
       throw new Error(`Caller is not Manager nor storeUpdater`)
     }
-    const estGas = await nftContract.removeFrom725StoreList.estimateGas(storeUpdater)
+    const estGas =
+      estimatedGas ?? (await nftContract.removeFrom725StoreList.estimateGas(storeUpdater))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -640,20 +675,21 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.cleanPermissions.estimateGas()
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.cleanPermissionsTx(nftAddress, address)
+    const tx = await this.cleanPermissionsTx(nftAddress, address, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async cleanPermissionsTx(
     nftAddress: string,
-    address: string
+    address: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== address) {
       throw new Error(`Caller is not NFT Owner`)
     }
-    const estGas = await nftContract.cleanPermissions.estimateGas()
+    const estGas = estimatedGas ?? (await nftContract.cleanPermissions.estimateGas())
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -697,7 +733,8 @@ export class Nft extends SmartContract {
       nftAddress,
       nftOwner,
       nftReceiver,
-      tokenIdentifier
+      tokenIdentifier,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -707,18 +744,17 @@ export class Nft extends SmartContract {
     nftAddress: string,
     nftOwner: string,
     nftReceiver: string,
-    tokenId?: number
+    tokenId?: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
       throw new Error(`Caller is not NFT Owner`)
     }
     const tokenIdentifier = tokenId || 1
-    const estGas = await nftContract.transferFrom.estimateGas(
-      nftOwner,
-      nftReceiver,
-      tokenIdentifier
-    )
+    const estGas =
+      estimatedGas ??
+      (await nftContract.transferFrom.estimateGas(nftOwner, nftReceiver, tokenIdentifier))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -766,7 +802,8 @@ export class Nft extends SmartContract {
       nftAddress,
       nftOwner,
       nftReceiver,
-      tokenIdentifier
+      tokenIdentifier,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -776,18 +813,21 @@ export class Nft extends SmartContract {
     nftAddress: string,
     nftOwner: string,
     nftReceiver: string,
-    tokenId?: number
+    tokenId?: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
       throw new Error(`Caller is not NFT Owner`)
     }
     const tokenIdentifier = tokenId || 1
-    const estGas = await nftContract.safeTransferFrom.estimateGas(
-      nftOwner,
-      nftReceiver,
-      tokenIdentifier
-    )
+    const estGas =
+      estimatedGas ??
+      (await nftContract.safeTransferFrom.estimateGas(
+        nftOwner,
+        nftReceiver,
+        tokenIdentifier
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -857,7 +897,8 @@ export class Nft extends SmartContract {
       flags,
       data,
       metadataHash,
-      metadataProofs
+      metadataProofs,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -872,7 +913,8 @@ export class Nft extends SmartContract {
     flags: string,
     data: string,
     metadataHash: string,
-    metadataProofs?: MetadataProof[]
+    metadataProofs?: MetadataProof[],
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (!metadataProofs) metadataProofs = []
@@ -884,15 +926,17 @@ export class Nft extends SmartContract {
       const p2pMatch = metadataDecryptorUrl.match(/\/p2p\/([^/]+)/)
       decryptorUrl = p2pMatch?.[1] ?? metadataDecryptorUrl
     }
-    const estGas = await nftContract.setMetaData.estimateGas(
-      metadataState,
-      decryptorUrl,
-      metadataDecryptorAddress,
-      flags,
-      data,
-      metadataHash,
-      metadataProofs
-    )
+    const estGas =
+      estimatedGas ??
+      (await nftContract.setMetaData.estimateGas(
+        metadataState,
+        decryptorUrl,
+        metadataDecryptorAddress,
+        flags,
+        data,
+        metadataHash,
+        metadataProofs
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -943,7 +987,8 @@ export class Nft extends SmartContract {
     const tx = await this.setMetadataAndTokenURITx(
       nftAddress,
       metadataUpdater,
-      metadataAndTokenURI
+      metadataAndTokenURI,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -952,7 +997,8 @@ export class Nft extends SmartContract {
   public async setMetadataAndTokenURITx(
     nftAddress: string,
     metadataUpdater: string,
-    metadataAndTokenURI: MetadataAndTokenURI
+    metadataAndTokenURI: MetadataAndTokenURI,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (!(await this.getNftPermissions(nftAddress, metadataUpdater)).updateMetadata) {
@@ -962,9 +1008,9 @@ export class Nft extends SmartContract {
       ...metadataAndTokenURI,
       metadataProofs: metadataAndTokenURI.metadataProofs || []
     }
-    const estGas = await nftContract.setMetaDataAndTokenURI.estimateGas(
-      sanitizedMetadataAndTokenURI
-    )
+    const estGas =
+      estimatedGas ??
+      (await nftContract.setMetaDataAndTokenURI.estimateGas(sanitizedMetadataAndTokenURI))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -999,7 +1045,7 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.setMetaDataState.estimateGas(metadataState)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.setMetadataStateTx(nftAddress, address, metadataState)
+    const tx = await this.setMetadataStateTx(nftAddress, address, metadataState, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -1007,13 +1053,15 @@ export class Nft extends SmartContract {
   public async setMetadataStateTx(
     nftAddress: string,
     address: string,
-    metadataState: number
+    metadataState: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
       throw new Error(`Caller is not Metadata updater`)
     }
-    const estGas = await nftContract.setMetaDataState.estimateGas(metadataState)
+    const estGas =
+      estimatedGas ?? (await nftContract.setMetaDataState.estimateGas(metadataState))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1038,17 +1086,18 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.setTokenURI.estimateGas('1', data)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.setTokenURITx(nftAddress, data)
+    const tx = await this.setTokenURITx(nftAddress, data, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setTokenURITx(
     nftAddress: string,
-    data: string
+    data: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
-    const estGas = await nftContract.setTokenURI.estimateGas('1', data)
+    const estGas = estimatedGas ?? (await nftContract.setTokenURI.estimateGas('1', data))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1132,7 +1181,7 @@ export class Nft extends SmartContract {
 
     const estGas = await nftContract.setNewData.estimateGas(keyHash, valueHex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setDataTx(nftAddress, address, key, value)
+    const tx = await this.setDataTx(nftAddress, address, key, value, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -1142,7 +1191,8 @@ export class Nft extends SmartContract {
     nftAddress: string,
     address: string,
     key: string,
-    value: string
+    value: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getNftPermissions(nftAddress, address)).store !== true) {
       throw new Error(`User is not ERC20 store updater`)
@@ -1150,7 +1200,8 @@ export class Nft extends SmartContract {
     const nftContract = this.getContract(nftAddress)
     const keyHash = keccak256(key)
     const valueHex = hexlify(toUtf8Bytes(value))
-    const estGas = await nftContract.setNewData.estimateGas(keyHash, valueHex)
+    const estGas =
+      estimatedGas ?? (await nftContract.setNewData.estimateGas(keyHash, valueHex))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/NFT.ts
+++ b/src/contracts/NFT.ts
@@ -20,7 +20,7 @@ import {
   calculateActiveTemplateIndex,
   getOceanArtifactsAddressesByChainId
 } from '../utils/Addresses.js'
-import { MetadataProof } from '@oceanprotocol/ddo-js'
+import type { MetadataProof } from '@oceanprotocol/ddo-js'
 export class Nft extends SmartContract {
   getDefaultAbi() {
     return ERC721Template.abi as AbiItem[]
@@ -60,59 +60,6 @@ export class Nft extends SmartContract {
     denyAccessList?: string,
     estimateGas?: G
   ): Promise<G extends false ? string : BigInt> {
-    if ((await this.getNftPermissions(nftAddress, address)).deployERC20 !== true) {
-      throw new Error(`Caller is not DatatokenDeployer`)
-    }
-    if (!templateIndex) templateIndex = 1
-
-    // Generate name & symbol if not present
-    if (!name || !symbol) {
-      ;({ name, symbol } = generateDtName())
-    }
-
-    // Create 721contract object
-    const nftContract = this.getContract(nftAddress)
-
-    if (!this.signer.provider) {
-      throw new Error('Provider is required but not available')
-    }
-    const { chainId } = await this.signer.provider.getNetwork()
-    const artifacts = getOceanArtifactsAddressesByChainId(Number(chainId))
-    if (filesObject) {
-      templateIndex = await calculateActiveTemplateIndex(
-        this.signer,
-        artifacts.ERC721Factory,
-        4,
-        Number(chainId)
-      )
-    }
-    const estGas = await nftContract.createERC20.estimateGas(
-      templateIndex,
-      [name, symbol],
-      [minter, paymentCollector, mpFeeAddress, feeToken],
-      [
-        await this.amountToUnits(null, cap, 18),
-        await this.amountToUnits(null, feeAmount, 18)
-      ],
-      []
-    )
-    if (estimateGas) return <G extends false ? string : bigint>estGas
-
-    const addresses = [minter, paymentCollector, mpFeeAddress, feeToken]
-    if (accessListContract) {
-      addresses.push(accessListContract.toLowerCase())
-      if (allowAccessList) {
-        addresses.push(allowAccessList.toLowerCase())
-      } else {
-        addresses.push(ZERO_ADDRESS)
-      }
-      if (denyAccessList) {
-        addresses.push(denyAccessList)
-      } else {
-        addresses.push(ZERO_ADDRESS)
-      }
-    }
-
     const tx = await this.createDatatokenTx(
       nftAddress,
       address,
@@ -128,9 +75,9 @@ export class Nft extends SmartContract {
       filesObject,
       accessListContract,
       allowAccessList,
-      denyAccessList,
-      estGas
+      denyAccessList
     )
+    if (estimateGas) return <G extends false ? string : bigint>tx.gasLimit
     const sentTx = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     if (!sentTx) {
       throw new Error('Failed to send createDatatoken transaction')
@@ -155,8 +102,7 @@ export class Nft extends SmartContract {
     filesObject?: string,
     accessListContract?: string,
     allowAccessList?: string,
-    denyAccessList?: string,
-    estimatedGas?: bigint
+    denyAccessList?: string
   ): Promise<TransactionRequest> {
     if ((await this.getNftPermissions(nftAddress, address)).deployERC20 !== true) {
       throw new Error(`Caller is not DatatokenDeployer`)
@@ -190,15 +136,13 @@ export class Nft extends SmartContract {
       await this.amountToUnits(null, feeAmount, 18)
     ]
     const bytesArgs = filesObject ? [toUtf8Bytes(filesObject)] : []
-    const estGas =
-      estimatedGas ??
-      (await nftContract.createERC20.estimateGas(
-        templateIndex,
-        [name, symbol],
-        addresses,
-        uintArgs,
-        bytesArgs
-      ))
+    const estGas = await nftContract.createERC20.estimateGas(
+      templateIndex,
+      [name, symbol],
+      addresses,
+      uintArgs,
+      bytesArgs
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -225,16 +169,8 @@ export class Nft extends SmartContract {
     manager: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-
-    if ((await this.getNftOwner(nftAddress)) !== address) {
-      throw new Error(`Caller is not NFT Owner`)
-    }
-
-    const estGas = await nftContract.addManager.estimateGas(manager)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addManagerTx(nftAddress, address, manager, estGas)
+    const tx = await this.addManagerTx(nftAddress, address, manager)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -242,14 +178,13 @@ export class Nft extends SmartContract {
   public async addManagerTx(
     nftAddress: string,
     address: string,
-    manager: string,
-    estimatedGas?: bigint
+    manager: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== address) {
       throw new Error(`Caller is not NFT Owner`)
     }
-    const estGas = estimatedGas ?? (await nftContract.addManager.estimateGas(manager))
+    const estGas = await nftContract.addManager.estimateGas(manager)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -272,16 +207,8 @@ export class Nft extends SmartContract {
     manager: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-
-    if ((await this.getNftOwner(nftAddress)) !== address) {
-      throw new Error(`Caller is not NFT Owner`)
-    }
-
-    const estGas = await nftContract.removeManager.estimateGas(manager)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeManagerTx(nftAddress, address, manager, estGas)
+    const tx = await this.removeManagerTx(nftAddress, address, manager)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -289,14 +216,13 @@ export class Nft extends SmartContract {
   public async removeManagerTx(
     nftAddress: string,
     address: string,
-    manager: string,
-    estimatedGas?: bigint
+    manager: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== address) {
       throw new Error(`Caller is not NFT Owner`)
     }
-    const estGas = estimatedGas ?? (await nftContract.removeManager.estimateGas(manager))
+    const estGas = await nftContract.removeManager.estimateGas(manager)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -319,22 +245,8 @@ export class Nft extends SmartContract {
     datatokenDeployer: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-
-    if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
-      throw new Error(`Caller is not Manager`)
-    }
-
-    // Estimate gas for addToCreateERC20List method
-    const estGas = await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addDatatokenDeployerTx(
-      nftAddress,
-      address,
-      datatokenDeployer,
-      estGas
-    )
+    const tx = await this.addDatatokenDeployerTx(nftAddress, address, datatokenDeployer)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -342,16 +254,13 @@ export class Nft extends SmartContract {
   public async addDatatokenDeployerTx(
     nftAddress: string,
     address: string,
-    datatokenDeployer: string,
-    estimatedGas?: bigint
+    datatokenDeployer: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
       throw new Error(`Caller is not Manager`)
     }
-    const estGas =
-      estimatedGas ??
-      (await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer))
+    const estGas = await nftContract.addToCreateERC20List.estimateGas(datatokenDeployer)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -378,8 +287,22 @@ export class Nft extends SmartContract {
     datatokenDeployer: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
+    const tx = await this.removeDatatokenDeployerTx(
+      nftAddress,
+      address,
+      datatokenDeployer
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
+  public async removeDatatokenDeployerTx(
+    nftAddress: string,
+    address: string,
+    datatokenDeployer: string
+  ): Promise<TransactionRequest> {
+    const nftContract = this.getContract(nftAddress)
     if (
       (await this.getNftPermissions(nftAddress, address)).manager !== true ||
       (address === datatokenDeployer &&
@@ -390,35 +313,6 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.removeFromCreateERC20List.estimateGas(
       datatokenDeployer
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeDatatokenDeployerTx(
-      nftAddress,
-      address,
-      datatokenDeployer,
-      estGas
-    )
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async removeDatatokenDeployerTx(
-    nftAddress: string,
-    address: string,
-    datatokenDeployer: string,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const nftContract = this.getContract(nftAddress)
-    if (
-      (await this.getNftPermissions(nftAddress, address)).manager !== true ||
-      (address === datatokenDeployer &&
-        (await this.getNftPermissions(nftAddress, address)).deployERC20 !== true)
-    ) {
-      throw new Error(`Caller is not Manager nor DatatokenDeployer`)
-    }
-    const estGas =
-      estimatedGas ??
-      (await nftContract.removeFromCreateERC20List.estimateGas(datatokenDeployer))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -445,21 +339,8 @@ export class Nft extends SmartContract {
     metadataUpdater: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-
-    if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
-      throw new Error(`Caller is not Manager`)
-    }
-
-    const estGas = await nftContract.addToMetadataList.estimateGas(metadataUpdater)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addMetadataUpdaterTx(
-      nftAddress,
-      address,
-      metadataUpdater,
-      estGas
-    )
+    const tx = await this.addMetadataUpdaterTx(nftAddress, address, metadataUpdater)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -467,15 +348,13 @@ export class Nft extends SmartContract {
   public async addMetadataUpdaterTx(
     nftAddress: string,
     address: string,
-    metadataUpdater: string,
-    estimatedGas?: bigint
+    metadataUpdater: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
       throw new Error(`Caller is not Manager`)
     }
-    const estGas =
-      estimatedGas ?? (await nftContract.addToMetadataList.estimateGas(metadataUpdater))
+    const estGas = await nftContract.addToMetadataList.estimateGas(metadataUpdater)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -498,24 +377,8 @@ export class Nft extends SmartContract {
     metadataUpdater: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    if (
-      (await this.getNftPermissions(nftAddress, address)).manager !== true ||
-      (address !== metadataUpdater &&
-        (await this.getNftPermissions(nftAddress, address)).updateMetadata !== true)
-    ) {
-      throw new Error(`Caller is not Manager nor Metadata Updater`)
-    }
-
-    const estGas = await nftContract.removeFromMetadataList.estimateGas(metadataUpdater)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeMetadataUpdaterTx(
-      nftAddress,
-      address,
-      metadataUpdater,
-      estGas
-    )
+    const tx = await this.removeMetadataUpdaterTx(nftAddress, address, metadataUpdater)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -523,8 +386,7 @@ export class Nft extends SmartContract {
   public async removeMetadataUpdaterTx(
     nftAddress: string,
     address: string,
-    metadataUpdater: string,
-    estimatedGas?: bigint
+    metadataUpdater: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (
@@ -534,9 +396,7 @@ export class Nft extends SmartContract {
     ) {
       throw new Error(`Caller is not Manager nor Metadata Updater`)
     }
-    const estGas =
-      estimatedGas ??
-      (await nftContract.removeFromMetadataList.estimateGas(metadataUpdater))
+    const estGas = await nftContract.removeFromMetadataList.estimateGas(metadataUpdater)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -563,16 +423,8 @@ export class Nft extends SmartContract {
     storeUpdater: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-
-    if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
-      throw new Error(`Caller is not Manager`)
-    }
-
-    const estGas = await nftContract.addTo725StoreList.estimateGas(storeUpdater)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addStoreUpdaterTx(nftAddress, address, storeUpdater, estGas)
+    const tx = await this.addStoreUpdaterTx(nftAddress, address, storeUpdater)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -580,15 +432,13 @@ export class Nft extends SmartContract {
   public async addStoreUpdaterTx(
     nftAddress: string,
     address: string,
-    storeUpdater: string,
-    estimatedGas?: bigint
+    storeUpdater: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftPermissions(nftAddress, address)).manager !== true) {
       throw new Error(`Caller is not Manager`)
     }
-    const estGas =
-      estimatedGas ?? (await nftContract.addTo725StoreList.estimateGas(storeUpdater))
+    const estGas = await nftContract.addTo725StoreList.estimateGas(storeUpdater)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -611,19 +461,8 @@ export class Nft extends SmartContract {
     storeUpdater: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    if (
-      (await this.getNftPermissions(nftAddress, address)).manager !== true ||
-      (address !== storeUpdater &&
-        (await this.getNftPermissions(nftAddress, address)).store !== true)
-    ) {
-      throw new Error(`Caller is not Manager nor storeUpdater`)
-    }
-
-    const estGas = await nftContract.removeFrom725StoreList.estimateGas(storeUpdater)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeStoreUpdaterTx(nftAddress, address, storeUpdater, estGas)
+    const tx = await this.removeStoreUpdaterTx(nftAddress, address, storeUpdater)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -631,8 +470,7 @@ export class Nft extends SmartContract {
   public async removeStoreUpdaterTx(
     nftAddress: string,
     address: string,
-    storeUpdater: string,
-    estimatedGas?: bigint
+    storeUpdater: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (
@@ -642,8 +480,7 @@ export class Nft extends SmartContract {
     ) {
       throw new Error(`Caller is not Manager nor storeUpdater`)
     }
-    const estGas =
-      estimatedGas ?? (await nftContract.removeFrom725StoreList.estimateGas(storeUpdater))
+    const estGas = await nftContract.removeFrom725StoreList.estimateGas(storeUpdater)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -667,29 +504,21 @@ export class Nft extends SmartContract {
     address: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    if ((await this.getNftOwner(nftAddress)) !== address) {
-      throw new Error(`Caller is not NFT Owner`)
-    }
-
-    const estGas = await nftContract.cleanPermissions.estimateGas()
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.cleanPermissionsTx(nftAddress, address, estGas)
+    const tx = await this.cleanPermissionsTx(nftAddress, address)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async cleanPermissionsTx(
     nftAddress: string,
-    address: string,
-    estimatedGas?: bigint
+    address: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== address) {
       throw new Error(`Caller is not NFT Owner`)
     }
-    const estGas = estimatedGas ?? (await nftContract.cleanPermissions.estimateGas())
+    const estGas = await nftContract.cleanPermissions.estimateGas()
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -715,27 +544,8 @@ export class Nft extends SmartContract {
     tokenId?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
-      throw new Error(`Caller is not NFT Owner`)
-    }
-
-    const tokenIdentifier = tokenId || 1
-
-    const estGas = await nftContract.transferFrom.estimateGas(
-      nftOwner,
-      nftReceiver,
-      tokenIdentifier
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.transferNftTx(
-      nftAddress,
-      nftOwner,
-      nftReceiver,
-      tokenIdentifier,
-      estGas
-    )
+    const tx = await this.transferNftTx(nftAddress, nftOwner, nftReceiver, tokenId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -744,17 +554,18 @@ export class Nft extends SmartContract {
     nftAddress: string,
     nftOwner: string,
     nftReceiver: string,
-    tokenId?: number,
-    estimatedGas?: bigint
+    tokenId?: number
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
       throw new Error(`Caller is not NFT Owner`)
     }
     const tokenIdentifier = tokenId || 1
-    const estGas =
-      estimatedGas ??
-      (await nftContract.transferFrom.estimateGas(nftOwner, nftReceiver, tokenIdentifier))
+    const estGas = await nftContract.transferFrom.estimateGas(
+      nftOwner,
+      nftReceiver,
+      tokenIdentifier
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -784,27 +595,8 @@ export class Nft extends SmartContract {
     tokenId?: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
-      throw new Error(`Caller is not NFT Owner`)
-    }
-
-    const tokenIdentifier = tokenId || 1
-
-    const estGas = await nftContract.safeTransferFrom.estimateGas(
-      nftOwner,
-      nftReceiver,
-      tokenIdentifier
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.safeTransferNftTx(
-      nftAddress,
-      nftOwner,
-      nftReceiver,
-      tokenIdentifier,
-      estGas
-    )
+    const tx = await this.safeTransferNftTx(nftAddress, nftOwner, nftReceiver, tokenId)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -813,21 +605,18 @@ export class Nft extends SmartContract {
     nftAddress: string,
     nftOwner: string,
     nftReceiver: string,
-    tokenId?: number,
-    estimatedGas?: bigint
+    tokenId?: number
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if ((await this.getNftOwner(nftAddress)) !== nftOwner) {
       throw new Error(`Caller is not NFT Owner`)
     }
     const tokenIdentifier = tokenId || 1
-    const estGas =
-      estimatedGas ??
-      (await nftContract.safeTransferFrom.estimateGas(
-        nftOwner,
-        nftReceiver,
-        tokenIdentifier
-      ))
+    const estGas = await nftContract.safeTransferFrom.estimateGas(
+      nftOwner,
+      nftReceiver,
+      tokenIdentifier
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -866,12 +655,38 @@ export class Nft extends SmartContract {
     metadataProofs?: MetadataProof[],
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const tx = await this.setMetadataTx(
+      nftAddress,
+      address,
+      metadataState,
+      metadataDecryptorUrl,
+      metadataDecryptorAddress,
+      flags,
+      data,
+      metadataHash,
+      metadataProofs
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setMetadataTx(
+    nftAddress: string,
+    address: string,
+    metadataState: number,
+    metadataDecryptorUrl: string,
+    metadataDecryptorAddress: string,
+    flags: string,
+    data: string,
+    metadataHash: string,
+    metadataProofs?: MetadataProof[]
+  ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (!metadataProofs) metadataProofs = []
     if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
       throw new Error(`Caller is not Metadata updater`)
     }
-    // Indexer expects a bare peer ID, not a full multiaddr, for P2P decrypt routing.
     let decryptorUrl = metadataDecryptorUrl
     if (metadataDecryptorUrl?.includes('/p2p/')) {
       const p2pMatch = metadataDecryptorUrl.match(/\/p2p\/([^/]+)/)
@@ -886,57 +701,6 @@ export class Nft extends SmartContract {
       metadataHash,
       metadataProofs
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.setMetadataTx(
-      nftAddress,
-      address,
-      metadataState,
-      metadataDecryptorUrl,
-      metadataDecryptorAddress,
-      flags,
-      data,
-      metadataHash,
-      metadataProofs,
-      estGas
-    )
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async setMetadataTx(
-    nftAddress: string,
-    address: string,
-    metadataState: number,
-    metadataDecryptorUrl: string,
-    metadataDecryptorAddress: string,
-    flags: string,
-    data: string,
-    metadataHash: string,
-    metadataProofs?: MetadataProof[],
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const nftContract = this.getContract(nftAddress)
-    if (!metadataProofs) metadataProofs = []
-    if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
-      throw new Error(`Caller is not Metadata updater`)
-    }
-    let decryptorUrl = metadataDecryptorUrl
-    if (metadataDecryptorUrl?.includes('/p2p/')) {
-      const p2pMatch = metadataDecryptorUrl.match(/\/p2p\/([^/]+)/)
-      decryptorUrl = p2pMatch?.[1] ?? metadataDecryptorUrl
-    }
-    const estGas =
-      estimatedGas ??
-      (await nftContract.setMetaData.estimateGas(
-        metadataState,
-        decryptorUrl,
-        metadataDecryptorAddress,
-        flags,
-        data,
-        metadataHash,
-        metadataProofs
-      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -971,6 +735,21 @@ export class Nft extends SmartContract {
     metadataAndTokenURI: MetadataAndTokenURI,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
+    const tx = await this.setMetadataAndTokenURITx(
+      nftAddress,
+      metadataUpdater,
+      metadataAndTokenURI
+    )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async setMetadataAndTokenURITx(
+    nftAddress: string,
+    metadataUpdater: string,
+    metadataAndTokenURI: MetadataAndTokenURI
+  ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (!(await this.getNftPermissions(nftAddress, metadataUpdater)).updateMetadata) {
       throw new Error(`Caller is not Metadata updater`)
@@ -982,35 +761,6 @@ export class Nft extends SmartContract {
     const estGas = await nftContract.setMetaDataAndTokenURI.estimateGas(
       sanitizedMetadataAndTokenURI
     )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.setMetadataAndTokenURITx(
-      nftAddress,
-      metadataUpdater,
-      metadataAndTokenURI,
-      estGas
-    )
-    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
-    return <ReceiptOrEstimate<G>>trxReceipt
-  }
-
-  public async setMetadataAndTokenURITx(
-    nftAddress: string,
-    metadataUpdater: string,
-    metadataAndTokenURI: MetadataAndTokenURI,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const nftContract = this.getContract(nftAddress)
-    if (!(await this.getNftPermissions(nftAddress, metadataUpdater)).updateMetadata) {
-      throw new Error(`Caller is not Metadata updater`)
-    }
-    const sanitizedMetadataAndTokenURI = {
-      ...metadataAndTokenURI,
-      metadataProofs: metadataAndTokenURI.metadataProofs || []
-    }
-    const estGas =
-      estimatedGas ??
-      (await nftContract.setMetaDataAndTokenURI.estimateGas(sanitizedMetadataAndTokenURI))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1037,15 +787,8 @@ export class Nft extends SmartContract {
     metadataState: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
-      throw new Error(`Caller is not Metadata updater`)
-    }
-
-    const estGas = await nftContract.setMetaDataState.estimateGas(metadataState)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.setMetadataStateTx(nftAddress, address, metadataState, estGas)
+    const tx = await this.setMetadataStateTx(nftAddress, address, metadataState)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
@@ -1053,15 +796,13 @@ export class Nft extends SmartContract {
   public async setMetadataStateTx(
     nftAddress: string,
     address: string,
-    metadataState: number,
-    estimatedGas?: bigint
+    metadataState: number
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
     if (!(await this.getNftPermissions(nftAddress, address)).updateMetadata) {
       throw new Error(`Caller is not Metadata updater`)
     }
-    const estGas =
-      estimatedGas ?? (await nftContract.setMetaDataState.estimateGas(metadataState))
+    const estGas = await nftContract.setMetaDataState.estimateGas(metadataState)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1082,22 +823,17 @@ export class Nft extends SmartContract {
     data: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const nftContract = this.getContract(nftAddress)
-    const estGas = await nftContract.setTokenURI.estimateGas('1', data)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.setTokenURITx(nftAddress, data, estGas)
+    const tx = await this.setTokenURITx(nftAddress, data)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async setTokenURITx(
     nftAddress: string,
-    data: string,
-    estimatedGas?: bigint
+    data: string
   ): Promise<TransactionRequest> {
     const nftContract = this.getContract(nftAddress)
-    const estGas = estimatedGas ?? (await nftContract.setTokenURI.estimateGas('1', data))
+    const estGas = await nftContract.setTokenURI.estimateGas('1', data)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1171,17 +907,8 @@ export class Nft extends SmartContract {
     value: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getNftPermissions(nftAddress, address)).store !== true) {
-      throw new Error(`User is not ERC20 store updater`)
-    }
-
-    const nftContract = this.getContract(nftAddress)
-    const keyHash = keccak256(key)
-    const valueHex = hexlify(toUtf8Bytes(value))
-
-    const estGas = await nftContract.setNewData.estimateGas(keyHash, valueHex)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.setDataTx(nftAddress, address, key, value, estGas)
+    const tx = await this.setDataTx(nftAddress, address, key, value)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -1191,8 +918,7 @@ export class Nft extends SmartContract {
     nftAddress: string,
     address: string,
     key: string,
-    value: string,
-    estimatedGas?: bigint
+    value: string
   ): Promise<TransactionRequest> {
     if ((await this.getNftPermissions(nftAddress, address)).store !== true) {
       throw new Error(`User is not ERC20 store updater`)
@@ -1200,8 +926,7 @@ export class Nft extends SmartContract {
     const nftContract = this.getContract(nftAddress)
     const keyHash = keccak256(key)
     const valueHex = hexlify(toUtf8Bytes(value))
-    const estGas =
-      estimatedGas ?? (await nftContract.setNewData.estimateGas(keyHash, valueHex))
+    const estGas = await nftContract.setNewData.estimateGas(keyHash, valueHex)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -1228,6 +953,7 @@ export class Nft extends SmartContract {
    * @param {string} nftAddress - The address of the NFT.
    * @param {number} id - The ID of the token.
    * @returns {Promise&lt;string&gt;}
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
    */
   public async getTokenURI(nftAddress: string, id: number): Promise<string> {
     const nftContract = this.getContract(nftAddress)

--- a/src/contracts/NFTFactory.ts
+++ b/src/contracts/NFTFactory.ts
@@ -540,6 +540,7 @@ export class NftFactory extends SmartContractWithAddress {
       dtParams,
       freParams
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -589,6 +590,7 @@ export class NftFactory extends SmartContractWithAddress {
       dtParams,
       dispenserParams
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt

--- a/src/contracts/NFTFactory.ts
+++ b/src/contracts/NFTFactory.ts
@@ -1,4 +1,4 @@
-import { toUtf8Bytes } from 'ethers'
+import { TransactionRequest, toUtf8Bytes } from 'ethers'
 import ERC721Factory from '@oceanprotocol/contracts/artifacts/contracts/ERC721Factory.sol/ERC721Factory.json'
 import {
   AbiItem,
@@ -13,7 +13,13 @@ import {
 import { SmartContractWithAddress } from './SmartContractWithAddress.js'
 import { generateDtName } from '../utils/DatatokenName.js'
 import { ZERO_ADDRESS } from '../utils/Constants.js'
-import { getEventFromTx, getTokenDecimals, sendTx } from '../utils/ContractUtils.js'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  getEventFromTx,
+  getTokenDecimals,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 import { LoggerInstance } from '../utils/Logger.js'
 
 /**
@@ -65,20 +71,8 @@ export class NftFactory extends SmartContractWithAddress {
     if (estimateGas) return <G extends false ? string : bigint>estGas
     // Invoke createToken function of the contract
     try {
-      const tx = await sendTx(
-        estGas,
-        this.getSignerAccordingSdk(),
-        this.config?.gasFeeMultiplier,
-        this.contract.deployERC721Contract,
-        nftData.name,
-        nftData.symbol,
-        nftData.templateIndex,
-        ZERO_ADDRESS,
-        ZERO_ADDRESS,
-        nftData.tokenURI,
-        nftData.transferable,
-        nftData.owner
-      )
+      const txReq = await this.createNFTTx(nftData)
+      const tx = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
       if (!tx) {
         const e =
           'Tx for deploying new NFT contract does not exist or status is not successful.'
@@ -91,6 +85,53 @@ export class NftFactory extends SmartContractWithAddress {
     } catch (e) {
       console.error(`Creation of NFT failed: ${e}`)
     }
+  }
+
+  public async createNFTTx(nftData: NftCreateData): Promise<TransactionRequest> {
+    if (!nftData.templateIndex) nftData.templateIndex = 1
+    if (!nftData.name || !nftData.symbol) {
+      const { name, symbol } = generateDtName()
+      nftData.name = name
+      nftData.symbol = symbol
+    }
+    if (nftData.templateIndex > (await this.getCurrentNFTTemplateCount())) {
+      throw new Error(`Template index doesnt exist`)
+    }
+    if (nftData.templateIndex === 0) {
+      throw new Error(`Template index cannot be ZERO`)
+    }
+    if ((await this.getNFTTemplate(nftData.templateIndex)).isActive === false) {
+      throw new Error(`Template is not active`)
+    }
+    const estGas = await this.contract.deployERC721Contract.estimateGas(
+      nftData.name,
+      nftData.symbol,
+      nftData.templateIndex,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      nftData.tokenURI,
+      nftData.transferable,
+      nftData.owner
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.deployERC721Contract,
+      [
+        nftData.name,
+        nftData.symbol,
+        nftData.templateIndex,
+        ZERO_ADDRESS,
+        ZERO_ADDRESS,
+        nftData.tokenURI,
+        nftData.transferable,
+        nftData.owner
+      ],
+      overrides
+    )
   }
 
   /**
@@ -207,14 +248,30 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.add721TokenTemplate.estimateGas(templateAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.addNFTTemplateTx(address, templateAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addNFTTemplateTx(
+    address: string,
+    templateAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address)
+      throw new Error(`Caller is not Factory Owner`)
+    if (templateAddress === ZERO_ADDRESS)
+      throw new Error(`Template cannot be ZERO address`)
+    const estGas = await this.contract.add721TokenTemplate.estimateGas(templateAddress)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.add721TokenTemplate,
-      templateAddress
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      this.contract.add721TokenTemplate,
+      [templateAddress],
+      overrides
+    )
   }
 
   /**
@@ -243,15 +300,32 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.disable721TokenTemplate.estimateGas(templateIndex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.disable721TokenTemplate,
-      templateIndex
-    )
+    const tx = await this.disableNFTTemplateTx(address, templateIndex)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async disableNFTTemplateTx(
+    address: string,
+    templateIndex: number
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address)
+      throw new Error(`Caller is not Factory Owner`)
+    if (templateIndex > (await this.getCurrentNFTTemplateCount()))
+      throw new Error(`Template index doesnt exist`)
+    if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
+    const estGas = await this.contract.disable721TokenTemplate.estimateGas(templateIndex)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.disable721TokenTemplate,
+      [templateIndex],
+      overrides
+    )
   }
 
   /**
@@ -282,15 +356,34 @@ export class NftFactory extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.reactivate721TokenTemplate,
-      templateIndex
-    )
+    const tx = await this.reactivateNFTTemplateTx(address, templateIndex)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async reactivateNFTTemplateTx(
+    address: string,
+    templateIndex: number
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address)
+      throw new Error(`Caller is not Factory Owner`)
+    if (templateIndex > (await this.getCurrentNFTTemplateCount()))
+      throw new Error(`Template index doesnt exist`)
+    if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
+    const estGas = await this.contract.reactivate721TokenTemplate.estimateGas(
+      templateIndex
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.reactivate721TokenTemplate,
+      [templateIndex],
+      overrides
+    )
   }
 
   /**
@@ -315,15 +408,27 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.addTokenTemplate.estimateGas(templateAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.addTokenTemplate,
-      templateAddress
-    )
+    const tx = await this.addTokenTemplateTx(address, templateAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addTokenTemplateTx(
+    address: string,
+    templateAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address)
+      throw new Error(`Caller is not Factory Owner`)
+    if (templateAddress === ZERO_ADDRESS)
+      throw new Error(`Template cannot be address ZERO`)
+    const estGas = await this.contract.addTokenTemplate.estimateGas(templateAddress)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(this.contract.addTokenTemplate, [templateAddress], overrides)
   }
 
   /**
@@ -355,15 +460,30 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.disableTokenTemplate.estimateGas(templateIndex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.disableTokenTemplate,
-      templateIndex
-    )
+    const tx = await this.disableTokenTemplateTx(address, templateIndex)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async disableTokenTemplateTx(
+    address: string,
+    templateIndex: number
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address)
+      throw new Error(`Caller is not Factory Owner`)
+    if (templateIndex > (await this.getCurrentTokenTemplateCount()))
+      throw new Error(`Template index doesnt exist`)
+    if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
+    if ((await this.getTokenTemplate(templateIndex)).isActive === false)
+      throw new Error(`Template is already disabled`)
+    const estGas = await this.contract.disableTokenTemplate.estimateGas(templateIndex)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(this.contract.disableTokenTemplate, [templateIndex], overrides)
   }
 
   /**
@@ -395,15 +515,34 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.reactivateTokenTemplate.estimateGas(templateIndex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.reactivateTokenTemplate,
-      templateIndex
-    )
+    const tx = await this.reactivateTokenTemplateTx(address, templateIndex)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async reactivateTokenTemplateTx(
+    address: string,
+    templateIndex: number
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address)
+      throw new Error(`Caller is not Factory Owner`)
+    if (templateIndex > (await this.getCurrentTokenTemplateCount()))
+      throw new Error(`Template index doesnt exist`)
+    if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
+    if ((await this.getTokenTemplate(templateIndex)).isActive === true)
+      throw new Error(`Template is already active`)
+    const estGas = await this.contract.reactivateTokenTemplate.estimateGas(templateIndex)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.reactivateTokenTemplate,
+      [templateIndex],
+      overrides
+    )
   }
 
   /**
@@ -428,15 +567,23 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.startMultipleTokenOrder.estimateGas(orders)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.startMultipleTokenOrder,
-      orders
-    )
+    const tx = await this.startMultipleTokenOrderTx(orders)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async startMultipleTokenOrderTx(
+    orders: TokenOrder[]
+  ): Promise<TransactionRequest> {
+    if (orders.length > 50) throw new Error(`Too many orders`)
+    const estGas = await this.contract.startMultipleTokenOrder.estimateGas(orders)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(this.contract.startMultipleTokenOrder, [orders], overrides)
   }
 
   /**
@@ -460,16 +607,31 @@ export class NftFactory extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.createNftWithErc20,
+    const tx = await this.createNftWithDatatokenTx(nftCreateData, dtParams)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async createNftWithDatatokenTx(
+    nftCreateData: NftCreateData,
+    dtParams: DatatokenCreateParams
+  ): Promise<TransactionRequest> {
+    const ercCreateData = await this.getErcCreationParams(dtParams)
+    const estGas = await this.contract.createNftWithErc20.estimateGas(
       nftCreateData,
       ercCreateData
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.createNftWithErc20,
+      [nftCreateData, ercCreateData],
+      overrides
+    )
   }
 
   /**
@@ -497,17 +659,38 @@ export class NftFactory extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.createNftWithErc20WithFixedRate,
+    const tx = await this.createNftWithDatatokenWithFixedRateTx(
+      nftCreateData,
+      dtParams,
+      freParams
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async createNftWithDatatokenWithFixedRateTx(
+    nftCreateData: NftCreateData,
+    dtParams: DatatokenCreateParams,
+    freParams: FreCreationParams
+  ): Promise<TransactionRequest> {
+    const ercCreateData = await this.getErcCreationParams(dtParams)
+    const fixedData = await this.getFreCreationParams(freParams)
+    const estGas = await this.contract.createNftWithErc20WithFixedRate.estimateGas(
       nftCreateData,
       ercCreateData,
       fixedData
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.createNftWithErc20WithFixedRate,
+      [nftCreateData, ercCreateData, fixedData],
+      overrides
+    )
   }
 
   /**
@@ -546,17 +729,47 @@ export class NftFactory extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.createNftWithErc20WithDispenser,
+    const tx = await this.createNftWithDatatokenWithDispenserTx(
+      nftCreateData,
+      dtParams,
+      dispenserParams
+    )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async createNftWithDatatokenWithDispenserTx(
+    nftCreateData: NftCreateData,
+    dtParams: DatatokenCreateParams,
+    dispenserParams: DispenserCreationParams
+  ): Promise<TransactionRequest> {
+    const ercCreateData = await this.getErcCreationParams(dtParams)
+    dispenserParams.maxBalance = await this.amountToUnits(
+      null,
+      dispenserParams.maxBalance,
+      18
+    )
+    dispenserParams.maxTokens = await this.amountToUnits(
+      null,
+      dispenserParams.maxTokens,
+      18
+    )
+    const estGas = await this.contract.createNftWithErc20WithDispenser.estimateGas(
       nftCreateData,
       ercCreateData,
       dispenserParams
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.createNftWithErc20WithDispenser,
+      [nftCreateData, ercCreateData, dispenserParams],
+      overrides
+    )
   }
 
   /**

--- a/src/contracts/NFTFactory.ts
+++ b/src/contracts/NFTFactory.ts
@@ -71,7 +71,7 @@ export class NftFactory extends SmartContractWithAddress {
     if (estimateGas) return <G extends false ? string : bigint>estGas
     // Invoke createToken function of the contract
     try {
-      const txReq = await this.createNFTTx(nftData)
+      const txReq = await this.createNFTTx(nftData, estGas)
       const tx = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
       if (!tx) {
         const e =
@@ -87,7 +87,10 @@ export class NftFactory extends SmartContractWithAddress {
     }
   }
 
-  public async createNFTTx(nftData: NftCreateData): Promise<TransactionRequest> {
+  public async createNFTTx(
+    nftData: NftCreateData,
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
     if (!nftData.templateIndex) nftData.templateIndex = 1
     if (!nftData.name || !nftData.symbol) {
       const { name, symbol } = generateDtName()
@@ -103,16 +106,18 @@ export class NftFactory extends SmartContractWithAddress {
     if ((await this.getNFTTemplate(nftData.templateIndex)).isActive === false) {
       throw new Error(`Template is not active`)
     }
-    const estGas = await this.contract.deployERC721Contract.estimateGas(
-      nftData.name,
-      nftData.symbol,
-      nftData.templateIndex,
-      ZERO_ADDRESS,
-      ZERO_ADDRESS,
-      nftData.tokenURI,
-      nftData.transferable,
-      nftData.owner
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.deployERC721Contract.estimateGas(
+        nftData.name,
+        nftData.symbol,
+        nftData.templateIndex,
+        ZERO_ADDRESS,
+        ZERO_ADDRESS,
+        nftData.tokenURI,
+        nftData.transferable,
+        nftData.owner
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -248,20 +253,23 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.add721TokenTemplate.estimateGas(templateAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addNFTTemplateTx(address, templateAddress)
+    const tx = await this.addNFTTemplateTx(address, templateAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async addNFTTemplateTx(
     address: string,
-    templateAddress: string
+    templateAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateAddress === ZERO_ADDRESS)
       throw new Error(`Template cannot be ZERO address`)
-    const estGas = await this.contract.add721TokenTemplate.estimateGas(templateAddress)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.add721TokenTemplate.estimateGas(templateAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -300,7 +308,7 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.disable721TokenTemplate.estimateGas(templateIndex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.disableNFTTemplateTx(address, templateIndex)
+    const tx = await this.disableNFTTemplateTx(address, templateIndex, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -308,14 +316,17 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async disableNFTTemplateTx(
     address: string,
-    templateIndex: number
+    templateIndex: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateIndex > (await this.getCurrentNFTTemplateCount()))
       throw new Error(`Template index doesnt exist`)
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
-    const estGas = await this.contract.disable721TokenTemplate.estimateGas(templateIndex)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.disable721TokenTemplate.estimateGas(templateIndex))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -356,7 +367,7 @@ export class NftFactory extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.reactivateNFTTemplateTx(address, templateIndex)
+    const tx = await this.reactivateNFTTemplateTx(address, templateIndex, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -364,16 +375,17 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async reactivateNFTTemplateTx(
     address: string,
-    templateIndex: number
+    templateIndex: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateIndex > (await this.getCurrentNFTTemplateCount()))
       throw new Error(`Template index doesnt exist`)
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
-    const estGas = await this.contract.reactivate721TokenTemplate.estimateGas(
-      templateIndex
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.reactivate721TokenTemplate.estimateGas(templateIndex))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -408,7 +420,7 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.addTokenTemplate.estimateGas(templateAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addTokenTemplateTx(address, templateAddress)
+    const tx = await this.addTokenTemplateTx(address, templateAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -416,13 +428,15 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async addTokenTemplateTx(
     address: string,
-    templateAddress: string
+    templateAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateAddress === ZERO_ADDRESS)
       throw new Error(`Template cannot be address ZERO`)
-    const estGas = await this.contract.addTokenTemplate.estimateGas(templateAddress)
+    const estGas =
+      estimatedGas ?? (await this.contract.addTokenTemplate.estimateGas(templateAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -460,7 +474,7 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.disableTokenTemplate.estimateGas(templateIndex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.disableTokenTemplateTx(address, templateIndex)
+    const tx = await this.disableTokenTemplateTx(address, templateIndex, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -468,7 +482,8 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async disableTokenTemplateTx(
     address: string,
-    templateIndex: number
+    templateIndex: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
@@ -477,7 +492,9 @@ export class NftFactory extends SmartContractWithAddress {
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
     if ((await this.getTokenTemplate(templateIndex)).isActive === false)
       throw new Error(`Template is already disabled`)
-    const estGas = await this.contract.disableTokenTemplate.estimateGas(templateIndex)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.disableTokenTemplate.estimateGas(templateIndex))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -515,7 +532,7 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.reactivateTokenTemplate.estimateGas(templateIndex)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.reactivateTokenTemplateTx(address, templateIndex)
+    const tx = await this.reactivateTokenTemplateTx(address, templateIndex, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -523,7 +540,8 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async reactivateTokenTemplateTx(
     address: string,
-    templateIndex: number
+    templateIndex: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
@@ -532,7 +550,9 @@ export class NftFactory extends SmartContractWithAddress {
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
     if ((await this.getTokenTemplate(templateIndex)).isActive === true)
       throw new Error(`Template is already active`)
-    const estGas = await this.contract.reactivateTokenTemplate.estimateGas(templateIndex)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.reactivateTokenTemplate.estimateGas(templateIndex))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -567,17 +587,19 @@ export class NftFactory extends SmartContractWithAddress {
     const estGas = await this.contract.startMultipleTokenOrder.estimateGas(orders)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.startMultipleTokenOrderTx(orders)
+    const tx = await this.startMultipleTokenOrderTx(orders, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async startMultipleTokenOrderTx(
-    orders: TokenOrder[]
+    orders: TokenOrder[],
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if (orders.length > 50) throw new Error(`Too many orders`)
-    const estGas = await this.contract.startMultipleTokenOrder.estimateGas(orders)
+    const estGas =
+      estimatedGas ?? (await this.contract.startMultipleTokenOrder.estimateGas(orders))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -607,7 +629,7 @@ export class NftFactory extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.createNftWithDatatokenTx(nftCreateData, dtParams)
+    const tx = await this.createNftWithDatatokenTx(nftCreateData, dtParams, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -615,13 +637,13 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async createNftWithDatatokenTx(
     nftCreateData: NftCreateData,
-    dtParams: DatatokenCreateParams
+    dtParams: DatatokenCreateParams,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
-    const estGas = await this.contract.createNftWithErc20.estimateGas(
-      nftCreateData,
-      ercCreateData
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.createNftWithErc20.estimateGas(nftCreateData, ercCreateData))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -662,7 +684,8 @@ export class NftFactory extends SmartContractWithAddress {
     const tx = await this.createNftWithDatatokenWithFixedRateTx(
       nftCreateData,
       dtParams,
-      freParams
+      freParams,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
@@ -672,15 +695,18 @@ export class NftFactory extends SmartContractWithAddress {
   public async createNftWithDatatokenWithFixedRateTx(
     nftCreateData: NftCreateData,
     dtParams: DatatokenCreateParams,
-    freParams: FreCreationParams
+    freParams: FreCreationParams,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
     const fixedData = await this.getFreCreationParams(freParams)
-    const estGas = await this.contract.createNftWithErc20WithFixedRate.estimateGas(
-      nftCreateData,
-      ercCreateData,
-      fixedData
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.createNftWithErc20WithFixedRate.estimateGas(
+        nftCreateData,
+        ercCreateData,
+        fixedData
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -709,30 +735,24 @@ export class NftFactory extends SmartContractWithAddress {
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
-
-    dispenserParams.maxBalance = await this.amountToUnits(
-      null,
-      dispenserParams.maxBalance,
-      18
-    )
-
-    dispenserParams.maxTokens = await this.amountToUnits(
-      null,
-      dispenserParams.maxTokens,
-      18
-    )
+    const dispenserParamsInUnits = {
+      ...dispenserParams,
+      maxBalance: await this.amountToUnits(null, dispenserParams.maxBalance, 18),
+      maxTokens: await this.amountToUnits(null, dispenserParams.maxTokens, 18)
+    }
 
     const estGas = await this.contract.createNftWithErc20WithDispenser.estimateGas(
       nftCreateData,
       ercCreateData,
-      dispenserParams
+      dispenserParamsInUnits
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
     const tx = await this.createNftWithDatatokenWithDispenserTx(
       nftCreateData,
       dtParams,
-      dispenserParams
+      dispenserParams,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
@@ -742,24 +762,22 @@ export class NftFactory extends SmartContractWithAddress {
   public async createNftWithDatatokenWithDispenserTx(
     nftCreateData: NftCreateData,
     dtParams: DatatokenCreateParams,
-    dispenserParams: DispenserCreationParams
+    dispenserParams: DispenserCreationParams,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
-    dispenserParams.maxBalance = await this.amountToUnits(
-      null,
-      dispenserParams.maxBalance,
-      18
-    )
-    dispenserParams.maxTokens = await this.amountToUnits(
-      null,
-      dispenserParams.maxTokens,
-      18
-    )
-    const estGas = await this.contract.createNftWithErc20WithDispenser.estimateGas(
-      nftCreateData,
-      ercCreateData,
-      dispenserParams
-    )
+    const dispenserParamsInUnits = {
+      ...dispenserParams,
+      maxBalance: await this.amountToUnits(null, dispenserParams.maxBalance, 18),
+      maxTokens: await this.amountToUnits(null, dispenserParams.maxTokens, 18)
+    }
+    const estGas =
+      estimatedGas ??
+      (await this.contract.createNftWithErc20WithDispenser.estimateGas(
+        nftCreateData,
+        ercCreateData,
+        dispenserParamsInUnits
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -767,7 +785,7 @@ export class NftFactory extends SmartContractWithAddress {
     )
     return buildUnsignedTx(
       this.contract.createNftWithErc20WithDispenser,
-      [nftCreateData, ercCreateData, dispenserParams],
+      [nftCreateData, ercCreateData, dispenserParamsInUnits],
       overrides
     )
   }

--- a/src/contracts/NFTFactory.ts
+++ b/src/contracts/NFTFactory.ts
@@ -40,38 +40,10 @@ export class NftFactory extends SmartContractWithAddress {
     nftData: NftCreateData,
     estimateGas?: G
   ): Promise<G extends false ? string : bigint> {
-    if (!nftData.templateIndex) nftData.templateIndex = 1
-
-    if (!nftData.name || !nftData.symbol) {
-      const { name, symbol } = generateDtName()
-      nftData.name = name
-      nftData.symbol = symbol
-    }
-    if (nftData.templateIndex > (await this.getCurrentNFTTemplateCount())) {
-      throw new Error(`Template index doesnt exist`)
-    }
-
-    if (nftData.templateIndex === 0) {
-      throw new Error(`Template index cannot be ZERO`)
-    }
-    if ((await this.getNFTTemplate(nftData.templateIndex)).isActive === false) {
-      throw new Error(`Template is not active`)
-    }
-
-    const estGas = await this.contract.deployERC721Contract.estimateGas(
-      nftData.name,
-      nftData.symbol,
-      nftData.templateIndex,
-      ZERO_ADDRESS,
-      ZERO_ADDRESS,
-      nftData.tokenURI,
-      nftData.transferable,
-      nftData.owner
-    )
-    if (estimateGas) return <G extends false ? string : bigint>estGas
+    const txReq = await this.createNFTTx(nftData)
+    if (estimateGas) return <G extends false ? string : bigint>txReq.gasLimit
     // Invoke createToken function of the contract
     try {
-      const txReq = await this.createNFTTx(nftData, estGas)
       const tx = await sendPreparedTransaction(this.getSignerAccordingSdk(), txReq)
       if (!tx) {
         const e =
@@ -87,37 +59,33 @@ export class NftFactory extends SmartContractWithAddress {
     }
   }
 
-  public async createNFTTx(
-    nftData: NftCreateData,
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    if (!nftData.templateIndex) nftData.templateIndex = 1
-    if (!nftData.name || !nftData.symbol) {
-      const { name, symbol } = generateDtName()
-      nftData.name = name
-      nftData.symbol = symbol
+  public async createNFTTx(nftData: NftCreateData): Promise<TransactionRequest> {
+    const normalizedData = { ...nftData }
+    if (!normalizedData.templateIndex) normalizedData.templateIndex = 1
+    if (!normalizedData.name || !normalizedData.symbol) {
+      const generated = generateDtName()
+      normalizedData.name = normalizedData.name || generated.name
+      normalizedData.symbol = normalizedData.symbol || generated.symbol
     }
-    if (nftData.templateIndex > (await this.getCurrentNFTTemplateCount())) {
+    if (normalizedData.templateIndex > (await this.getCurrentNFTTemplateCount())) {
       throw new Error(`Template index doesnt exist`)
     }
-    if (nftData.templateIndex === 0) {
+    if (normalizedData.templateIndex === 0) {
       throw new Error(`Template index cannot be ZERO`)
     }
-    if ((await this.getNFTTemplate(nftData.templateIndex)).isActive === false) {
+    if ((await this.getNFTTemplate(normalizedData.templateIndex)).isActive === false) {
       throw new Error(`Template is not active`)
     }
-    const estGas =
-      estimatedGas ??
-      (await this.contract.deployERC721Contract.estimateGas(
-        nftData.name,
-        nftData.symbol,
-        nftData.templateIndex,
-        ZERO_ADDRESS,
-        ZERO_ADDRESS,
-        nftData.tokenURI,
-        nftData.transferable,
-        nftData.owner
-      ))
+    const estGas = await this.contract.deployERC721Contract.estimateGas(
+      normalizedData.name,
+      normalizedData.symbol,
+      normalizedData.templateIndex,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      normalizedData.tokenURI,
+      normalizedData.transferable,
+      normalizedData.owner
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -126,14 +94,14 @@ export class NftFactory extends SmartContractWithAddress {
     return buildUnsignedTx(
       this.contract.deployERC721Contract,
       [
-        nftData.name,
-        nftData.symbol,
-        nftData.templateIndex,
+        normalizedData.name,
+        normalizedData.symbol,
+        normalizedData.templateIndex,
         ZERO_ADDRESS,
         ZERO_ADDRESS,
-        nftData.tokenURI,
-        nftData.transferable,
-        nftData.owner
+        normalizedData.tokenURI,
+        normalizedData.transferable,
+        normalizedData.owner
       ],
       overrides
     )
@@ -243,33 +211,21 @@ export class NftFactory extends SmartContractWithAddress {
     templateAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-    if (templateAddress === ZERO_ADDRESS) {
-      throw new Error(`Template cannot be ZERO address`)
-    }
-
-    const estGas = await this.contract.add721TokenTemplate.estimateGas(templateAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addNFTTemplateTx(address, templateAddress, estGas)
+    const tx = await this.addNFTTemplateTx(address, templateAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async addNFTTemplateTx(
     address: string,
-    templateAddress: string,
-    estimatedGas?: bigint
+    templateAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateAddress === ZERO_ADDRESS)
       throw new Error(`Template cannot be ZERO address`)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.add721TokenTemplate.estimateGas(templateAddress))
+    const estGas = await this.contract.add721TokenTemplate.estimateGas(templateAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -294,21 +250,8 @@ export class NftFactory extends SmartContractWithAddress {
     templateIndex: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-    if (templateIndex > (await this.getCurrentNFTTemplateCount())) {
-      throw new Error(`Template index doesnt exist`)
-    }
-
-    if (templateIndex === 0) {
-      throw new Error(`Template index cannot be ZERO`)
-    }
-
-    const estGas = await this.contract.disable721TokenTemplate.estimateGas(templateIndex)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.disableNFTTemplateTx(address, templateIndex, estGas)
+    const tx = await this.disableNFTTemplateTx(address, templateIndex)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -316,17 +259,14 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async disableNFTTemplateTx(
     address: string,
-    templateIndex: number,
-    estimatedGas?: bigint
+    templateIndex: number
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateIndex > (await this.getCurrentNFTTemplateCount()))
       throw new Error(`Template index doesnt exist`)
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.disable721TokenTemplate.estimateGas(templateIndex))
+    const estGas = await this.contract.disable721TokenTemplate.estimateGas(templateIndex)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -351,23 +291,8 @@ export class NftFactory extends SmartContractWithAddress {
     templateIndex: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-    if (templateIndex > (await this.getCurrentNFTTemplateCount())) {
-      throw new Error(`Template index doesnt exist`)
-    }
-
-    if (templateIndex === 0) {
-      throw new Error(`Template index cannot be ZERO`)
-    }
-
-    const estGas = await this.contract.reactivate721TokenTemplate.estimateGas(
-      templateIndex
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.reactivateNFTTemplateTx(address, templateIndex, estGas)
+    const tx = await this.reactivateNFTTemplateTx(address, templateIndex)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -375,17 +300,16 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async reactivateNFTTemplateTx(
     address: string,
-    templateIndex: number,
-    estimatedGas?: bigint
+    templateIndex: number
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateIndex > (await this.getCurrentNFTTemplateCount()))
       throw new Error(`Template index doesnt exist`)
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.reactivate721TokenTemplate.estimateGas(templateIndex))
+    const estGas = await this.contract.reactivate721TokenTemplate.estimateGas(
+      templateIndex
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -410,17 +334,8 @@ export class NftFactory extends SmartContractWithAddress {
     templateAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-    if (templateAddress === ZERO_ADDRESS) {
-      throw new Error(`Template cannot be address ZERO`)
-    }
-
-    const estGas = await this.contract.addTokenTemplate.estimateGas(templateAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addTokenTemplateTx(address, templateAddress, estGas)
+    const tx = await this.addTokenTemplateTx(address, templateAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -428,15 +343,13 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async addTokenTemplateTx(
     address: string,
-    templateAddress: string,
-    estimatedGas?: bigint
+    templateAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
     if (templateAddress === ZERO_ADDRESS)
       throw new Error(`Template cannot be address ZERO`)
-    const estGas =
-      estimatedGas ?? (await this.contract.addTokenTemplate.estimateGas(templateAddress))
+    const estGas = await this.contract.addTokenTemplate.estimateGas(templateAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -457,24 +370,8 @@ export class NftFactory extends SmartContractWithAddress {
     templateIndex: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-    if (templateIndex > (await this.getCurrentTokenTemplateCount())) {
-      throw new Error(`Template index doesnt exist`)
-    }
-
-    if (templateIndex === 0) {
-      throw new Error(`Template index cannot be ZERO`)
-    }
-    if ((await this.getTokenTemplate(templateIndex)).isActive === false) {
-      throw new Error(`Template is already disabled`)
-    }
-
-    const estGas = await this.contract.disableTokenTemplate.estimateGas(templateIndex)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.disableTokenTemplateTx(address, templateIndex, estGas)
+    const tx = await this.disableTokenTemplateTx(address, templateIndex)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -482,8 +379,7 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async disableTokenTemplateTx(
     address: string,
-    templateIndex: number,
-    estimatedGas?: bigint
+    templateIndex: number
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
@@ -492,9 +388,7 @@ export class NftFactory extends SmartContractWithAddress {
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
     if ((await this.getTokenTemplate(templateIndex)).isActive === false)
       throw new Error(`Template is already disabled`)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.disableTokenTemplate.estimateGas(templateIndex))
+    const estGas = await this.contract.disableTokenTemplate.estimateGas(templateIndex)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -515,24 +409,8 @@ export class NftFactory extends SmartContractWithAddress {
     templateIndex: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Factory Owner`)
-    }
-    if (templateIndex > (await this.getCurrentTokenTemplateCount())) {
-      throw new Error(`Template index doesnt exist`)
-    }
-
-    if (templateIndex === 0) {
-      throw new Error(`Template index cannot be ZERO`)
-    }
-    if ((await this.getTokenTemplate(templateIndex)).isActive === true) {
-      throw new Error(`Template is already active`)
-    }
-
-    const estGas = await this.contract.reactivateTokenTemplate.estimateGas(templateIndex)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.reactivateTokenTemplateTx(address, templateIndex, estGas)
+    const tx = await this.reactivateTokenTemplateTx(address, templateIndex)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -540,8 +418,7 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async reactivateTokenTemplateTx(
     address: string,
-    templateIndex: number,
-    estimatedGas?: bigint
+    templateIndex: number
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address)
       throw new Error(`Caller is not Factory Owner`)
@@ -550,9 +427,7 @@ export class NftFactory extends SmartContractWithAddress {
     if (templateIndex === 0) throw new Error(`Template index cannot be ZERO`)
     if ((await this.getTokenTemplate(templateIndex)).isActive === true)
       throw new Error(`Template is already active`)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.reactivateTokenTemplate.estimateGas(templateIndex))
+    const estGas = await this.contract.reactivateTokenTemplate.estimateGas(templateIndex)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -584,22 +459,18 @@ export class NftFactory extends SmartContractWithAddress {
       throw new Error(`Too many orders`)
     }
 
-    const estGas = await this.contract.startMultipleTokenOrder.estimateGas(orders)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.startMultipleTokenOrderTx(orders, estGas)
+    const tx = await this.startMultipleTokenOrderTx(orders)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async startMultipleTokenOrderTx(
-    orders: TokenOrder[],
-    estimatedGas?: bigint
+    orders: TokenOrder[]
   ): Promise<TransactionRequest> {
     if (orders.length > 50) throw new Error(`Too many orders`)
-    const estGas =
-      estimatedGas ?? (await this.contract.startMultipleTokenOrder.estimateGas(orders))
+    const estGas = await this.contract.startMultipleTokenOrder.estimateGas(orders)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -621,15 +492,8 @@ export class NftFactory extends SmartContractWithAddress {
     dtParams: DatatokenCreateParams,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const ercCreateData = await this.getErcCreationParams(dtParams)
-
-    const estGas = await this.contract.createNftWithErc20.estimateGas(
-      nftCreateData,
-      ercCreateData
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.createNftWithDatatokenTx(nftCreateData, dtParams, estGas)
+    const tx = await this.createNftWithDatatokenTx(nftCreateData, dtParams)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -637,13 +501,13 @@ export class NftFactory extends SmartContractWithAddress {
 
   public async createNftWithDatatokenTx(
     nftCreateData: NftCreateData,
-    dtParams: DatatokenCreateParams,
-    estimatedGas?: bigint
+    dtParams: DatatokenCreateParams
   ): Promise<TransactionRequest> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.createNftWithErc20.estimateGas(nftCreateData, ercCreateData))
+    const estGas = await this.contract.createNftWithErc20.estimateGas(
+      nftCreateData,
+      ercCreateData
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -671,21 +535,10 @@ export class NftFactory extends SmartContractWithAddress {
     freParams: FreCreationParams,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const ercCreateData = await this.getErcCreationParams(dtParams)
-    const fixedData = await this.getFreCreationParams(freParams)
-
-    const estGas = await this.contract.createNftWithErc20WithFixedRate.estimateGas(
-      nftCreateData,
-      ercCreateData,
-      fixedData
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
     const tx = await this.createNftWithDatatokenWithFixedRateTx(
       nftCreateData,
       dtParams,
-      freParams,
-      estGas
+      freParams
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
@@ -695,18 +548,15 @@ export class NftFactory extends SmartContractWithAddress {
   public async createNftWithDatatokenWithFixedRateTx(
     nftCreateData: NftCreateData,
     dtParams: DatatokenCreateParams,
-    freParams: FreCreationParams,
-    estimatedGas?: bigint
+    freParams: FreCreationParams
   ): Promise<TransactionRequest> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
     const fixedData = await this.getFreCreationParams(freParams)
-    const estGas =
-      estimatedGas ??
-      (await this.contract.createNftWithErc20WithFixedRate.estimateGas(
-        nftCreateData,
-        ercCreateData,
-        fixedData
-      ))
+    const estGas = await this.contract.createNftWithErc20WithFixedRate.estimateGas(
+      nftCreateData,
+      ercCreateData,
+      fixedData
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -734,25 +584,10 @@ export class NftFactory extends SmartContractWithAddress {
     dispenserParams: DispenserCreationParams,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const ercCreateData = await this.getErcCreationParams(dtParams)
-    const dispenserParamsInUnits = {
-      ...dispenserParams,
-      maxBalance: await this.amountToUnits(null, dispenserParams.maxBalance, 18),
-      maxTokens: await this.amountToUnits(null, dispenserParams.maxTokens, 18)
-    }
-
-    const estGas = await this.contract.createNftWithErc20WithDispenser.estimateGas(
-      nftCreateData,
-      ercCreateData,
-      dispenserParamsInUnits
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
     const tx = await this.createNftWithDatatokenWithDispenserTx(
       nftCreateData,
       dtParams,
-      dispenserParams,
-      estGas
+      dispenserParams
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
@@ -762,8 +597,7 @@ export class NftFactory extends SmartContractWithAddress {
   public async createNftWithDatatokenWithDispenserTx(
     nftCreateData: NftCreateData,
     dtParams: DatatokenCreateParams,
-    dispenserParams: DispenserCreationParams,
-    estimatedGas?: bigint
+    dispenserParams: DispenserCreationParams
   ): Promise<TransactionRequest> {
     const ercCreateData = await this.getErcCreationParams(dtParams)
     const dispenserParamsInUnits = {
@@ -771,13 +605,11 @@ export class NftFactory extends SmartContractWithAddress {
       maxBalance: await this.amountToUnits(null, dispenserParams.maxBalance, 18),
       maxTokens: await this.amountToUnits(null, dispenserParams.maxTokens, 18)
     }
-    const estGas =
-      estimatedGas ??
-      (await this.contract.createNftWithErc20WithDispenser.estimateGas(
-        nftCreateData,
-        ercCreateData,
-        dispenserParamsInUnits
-      ))
+    const estGas = await this.contract.createNftWithErc20WithDispenser.estimateGas(
+      nftCreateData,
+      ercCreateData,
+      dispenserParamsInUnits
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Router.ts
+++ b/src/contracts/Router.ts
@@ -1,5 +1,10 @@
 import FactoryRouter from '@oceanprotocol/contracts/artifacts/contracts/pools/FactoryRouter.sol/FactoryRouter.json'
-import { sendTx } from '../utils/ContractUtils.js'
+import { TransactionRequest } from 'ethers'
+import {
+  buildTxOverrides,
+  buildUnsignedTx,
+  sendPreparedTransaction
+} from '../utils/ContractUtils.js'
 import { Operation, ReceiptOrEstimate, AbiItem } from '../@types/index.js'
 import { SmartContractWithAddress } from './SmartContractWithAddress.js'
 
@@ -25,16 +30,19 @@ export class Router extends SmartContractWithAddress {
   ): Promise<ReceiptOrEstimate<G>> {
     const estGas = await this.contract.buyDTBatch.estimateGas(operations)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
+    const tx = await this.buyDatatokenBatchTx(operations)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
 
-    const trxReceipt = await sendTx(
+  public async buyDatatokenBatchTx(operations: Operation[]): Promise<TransactionRequest> {
+    const estGas = await this.contract.buyDTBatch.estimateGas(operations)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.buyDTBatch,
-      operations
+      this.config?.gasFeeMultiplier
     )
-
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.buyDTBatch, [operations], overrides)
   }
 
   /**
@@ -91,15 +99,26 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.addApprovedToken.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.addApprovedToken,
-      tokenAddress
-    )
+    const tx = await this.addApprovedTokenTx(address, tokenAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addApprovedTokenTx(
+    address: string,
+    tokenAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.addApprovedToken.estimateGas(tokenAddress)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(this.contract.addApprovedToken, [tokenAddress], overrides)
   }
 
   /**
@@ -121,14 +140,25 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.removeApprovedToken.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.removeApprovedTokenTx(address, tokenAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeApprovedTokenTx(
+    address: string,
+    tokenAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.removeApprovedToken.estimateGas(tokenAddress)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.removeApprovedToken,
-      tokenAddress
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.removeApprovedToken, [tokenAddress], overrides)
   }
 
   /**
@@ -150,15 +180,26 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.addFixedRateContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.addFixedRateContract,
-      tokenAddress
-    )
+    const tx = await this.addFixedRateContractTx(address, tokenAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addFixedRateContractTx(
+    address: string,
+    tokenAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.addFixedRateContract.estimateGas(tokenAddress)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(this.contract.addFixedRateContract, [tokenAddress], overrides)
   }
 
   /**
@@ -180,15 +221,30 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.removeFixedRateContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.removeFixedRateContract,
-      tokenAddress
-    )
+    const tx = await this.removeFixedRateContractTx(address, tokenAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeFixedRateContractTx(
+    address: string,
+    tokenAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.removeFixedRateContract.estimateGas(tokenAddress)
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.removeFixedRateContract,
+      [tokenAddress],
+      overrides
+    )
   }
 
   /**
@@ -210,14 +266,25 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.addDispenserContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.addDispenserContractTx(address, tokenAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async addDispenserContractTx(
+    address: string,
+    tokenAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.addDispenserContract.estimateGas(tokenAddress)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.addDispenserContract,
-      tokenAddress
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(this.contract.addDispenserContract, [tokenAddress], overrides)
   }
 
   /**
@@ -239,14 +306,29 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.removeDispenserContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
+    const tx = await this.removeDispenserContractTx(address, tokenAddress)
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
+    return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async removeDispenserContractTx(
+    address: string,
+    tokenAddress: string
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.removeDispenserContract.estimateGas(tokenAddress)
+    const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.removeDispenserContract,
-      tokenAddress
+      this.config?.gasFeeMultiplier
     )
-    return <ReceiptOrEstimate<G>>trxReceipt
+    return buildUnsignedTx(
+      this.contract.removeDispenserContract,
+      [tokenAddress],
+      overrides
+    )
   }
 
   /** Get OPF Fee per token
@@ -295,17 +377,43 @@ export class Router extends SmartContractWithAddress {
     )
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const trxReceipt = await sendTx(
-      estGas,
-      this.getSignerAccordingSdk(),
-      this.config?.gasFeeMultiplier,
-      this.contract.updateOPCFee,
+    const tx = await this.updateOPCFeeTx(
+      address,
       newSwapOceanFee,
       newSwapNonOceanFee,
       newConsumeFee,
       newProviderFee
     )
+    const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
+  }
+
+  public async updateOPCFeeTx(
+    address: string,
+    newSwapOceanFee: number,
+    newSwapNonOceanFee: number,
+    newConsumeFee: number,
+    newProviderFee: number
+  ): Promise<TransactionRequest> {
+    if ((await this.getOwner()) !== address) {
+      throw new Error(`Caller is not Router Owner`)
+    }
+    const estGas = await this.contract.updateOPCFee.estimateGas(
+      newSwapOceanFee,
+      newSwapNonOceanFee,
+      newConsumeFee,
+      newProviderFee
+    )
+    const overrides = await buildTxOverrides(
+      estGas,
+      this.getSignerAccordingSdk(),
+      this.config?.gasFeeMultiplier
+    )
+    return buildUnsignedTx(
+      this.contract.updateOPCFee,
+      [newSwapOceanFee, newSwapNonOceanFee, newConsumeFee, newProviderFee],
+      overrides
+    )
   }
 }

--- a/src/contracts/Router.ts
+++ b/src/contracts/Router.ts
@@ -30,13 +30,17 @@ export class Router extends SmartContractWithAddress {
   ): Promise<ReceiptOrEstimate<G>> {
     const estGas = await this.contract.buyDTBatch.estimateGas(operations)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.buyDatatokenBatchTx(operations)
+    const tx = await this.buyDatatokenBatchTx(operations, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async buyDatatokenBatchTx(operations: Operation[]): Promise<TransactionRequest> {
-    const estGas = await this.contract.buyDTBatch.estimateGas(operations)
+  public async buyDatatokenBatchTx(
+    operations: Operation[],
+    estimatedGas?: bigint
+  ): Promise<TransactionRequest> {
+    const estGas =
+      estimatedGas ?? (await this.contract.buyDTBatch.estimateGas(operations))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -99,7 +103,7 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.addApprovedToken.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addApprovedTokenTx(address, tokenAddress)
+    const tx = await this.addApprovedTokenTx(address, tokenAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -107,12 +111,14 @@ export class Router extends SmartContractWithAddress {
 
   public async addApprovedTokenTx(
     address: string,
-    tokenAddress: string
+    tokenAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.addApprovedToken.estimateGas(tokenAddress)
+    const estGas =
+      estimatedGas ?? (await this.contract.addApprovedToken.estimateGas(tokenAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -140,19 +146,21 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.removeApprovedToken.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.removeApprovedTokenTx(address, tokenAddress)
+    const tx = await this.removeApprovedTokenTx(address, tokenAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async removeApprovedTokenTx(
     address: string,
-    tokenAddress: string
+    tokenAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.removeApprovedToken.estimateGas(tokenAddress)
+    const estGas =
+      estimatedGas ?? (await this.contract.removeApprovedToken.estimateGas(tokenAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -180,7 +188,7 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.addFixedRateContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addFixedRateContractTx(address, tokenAddress)
+    const tx = await this.addFixedRateContractTx(address, tokenAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -188,12 +196,14 @@ export class Router extends SmartContractWithAddress {
 
   public async addFixedRateContractTx(
     address: string,
-    tokenAddress: string
+    tokenAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.addFixedRateContract.estimateGas(tokenAddress)
+    const estGas =
+      estimatedGas ?? (await this.contract.addFixedRateContract.estimateGas(tokenAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -221,7 +231,7 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.removeFixedRateContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.removeFixedRateContractTx(address, tokenAddress)
+    const tx = await this.removeFixedRateContractTx(address, tokenAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -229,12 +239,15 @@ export class Router extends SmartContractWithAddress {
 
   public async removeFixedRateContractTx(
     address: string,
-    tokenAddress: string
+    tokenAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.removeFixedRateContract.estimateGas(tokenAddress)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.removeFixedRateContract.estimateGas(tokenAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -266,19 +279,21 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.addDispenserContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.addDispenserContractTx(address, tokenAddress)
+    const tx = await this.addDispenserContractTx(address, tokenAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async addDispenserContractTx(
     address: string,
-    tokenAddress: string
+    tokenAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.addDispenserContract.estimateGas(tokenAddress)
+    const estGas =
+      estimatedGas ?? (await this.contract.addDispenserContract.estimateGas(tokenAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -306,19 +321,22 @@ export class Router extends SmartContractWithAddress {
     const estGas = await this.contract.removeDispenserContract.estimateGas(tokenAddress)
     if (estimateGas) return <ReceiptOrEstimate<G>>estGas
 
-    const tx = await this.removeDispenserContractTx(address, tokenAddress)
+    const tx = await this.removeDispenserContractTx(address, tokenAddress, estGas)
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async removeDispenserContractTx(
     address: string,
-    tokenAddress: string
+    tokenAddress: string,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.removeDispenserContract.estimateGas(tokenAddress)
+    const estGas =
+      estimatedGas ??
+      (await this.contract.removeDispenserContract.estimateGas(tokenAddress))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -382,7 +400,8 @@ export class Router extends SmartContractWithAddress {
       newSwapOceanFee,
       newSwapNonOceanFee,
       newConsumeFee,
-      newProviderFee
+      newProviderFee,
+      estGas
     )
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
@@ -394,17 +413,20 @@ export class Router extends SmartContractWithAddress {
     newSwapOceanFee: number,
     newSwapNonOceanFee: number,
     newConsumeFee: number,
-    newProviderFee: number
+    newProviderFee: number,
+    estimatedGas?: bigint
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas = await this.contract.updateOPCFee.estimateGas(
-      newSwapOceanFee,
-      newSwapNonOceanFee,
-      newConsumeFee,
-      newProviderFee
-    )
+    const estGas =
+      estimatedGas ??
+      (await this.contract.updateOPCFee.estimateGas(
+        newSwapOceanFee,
+        newSwapNonOceanFee,
+        newConsumeFee,
+        newProviderFee
+      ))
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/contracts/Router.ts
+++ b/src/contracts/Router.ts
@@ -28,19 +28,14 @@ export class Router extends SmartContractWithAddress {
     operations: Operation[],
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    const estGas = await this.contract.buyDTBatch.estimateGas(operations)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-    const tx = await this.buyDatatokenBatchTx(operations, estGas)
+    const tx = await this.buyDatatokenBatchTx(operations)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
-  public async buyDatatokenBatchTx(
-    operations: Operation[],
-    estimatedGas?: bigint
-  ): Promise<TransactionRequest> {
-    const estGas =
-      estimatedGas ?? (await this.contract.buyDTBatch.estimateGas(operations))
+  public async buyDatatokenBatchTx(operations: Operation[]): Promise<TransactionRequest> {
+    const estGas = await this.contract.buyDTBatch.estimateGas(operations)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -96,14 +91,8 @@ export class Router extends SmartContractWithAddress {
     tokenAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.addApprovedToken.estimateGas(tokenAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addApprovedTokenTx(address, tokenAddress, estGas)
+    const tx = await this.addApprovedTokenTx(address, tokenAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -111,14 +100,12 @@ export class Router extends SmartContractWithAddress {
 
   public async addApprovedTokenTx(
     address: string,
-    tokenAddress: string,
-    estimatedGas?: bigint
+    tokenAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ?? (await this.contract.addApprovedToken.estimateGas(tokenAddress))
+    const estGas = await this.contract.addApprovedToken.estimateGas(tokenAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -139,28 +126,20 @@ export class Router extends SmartContractWithAddress {
     tokenAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.removeApprovedToken.estimateGas(tokenAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeApprovedTokenTx(address, tokenAddress, estGas)
+    const tx = await this.removeApprovedTokenTx(address, tokenAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async removeApprovedTokenTx(
     address: string,
-    tokenAddress: string,
-    estimatedGas?: bigint
+    tokenAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ?? (await this.contract.removeApprovedToken.estimateGas(tokenAddress))
+    const estGas = await this.contract.removeApprovedToken.estimateGas(tokenAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -181,14 +160,8 @@ export class Router extends SmartContractWithAddress {
     tokenAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.addFixedRateContract.estimateGas(tokenAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addFixedRateContractTx(address, tokenAddress, estGas)
+    const tx = await this.addFixedRateContractTx(address, tokenAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -196,14 +169,12 @@ export class Router extends SmartContractWithAddress {
 
   public async addFixedRateContractTx(
     address: string,
-    tokenAddress: string,
-    estimatedGas?: bigint
+    tokenAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ?? (await this.contract.addFixedRateContract.estimateGas(tokenAddress))
+    const estGas = await this.contract.addFixedRateContract.estimateGas(tokenAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -224,14 +195,8 @@ export class Router extends SmartContractWithAddress {
     tokenAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.removeFixedRateContract.estimateGas(tokenAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeFixedRateContractTx(address, tokenAddress, estGas)
+    const tx = await this.removeFixedRateContractTx(address, tokenAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -239,15 +204,12 @@ export class Router extends SmartContractWithAddress {
 
   public async removeFixedRateContractTx(
     address: string,
-    tokenAddress: string,
-    estimatedGas?: bigint
+    tokenAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ??
-      (await this.contract.removeFixedRateContract.estimateGas(tokenAddress))
+    const estGas = await this.contract.removeFixedRateContract.estimateGas(tokenAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -272,28 +234,20 @@ export class Router extends SmartContractWithAddress {
     tokenAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.addDispenserContract.estimateGas(tokenAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.addDispenserContractTx(address, tokenAddress, estGas)
+    const tx = await this.addDispenserContractTx(address, tokenAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async addDispenserContractTx(
     address: string,
-    tokenAddress: string,
-    estimatedGas?: bigint
+    tokenAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ?? (await this.contract.addDispenserContract.estimateGas(tokenAddress))
+    const estGas = await this.contract.addDispenserContract.estimateGas(tokenAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -314,29 +268,20 @@ export class Router extends SmartContractWithAddress {
     tokenAddress: string,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.removeDispenserContract.estimateGas(tokenAddress)
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
-    const tx = await this.removeDispenserContractTx(address, tokenAddress, estGas)
+    const tx = await this.removeDispenserContractTx(address, tokenAddress)
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
     return <ReceiptOrEstimate<G>>trxReceipt
   }
 
   public async removeDispenserContractTx(
     address: string,
-    tokenAddress: string,
-    estimatedGas?: bigint
+    tokenAddress: string
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ??
-      (await this.contract.removeDispenserContract.estimateGas(tokenAddress))
+    const estGas = await this.contract.removeDispenserContract.estimateGas(tokenAddress)
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),
@@ -383,26 +328,14 @@ export class Router extends SmartContractWithAddress {
     newProviderFee: number,
     estimateGas?: G
   ): Promise<ReceiptOrEstimate<G>> {
-    if ((await this.getOwner()) !== address) {
-      throw new Error(`Caller is not Router Owner`)
-    }
-
-    const estGas = await this.contract.updateOPCFee.estimateGas(
-      newSwapOceanFee,
-      newSwapNonOceanFee,
-      newConsumeFee,
-      newProviderFee
-    )
-    if (estimateGas) return <ReceiptOrEstimate<G>>estGas
-
     const tx = await this.updateOPCFeeTx(
       address,
       newSwapOceanFee,
       newSwapNonOceanFee,
       newConsumeFee,
-      newProviderFee,
-      estGas
+      newProviderFee
     )
+    if (estimateGas) return <ReceiptOrEstimate<G>>tx.gasLimit
     const trxReceipt = await sendPreparedTransaction(this.getSignerAccordingSdk(), tx)
 
     return <ReceiptOrEstimate<G>>trxReceipt
@@ -413,20 +346,17 @@ export class Router extends SmartContractWithAddress {
     newSwapOceanFee: number,
     newSwapNonOceanFee: number,
     newConsumeFee: number,
-    newProviderFee: number,
-    estimatedGas?: bigint
+    newProviderFee: number
   ): Promise<TransactionRequest> {
     if ((await this.getOwner()) !== address) {
       throw new Error(`Caller is not Router Owner`)
     }
-    const estGas =
-      estimatedGas ??
-      (await this.contract.updateOPCFee.estimateGas(
-        newSwapOceanFee,
-        newSwapNonOceanFee,
-        newConsumeFee,
-        newProviderFee
-      ))
+    const estGas = await this.contract.updateOPCFee.estimateGas(
+      newSwapOceanFee,
+      newSwapNonOceanFee,
+      newConsumeFee,
+      newProviderFee
+    )
     const overrides = await buildTxOverrides(
       estGas,
       this.getSignerAccordingSdk(),

--- a/src/services/Aquarius.ts
+++ b/src/services/Aquarius.ts
@@ -3,7 +3,12 @@ import { LoggerInstance } from '../utils/Logger'
 import { sleep } from '../utils/General.js'
 import { Signer } from 'ethers'
 import { signRequest } from '../utils/SignatureUtils.js'
-import { Asset, DDO, DDOManager, ValidateMetadata } from '@oceanprotocol/ddo-js'
+import {
+  DDOManager,
+  type Asset,
+  type DDO,
+  type ValidateMetadata
+} from '@oceanprotocol/ddo-js'
 import { PROTOCOL_COMMANDS } from '../@types/Provider.js'
 import { isP2pUri, getAuthorization } from './providers/BaseProvider.js'
 import { ProviderInstance } from './Provider.js'

--- a/src/utils/Assets.ts
+++ b/src/utils/Assets.ts
@@ -15,7 +15,7 @@ import { ProviderInstance } from '../services/Provider.js'
 import AccessListFactory from '@oceanprotocol/contracts/artifacts/contracts/accesslists/AccessListFactory.sol/AccessListFactory.json'
 import ERC20Template4 from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template4.sol/ERC20Template4.json'
 import { calculateActiveTemplateIndex } from './Addresses.js'
-import { DDO, DDOManager } from '@oceanprotocol/ddo-js'
+import { DDOManager, type DDO } from '@oceanprotocol/ddo-js'
 import { StorageObject } from '../@types/File.js'
 
 export const DEVELOPMENT_CHAIN_ID = 8996

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -10,6 +10,12 @@ import {
   EventLog,
   TransactionReceipt
 } from 'ethers'
+import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template.sol/ERC20Template.json'
+import ERC20TemplateEnterprise from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20TemplateEnterprise.sol/ERC20TemplateEnterprise.json'
+import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json'
+import ERC721Factory from '@oceanprotocol/contracts/artifacts/contracts/ERC721Factory.sol/ERC721Factory.json'
+import FixedRateExchange from '@oceanprotocol/contracts/artifacts/contracts/pools/fixedRate/FixedRateExchange.sol/FixedRateExchange.json'
+import AccessListFactory from '@oceanprotocol/contracts/artifacts/contracts/accesslists/AccessListFactory.sol/AccessListFactory.json'
 
 import { Config, KNOWN_CONFIDENTIAL_EVMS } from '../config/index.js'
 import { LoggerInstance } from './Logger.js'
@@ -22,6 +28,14 @@ const MIN_GAS_FEE_SAPPHIRE = 10000000000 // recommended for mainnet and testnet 
 const POLYGON_NETWORK_ID = 137
 const MUMBAI_NETWORK_ID = 80001
 const SEPOLIA_NETWORK_ID = 11155111
+const EVENT_INTERFACES = [
+  new ethers.Interface(ERC20Template.abi),
+  new ethers.Interface(ERC20TemplateEnterprise.abi),
+  new ethers.Interface(ERC721Template.abi),
+  new ethers.Interface(ERC721Factory.abi),
+  new ethers.Interface(FixedRateExchange.abi),
+  new ethers.Interface(AccessListFactory.abi)
+]
 
 export function setContractDefaults(contract: Contract, config: Config): Contract {
   // TO DO - since ethers does not provide this
@@ -31,7 +45,7 @@ export function setContractDefaults(contract: Contract, config: Config): Contrac
     if (config.transactionConfirmationBlocks)
       contract.transactionConfirmationBlocks = config.transactionConfirmationBlocks
     if (config.transactionPollingTimeout)
-      contract.transactionPollingTimeout = config.transactionPollingTimeout
+      contract.transactionPollingTimeout = config.transactio nPollingTimeout
   }
   */
   return contract
@@ -41,7 +55,7 @@ export function setContractDefaults(contract: Contract, config: Config): Contrac
  * Asynchronous function that returns a fair gas price based on the current gas price and a multiplier.
  * @param {Signer} signer - The signer object to use for fetching the current gas price.
  * @param {number} gasFeeMultiplier - The multiplier to apply to the current gas price. If not provided, the current gas price is returned as a string.
- * @returns A Promise that resolves to a string representation of the fair gas price.
+ * @returns A Promise that resolves to a string representation of  the fair gas price.
  */
 export async function getFairGasPrice(
   signer: Signer,
@@ -57,7 +71,7 @@ export async function getFairGasPrice(
  * Asynchronous function that returns the number of decimal places for a given token.
  * @param {Signer} signer - The signer object to use for fetching the token decimals.
  * @param {string} token - The address of the token contract.
- * @returns A Promise that resolves to the number of decimal places for the token.
+ * @returns A Promise that resolves to the number of decimal p laces for the token.
  */
 export async function getTokenDecimals(signer: Signer, token: string) {
   const tokenContract = new ethers.Contract(token, minAbi, signer)
@@ -70,7 +84,7 @@ export async function getTokenDecimals(signer: Signer, token: string) {
  * @param {string} token - The token to convert
  * @param {string} amount - The amount of units to convert
  * @param {number} [tokenDecimals] - The number of decimals in the token
- * @returns {Promise<string>} - The converted amount in tokens
+ * @returns {Promise<string>} - The conver ted amount in tokens
  */
 export async function unitsToAmount(
   signer: Signer,
@@ -93,7 +107,7 @@ export async function unitsToAmount(
  * @param {string} token - The token to convert
  * @param {string} amount - The amount of tokens to convert
  * @param {number} [tokenDecimals] - The number of decimals of the token
- * @returns {Promise<string>} - The converted amount in units
+ * @returns {Promise<string>} - The conve rted amount in units
  */
 export async function amountToUnits(
   signer: Signer,
@@ -109,19 +123,39 @@ export async function amountToUnits(
   return amountFormatted.toString()
 }
 
-export function getEventFromTx(
-  txReceipt: TransactionReceipt,
-  eventName: string
-): EventLog | undefined {
+export function getEventFromTx(txReceipt: TransactionReceipt, eventName: string): any {
   if (!txReceipt || !txReceipt.logs) {
     return undefined
   }
 
   const foundLog = txReceipt.logs.filter((log): log is EventLog => {
-    return log instanceof EventLog && log.eventName === eventName
+    if (!(log instanceof EventLog) || log.eventName !== eventName) return false
+    const topic0 = log.topics?.[0]?.toLowerCase()
+    // Keep backward compatibility for receipts where ethers doesn't expose eventSignature.
+    if (!topic0 || !log.eventSignature) return true
+    return topic0 === ethers.id(log.eventSignature).toLowerCase()
   })[0]
+  if (foundLog) return foundLog
 
-  return foundLog
+  // Fallback for receipts created via signer.sendTransaction(txRequest).
+  for (const log of txReceipt.logs) {
+    for (const eventInterface of EVENT_INTERFACES) {
+      try {
+        const parsed = eventInterface.parseLog(log)
+        if (!parsed || parsed.name !== eventName) continue
+        return {
+          event: parsed.name,
+          eventName: parsed.name,
+          args: parsed.args,
+          topics: log.topics,
+          data: log.data
+        }
+      } catch {
+        // ignore non-matching log/interface pairs
+      }
+    }
+  }
+  return undefined
 }
 
 /**
@@ -131,7 +165,7 @@ export function getEventFromTx(
  * @param {number} gasFeeMultiplier number represinting the multiplier we apply to gas fees
  * @param {Function} functionToSend function that we need to send
  * @param {...any[]} args arguments of the function
- * @return {Promise<any>} transaction receipt
+ * @return {Promise<any>}  transaction receipt
  */
 export async function sendTx(
   estGas: bigint,

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -180,7 +180,7 @@ export async function sendTx(
   ...args: any[]
 ): Promise<TransactionResponse> {
   const overrides = await buildTxOverrides(estGas, signer, gasFeeMultiplier)
-  return sendPreparedTx(signer, functionToSend, args, overrides)
+  return sendPreparedTx(functionToSend, args, overrides)
 }
 
 export async function buildTxOverrides(
@@ -248,7 +248,6 @@ export async function buildUnsignedTx(
 }
 
 export async function sendPreparedTx(
-  signer: Signer,
   functionToSend: BaseContractMethod,
   args: any[],
   overrides: Record<string, any>

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -45,7 +45,7 @@ export function setContractDefaults(contract: Contract, config: Config): Contrac
     if (config.transactionConfirmationBlocks)
       contract.transactionConfirmationBlocks = config.transactionConfirmationBlocks
     if (config.transactionPollingTimeout)
-      contract.transactionPollingTimeout = config.transactio nPollingTimeout
+      contract.transactionPollingTimeout = config.transactionPollingTimeout
   }
   */
   return contract
@@ -55,7 +55,7 @@ export function setContractDefaults(contract: Contract, config: Config): Contrac
  * Asynchronous function that returns a fair gas price based on the current gas price and a multiplier.
  * @param {Signer} signer - The signer object to use for fetching the current gas price.
  * @param {number} gasFeeMultiplier - The multiplier to apply to the current gas price. If not provided, the current gas price is returned as a string.
- * @returns A Promise that resolves to a string representation of  the fair gas price.
+ * @returns A Promise that resolves to a string representation of the fair gas price.
  */
 export async function getFairGasPrice(
   signer: Signer,
@@ -71,7 +71,7 @@ export async function getFairGasPrice(
  * Asynchronous function that returns the number of decimal places for a given token.
  * @param {Signer} signer - The signer object to use for fetching the token decimals.
  * @param {string} token - The address of the token contract.
- * @returns A Promise that resolves to the number of decimal p laces for the token.
+ * @returns A Promise that resolves to the number of decimal places for the token.
  */
 export async function getTokenDecimals(signer: Signer, token: string) {
   const tokenContract = new ethers.Contract(token, minAbi, signer)
@@ -84,7 +84,7 @@ export async function getTokenDecimals(signer: Signer, token: string) {
  * @param {string} token - The token to convert
  * @param {string} amount - The amount of units to convert
  * @param {number} [tokenDecimals] - The number of decimals in the token
- * @returns {Promise<string>} - The conver ted amount in tokens
+ * @returns {Promise<string>} - The converted amount in tokens
  */
 export async function unitsToAmount(
   signer: Signer,
@@ -107,7 +107,7 @@ export async function unitsToAmount(
  * @param {string} token - The token to convert
  * @param {string} amount - The amount of tokens to convert
  * @param {number} [tokenDecimals] - The number of decimals of the token
- * @returns {Promise<string>} - The conve rted amount in units
+ * @returns {Promise<string>} - The converted amount in units
  */
 export async function amountToUnits(
   signer: Signer,

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -3,6 +3,7 @@ import {
   Signer,
   Contract,
   TransactionResponse,
+  TransactionRequest,
   BaseContractMethod,
   formatUnits,
   parseUnits,
@@ -139,6 +140,15 @@ export async function sendTx(
   functionToSend: BaseContractMethod,
   ...args: any[]
 ): Promise<TransactionResponse> {
+  const overrides = await buildTxOverrides(estGas, signer, gasFeeMultiplier)
+  return sendPreparedTx(signer, functionToSend, args, overrides)
+}
+
+export async function buildTxOverrides(
+  estGas: bigint,
+  signer: Signer,
+  gasFeeMultiplier: number
+): Promise<Record<string, any>> {
   const { chainId } = await signer.provider.getNetwork()
   const feeHistory = await signer.provider.getFeeData()
   let overrides: Record<string, any> = {}
@@ -186,12 +196,44 @@ export async function sendTx(
     }
   }
   overrides.gasLimit = BigInt(new BigNumber(estGas).plus(20000n).toString())
+  return overrides
+}
+
+export async function buildUnsignedTx(
+  functionToSend: BaseContractMethod,
+  args: any[],
+  overrides: Record<string, any>
+): Promise<TransactionRequest> {
+  const tx = await functionToSend.populateTransaction(...args, overrides)
+  return tx
+}
+
+export async function sendPreparedTx(
+  signer: Signer,
+  functionToSend: BaseContractMethod,
+  args: any[],
+  overrides: Record<string, any>
+): Promise<TransactionResponse> {
   try {
     const trxReceipt = await functionToSend(...args, overrides)
     await trxReceipt.wait()
     return trxReceipt
   } catch (e) {
     LoggerInstance.error('Send tx error: ', e)
+    return null
+  }
+}
+
+export async function sendPreparedTransaction(
+  signer: Signer,
+  tx: TransactionRequest
+): Promise<TransactionResponse> {
+  try {
+    const trxReceipt = await signer.sendTransaction(tx)
+    await trxReceipt.wait()
+    return trxReceipt
+  } catch (e) {
+    LoggerInstance.error('Send prepared tx error: ', e)
     return null
   }
 }

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -147,6 +147,11 @@ export function getEventFromTx(txReceipt: TransactionReceipt, eventName: string)
           event: parsed.name,
           eventName: parsed.name,
           args: parsed.args,
+          transactionHash: log.transactionHash,
+          blockHash: log.blockHash,
+          blockNumber: log.blockNumber,
+          address: log.address,
+          logIndex: log.index,
           topics: log.topics,
           data: log.data
         }

--- a/src/utils/OrderUtils.ts
+++ b/src/utils/OrderUtils.ts
@@ -10,7 +10,7 @@ import { approve, approveWei } from './TokenUtils.js'
 import { Dispenser } from '../contracts/Dispenser.js'
 import { FixedRateExchange } from '../contracts/FixedRateExchange.js'
 import { FreOrderParams } from '../@types/FixedPrice.js'
-import { Asset, DDOManager } from '@oceanprotocol/ddo-js'
+import { DDOManager, type Asset } from '@oceanprotocol/ddo-js'
 
 /**
  * Orders an asset based on the specified pricing schema and configuration.

--- a/test/unit/FixedRateExchange.test.ts
+++ b/test/unit/FixedRateExchange.test.ts
@@ -266,8 +266,8 @@ describe('Fixed Rate unit test', () => {
       )
       expect(
         new BigNumber(await amountToUnits(user1, addresses.MockDAI, daiBalanceBefore))
-          .minus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount))
-          .toString()
+          .minus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount.toString()))
+          .toFixed(0)
       ).to.equal(
         await amountToUnits(
           user1,
@@ -309,8 +309,8 @@ describe('Fixed Rate unit test', () => {
       expect(await balance(user1, dtAddress, await user1.getAddress())).to.equal('0.0')
       expect(
         new BigNumber(await amountToUnits(user1, addresses.MockDAI, daiBalanceBefore))
-          .plus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount))
-          .toString()
+          .plus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount.toString()))
+          .toFixed(0)
       ).to.equal(
         await amountToUnits(
           user1,
@@ -446,7 +446,7 @@ describe('Fixed Rate unit test', () => {
           await amountToUnits(user1, addresses.MockDAI, daiBalanceBeforeCollect)
         )
           .plus(new BigNumber(await amountToUnits(user1, addresses.MockDAI, '0.021')))
-          .toString()
+          .toFixed(0)
       )
     })
 
@@ -667,8 +667,8 @@ describe('Fixed Rate unit test', () => {
       )
       expect(
         new BigNumber(await amountToUnits(user1, addresses.MockUSDC, usdcBalanceBefore))
-          .minus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount))
-          .toString()
+          .minus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount.toString()))
+          .toFixed(0)
       ).to.equal(
         await amountToUnits(
           user1,
@@ -710,8 +710,8 @@ describe('Fixed Rate unit test', () => {
       expect(await balance(user1, dtAddress, await user1.getAddress())).to.equal('0.0')
       expect(
         new BigNumber(await amountToUnits(user1, addresses.MockUSDC, usdcBalanceBefore))
-          .plus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount))
-          .toString()
+          .plus(new BigNumber(SwappedEvent.args.baseTokenSwappedAmount.toString()))
+          .toFixed(0)
       ).to.equal(
         await amountToUnits(
           user1,


### PR DESCRIPTION
## Summary

This PR refactors contract write flows to support offline signing while preserving existing high-level APIs.

- Add reusable transaction-building helpers in `src/utils/ContractUtils.ts`:
  - `buildTxOverrides(estGas, signer, gasFeeMultiplier)`
  - `buildUnsignedTx(functionToSend, args, overrides)`
  - `sendPreparedTx(signer, functionToSend, args, overrides)`
  - `sendPreparedTransaction(signer, tx)`
- Keep `sendTx(...)` behavior intact, but internally reuse shared override/send helpers.
- Introduce `*Tx` methods across contract wrappers to return unsigned `TransactionRequest`.
- Refactor existing state-changing methods to:
  1) keep permission checks and argument normalization,
  2) call corresponding `*Tx` method to build tx,
  3) send via `sendPreparedTransaction(...)`.

## Why

Today, write methods both build and send transactions inline, which duplicates logic and makes offline signing difficult.

This change:
- centralizes transaction construction,
- removes duplicated transaction-building paths,
- enables agents/clients to request unsigned tx payloads for external signing,
- keeps backward compatibility for existing callers using legacy methods.

## Scope

### Core utility changes

- `src/utils/ContractUtils.ts`
  - extract shared gas/override logic from `sendTx`,
  - add unsigned tx construction helper,
  - add helper to send prebuilt unsigned transactions.

### Contract wrappers updated

- `src/contracts/AccessList.ts`
- `src/contracts/AccessListFactory.ts`
- `src/contracts/Datatoken.ts`
- `src/contracts/Datatoken4.ts`
- `src/contracts/Dispenser.ts`
- `src/contracts/Escrow.ts`
- `src/contracts/FixedRateExchange.ts`
- `src/contracts/NFT.ts`
- `src/contracts/NFTFactory.ts`
- `src/contracts/Router.ts`

## New `*Tx` API surface (high level)

- `AccessList`: mint/batchMint/burn/ownership write ops now have `*Tx`.
- `AccessListFactory`: deploy + template-change operations now have `*Tx`.
- `Datatoken` + `Datatoken4`: major write operations now expose unsigned tx builders.
- `Dispenser`: create/activate/deactivate/setAllowedSwapper/dispense/ownerWithdraw `*Tx`.
- `Escrow`: deposit/withdraw/authorize/cancelExpiredLocks `*Tx`.
- `FixedRateExchange`: all core exchange write ops now expose `*Tx`.
- `NFT`: ERC20 creation, permission management, transfer, metadata, token URI, store writes now expose `*Tx`.
- `NFTFactory`: NFT/template and composite create/order flows now expose `*Tx`.
- `Router`: batch buy + approved-token/fixed-rate/dispenser/opc updates expose `*Tx`.

## Backward compatibility

- Existing method names and return semantics are preserved for legacy callers.
- `estimateGas` paths are retained.
- Permission checks, input normalization, and event extraction behavior remain in place.

## Tests update
Cause: [bignumber.js](https://mikemcl.github.io/bignumber.js/) switches to exponential notation in .toString() when the magnitude is large enough (default EXPONENTIAL_AT is 21). Values around 1e21 wei hit that, so you got '1.070373e+21' while amountToUnits(...) still returns a full decimal string '1070373000000000000000'. Same number, different string → assertion fails.

Change: For those wei comparisons, use .toFixed(0) instead of .toString() on the BigNumber result, and normalize the event arg with .toString() when building the BigNumber (works cleanly with ethers bigint args).