### PR TITLE
add service streamable logs

### DIFF
--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -151,7 +151,8 @@ export const PROTOCOL_COMMANDS = {
   SERVICE_STOP: 'serviceStop',
   SERVICE_RESTART: 'serviceRestart',
   SERVICE_GET_STATUS: 'serviceGetStatus',
-  SERVICE_EXTEND: 'serviceExtend'
+  SERVICE_EXTEND: 'serviceExtend',
+  SERVICE_GET_STREAMABLE_LOGS: 'serviceGetStreamableLogs'
 }
 
 export interface NodeLogsParams {

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -828,6 +828,22 @@ export class BaseProvider {
     )
   }
 
+  public async serviceGetStreamableLogs(
+    nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
+    serviceId: string,
+    since?: string,
+    signal?: AbortSignal
+  ): Promise<any> {
+    return this.getImpl(nodeUri).serviceGetStreamableLogs(
+      nodeUri,
+      signerOrAuthToken,
+      serviceId,
+      since,
+      signal
+    )
+  }
+
   public async fetchConfig(
     nodeUri: OceanNode,
     payload: Record<string, any>

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -2199,4 +2199,45 @@ export class HttpProvider {
     const data = await response.json()
     return Array.isArray(data) ? data : []
   }
+
+  public async serviceGetStreamableLogs(
+    nodeUri: string,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
+    serviceId: string,
+    since?: string,
+    signal?: AbortSignal
+  ): Promise<any> {
+    const providerEndpoints = await this.getEndpoints(nodeUri)
+    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
+    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceGetStreamableLogs')
+    const authPayload = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.SERVICE_GET_STREAMABLE_LOGS,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
+    const query = this.buildQuery({
+      ...authPayload,
+      serviceId,
+      ...(since ? { since } : {})
+    })
+    const headers: Record<string, string> = {}
+    if (typeof signerOrAuthToken === 'string') headers.Authorization = signerOrAuthToken
+    const response = await fetch(`${route}?${query.toString()}`, {
+      method: 'GET',
+      headers,
+      signal
+    })
+    if (response?.ok || response?.status === 200) {
+      return responseBodyToAsyncIterable(response.body)
+    }
+    LoggerInstance.error(
+      'serviceGetStreamableLogs failed: ',
+      response.status,
+      response.statusText
+    )
+    return null
+  }
 }

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -2209,7 +2209,11 @@ export class HttpProvider {
   ): Promise<any> {
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceGetStreamableLogs')
+    const route = this.resolveServiceRoute(
+      nodeUri,
+      serviceEndpoints,
+      'serviceGetStreamableLogs'
+    )
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -634,6 +634,7 @@ export class P2pProvider {
 
       if (
         command === PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS ||
+        command === PROTOCOL_COMMANDS.SERVICE_GET_STREAMABLE_LOGS ||
         command === PROTOCOL_COMMANDS.COMPUTE_GET_RESULT
       ) {
         const streamableChunks = (async function* () {
@@ -1906,5 +1907,31 @@ export class P2pProvider {
       signal
     )
     return Array.isArray(result) ? result : []
+  }
+
+  /**
+   * Stream a running service's container logs via P2P. `since` optionally bounds the lower time
+   * (Unix seconds, or a relative duration like '30s'/'2h'); omit for the full history then live.
+   */
+  public async serviceGetStreamableLogs(
+    nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
+    serviceId: string,
+    since?: string,
+    signal?: AbortSignal
+  ): Promise<any> {
+    const authPayload = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.SERVICE_GET_STREAMABLE_LOGS,
+      signal
+    )
+    return this.sendP2pCommand(
+      nodeUri,
+      PROTOCOL_COMMANDS.SERVICE_GET_STREAMABLE_LOGS,
+      { ...authPayload, serviceId, ...(since ? { since } : {}) },
+      signerOrAuthToken,
+      signal
+    )
   }
 }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- add service streamable logs
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving streamable service logs through both HTTP and P2P connections.
  * Introduced a new command so clients can request log streaming from supported nodes.
  * Responses can now be consumed as a live async stream instead of a one-time payload.

* **Bug Fixes**
  * Improved handling of streamed log responses to return data more reliably across transport types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->