### PR TITLE
send only job id

### DIFF
--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -399,7 +399,10 @@ export class BaseProvider {
       const baseUrl = incentiveBackendUrl.replace(/\/+$/, '')
       const peerId = await this.resolveNodePeerId(nodeUri)
 
-      await fetch(`${baseUrl}/jobs/${encodeURIComponent(job.jobId)}/started`, {
+      const dashIndex = job.jobId.indexOf('-')
+      const bareJobId = dashIndex > 0 ? job.jobId.slice(dashIndex + 1) : job.jobId
+
+      await fetch(`${baseUrl}/jobs/${encodeURIComponent(bareJobId)}/started`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- We need to only parse and send the job id, not env-jobid
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job start notifications so the correct job identifier is sent to the backend, reducing mismatches for jobs with prefixed IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->