### PR TITLE
add dockerCmd/dockerEntrypoint params on service restart

### DIFF
--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -803,6 +803,8 @@ export class BaseProvider {
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId: string,
     userData?: ServiceUserData,
+    dockerCmd?: string[],
+    dockerEntrypoint?: string[],
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
     return this.getImpl(nodeUri).serviceRestart(
@@ -810,6 +812,8 @@ export class BaseProvider {
       signerOrAuthToken,
       serviceId,
       userData,
+      dockerCmd,
+      dockerEntrypoint,
       signal
     )
   }

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -2121,8 +2121,10 @@ export class HttpProvider {
   }
 
   /**
-   * Restarts a running service (recreates the container). When `userData` is
-   * supplied it REPLACES the stored userData; otherwise the stored one is reused.
+   * Restarts a running service (recreates the container). When `userData`, `dockerCmd` or
+   * `dockerEntrypoint` is supplied it REPLACES the stored value;
+   * otherwise the stored one is reused.  Passing a new `dockerCmd` swaps the launch command
+   * (e.g. a different model) while keeping the same serviceId, host port and expiry.
    * @return {Promise<ServiceJob[]>} The restarted service job (single-element array).
    */
   public async serviceRestart(
@@ -2130,6 +2132,8 @@ export class HttpProvider {
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId: string,
     userData?: ServiceUserData,
+    dockerCmd?: string[],
+    dockerEntrypoint?: string[],
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
     const providerEndpoints = await this.getEndpoints(nodeUri)
@@ -2153,7 +2157,11 @@ export class HttpProvider {
       body: JSON.stringify({
         ...authPayload,
         serviceId,
-        userData: await this.encryptServiceUserData(nodeUri, userData)
+        userData: await this.encryptServiceUserData(nodeUri, userData),
+        // Only send when supplied — an omitted override reuses the node's stored value, whereas an
+        // explicit [] REPLACES it with "no override" (matches ocean-node's restartService semantics).
+        ...(dockerCmd !== undefined ? { dockerCmd } : {}),
+        ...(dockerEntrypoint !== undefined ? { dockerEntrypoint } : {})
       }),
       signal
     })

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -1865,6 +1865,8 @@ export class P2pProvider {
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId: string,
     userData?: ServiceUserData,
+    dockerCmd?: string[],
+    dockerEntrypoint?: string[],
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
     const authPayload = await this.getSignedCommandParams(
@@ -1879,7 +1881,11 @@ export class P2pProvider {
       {
         ...authPayload,
         serviceId,
-        userData: await this.encryptServiceUserData(nodeUri, userData)
+        userData: await this.encryptServiceUserData(nodeUri, userData),
+        // Only send when supplied — an omitted override reuses the node's stored value, whereas an
+        // explicit [] REPLACES it with "no override" (matches ocean-node's restartService semantics).
+        ...(dockerCmd !== undefined ? { dockerCmd } : {}),
+        ...(dockerEntrypoint !== undefined ? { dockerEntrypoint } : {})
       },
       signerOrAuthToken,
       signal


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- add dockerCmd/dockerEntrypoint params on service restart
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Service restarts now support optional Docker command and entrypoint overrides.
  - Explicitly provided values, including empty lists, are applied during restart.
  - When overrides are omitted, the service continues using its previously stored configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->