### PR TITLE
add service list

### DIFF
--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -151,6 +151,7 @@ export const PROTOCOL_COMMANDS = {
   SERVICE_STOP: 'serviceStop',
   SERVICE_RESTART: 'serviceRestart',
   SERVICE_GET_STATUS: 'serviceGetStatus',
+  SERVICE_LIST: 'serviceList',
   SERVICE_EXTEND: 'serviceExtend',
   SERVICE_GET_STREAMABLE_LOGS: 'serviceGetStreamableLogs'
 }

--- a/src/@types/Services.ts
+++ b/src/@types/Services.ts
@@ -110,6 +110,32 @@ export interface ServiceJob {
   extendPayments?: ServiceJobPayment[] // one entry per successful SERVICE_EXTEND
 }
 
+// Returned by SERVICE_LIST, which is authenticated but NOT owner-scoped (any consumer
+// identity sees every owner's services). On top of the always-stripped userData, the
+// node removes everything that reveals HOW a service is configured — CMD/ENTRYPOINT
+// overrides and any inline Dockerfile. Identity, status, resources, endpoints and
+// payment metadata are kept; use the owner-scoped SERVICE_GET_STATUS for the full view.
+export type ServiceJobListed = Omit<
+  ServiceJob,
+  'dockerCmd' | 'dockerEntrypoint' | 'dockerfile' | 'additionalDockerFiles'
+>
+
+// Filters for SERVICE_LIST (getServices). With no filters the node returns only the
+// services currently holding a resource reservation — exactly what the engines count
+// against the shared pools: Running/Restarting/Stopping, the mid-start pipeline states,
+// paid Error (container died, restartable), and explicitly Stopped within the paid
+// window. Expired and never-paid jobs hold nothing and are not listed by default.
+export interface ServiceListFilters {
+  // filter to ONE specific status (any ServiceStatusNumber, incl. Expired); takes
+  // precedence over includeAllStatuses
+  status?: ServiceStatusNumber
+  // return services in EVERY status instead of only the resource-holding set
+  includeAllStatuses?: boolean
+  // only services created at/after this moment: ISO date string, or a Unix timestamp
+  // (seconds or milliseconds) as a string
+  fromTimestamp?: string
+}
+
 // ── Request shapes ─────────────────────────────────────────────────────
 
 export interface ServicePayment {

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -31,6 +31,8 @@ import {
   PersistentStorageObject,
   PersistentStorageUpdateBucketResponse,
   ServiceJob,
+  ServiceJobListed,
+  ServiceListFilters,
   ServiceTemplatePublic,
   ServiceStartParams,
   ServiceUserData,
@@ -830,6 +832,15 @@ export class BaseProvider {
       serviceId,
       signal
     )
+  }
+
+  public async getServices(
+    nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
+    filters?: ServiceListFilters,
+    signal?: AbortSignal
+  ): Promise<ServiceJobListed[]> {
+    return this.getImpl(nodeUri).getServices(nodeUri, signerOrAuthToken, filters, signal)
   }
 
   public async serviceGetStreamableLogs(

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -29,6 +29,8 @@ import {
   PersistentStorageObject,
   PersistentStorageUpdateBucketResponse,
   ServiceJob,
+  ServiceJobListed,
+  ServiceListFilters,
   ServiceTemplatePublic,
   ServiceStartParams,
   ServiceUserData,
@@ -2195,6 +2197,48 @@ export class HttpProvider {
     const query = this.buildQuery({
       ...authPayload,
       ...(serviceId ? { serviceId } : {})
+    })
+    const headers: Record<string, string> = {}
+    if (typeof signerOrAuthToken === 'string') headers.Authorization = signerOrAuthToken
+    const response = await fetch(`${route}?${query.toString()}`, {
+      method: 'GET',
+      headers,
+      signal
+    })
+    if (!response.ok) throw new Error(await response.text())
+    const data = await response.json()
+    return Array.isArray(data) ? data : []
+  }
+
+  /**
+   * Node-wide service listing (SERVICE_LIST). Authenticated but NOT owner-scoped: any
+   * consumer identity sees every owner's services, listing-sanitized (no userData, no
+   * dockerCmd/dockerEntrypoint, no Dockerfile). Default (no filters) returns only the
+   * services currently holding a resource reservation; see ServiceListFilters.
+   * @return {Promise<ServiceJobListed[]>} The matching service jobs.
+   */
+  public async getServices(
+    nodeUri: string,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
+    filters?: ServiceListFilters,
+    signal?: AbortSignal
+  ): Promise<ServiceJobListed[]> {
+    const providerEndpoints = await this.getEndpoints(nodeUri)
+    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
+    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceList')
+    const authPayload = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.SERVICE_LIST,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
+    const query = this.buildQuery({
+      ...authPayload,
+      ...(filters?.status !== undefined ? { status: String(filters.status) } : {}),
+      ...(filters?.includeAllStatuses ? { includeAllStatuses: 'true' } : {}),
+      ...(filters?.fromTimestamp ? { fromTimestamp: filters.fromTimestamp } : {})
     })
     const headers: Record<string, string> = {}
     if (typeof signerOrAuthToken === 'string') headers.Authorization = signerOrAuthToken

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -44,6 +44,8 @@ import {
   PersistentStorageObject,
   PersistentStorageUpdateBucketResponse,
   ServiceJob,
+  ServiceJobListed,
+  ServiceListFilters,
   ServiceTemplatePublic,
   ServiceStartParams,
   ServiceUserData,
@@ -1909,6 +1911,39 @@ export class P2pProvider {
       nodeUri,
       PROTOCOL_COMMANDS.SERVICE_GET_STATUS,
       { ...authPayload, ...(serviceId ? { serviceId } : {}) },
+      signerOrAuthToken,
+      signal
+    )
+    return Array.isArray(result) ? result : []
+  }
+
+  /**
+   * Node-wide service listing (SERVICE_LIST) via P2P. Authenticated but NOT owner-scoped:
+   * any consumer identity sees every owner's services, listing-sanitized (no userData, no
+   * dockerCmd/dockerEntrypoint, no Dockerfile). Default (no filters) returns only the
+   * services currently holding a resource reservation; see ServiceListFilters.
+   */
+  public async getServices(
+    nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
+    filters?: ServiceListFilters,
+    signal?: AbortSignal
+  ): Promise<ServiceJobListed[]> {
+    const authPayload = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.SERVICE_LIST,
+      signal
+    )
+    const result = await this.sendP2pCommand(
+      nodeUri,
+      PROTOCOL_COMMANDS.SERVICE_LIST,
+      {
+        ...authPayload,
+        ...(filters?.status !== undefined ? { status: filters.status } : {}),
+        ...(filters?.includeAllStatuses ? { includeAllStatuses: true } : {}),
+        ...(filters?.fromTimestamp ? { fromTimestamp: filters.fromTimestamp } : {})
+      },
       signerOrAuthToken,
       signal
     )

--- a/test/integration/Services.test.ts
+++ b/test/integration/Services.test.ts
@@ -293,6 +293,56 @@ describe('Service on Demand flow tests', () => {
     )
   })
 
+  it('lists services node-wide via getServices (SERVICE_LIST, not owner-scoped)', async function () {
+    if (skipLifecycle || !serviceId) this.skip()
+
+    // default listing (resource-holding services only), called with a DIFFERENT
+    // identity than the owner — SERVICE_LIST is authenticated but not owner-scoped
+    const listed = await ProviderInstance.getServices(providerUrl, publisherAccount)
+    const job = listed.find((j) => j.serviceId === serviceId)
+    assert(job, "another consumer's default listing should include the running service")
+
+    // listing-sanitized: no userData, no CMD/ENTRYPOINT overrides, no Dockerfile
+    for (const field of [
+      'userData',
+      'dockerCmd',
+      'dockerEntrypoint',
+      'dockerfile',
+      'additionalDockerFiles'
+    ]) {
+      expect((job as any)[field], `${field} should be stripped`).to.equal(undefined)
+    }
+    assert(job.owner, 'identity fields are kept')
+    assert(job.payment, 'payment metadata is kept')
+
+    // status filter narrows to ONE specific status
+    const running = await ProviderInstance.getServices(providerUrl, consumerAccount, {
+      status: ServiceStatusNumber.Running
+    })
+    assert(
+      running.some((j) => j.serviceId === serviceId),
+      'status=Running should include the service'
+    )
+    const expired = await ProviderInstance.getServices(providerUrl, consumerAccount, {
+      status: ServiceStatusNumber.Expired
+    })
+    assert(
+      !expired.some((j) => j.serviceId === serviceId),
+      'status=Expired should not include the running service'
+    )
+
+    // fromTimestamp: a future moment excludes everything created so far
+    const future = new Date(Date.now() + 3600 * 1000).toISOString()
+    const none = await ProviderInstance.getServices(providerUrl, consumerAccount, {
+      includeAllStatuses: true,
+      fromTimestamp: future
+    })
+    assert(
+      !none.some((j) => j.serviceId === serviceId),
+      'a future fromTimestamp should exclude the service'
+    )
+  })
+
   it('extends the service → expiresAt advances, extendPayments grows', async function () {
     if (skipLifecycle || !serviceId) this.skip()
     this.timeout(120000)
@@ -322,6 +372,8 @@ describe('Service on Demand flow tests', () => {
       providerUrl,
       consumerAccount,
       serviceId,
+      undefined,
+      undefined,
       undefined,
       opSignal()
     )

--- a/test/unit/Services.test.ts
+++ b/test/unit/Services.test.ts
@@ -13,6 +13,7 @@ describe('Service on Demand client wiring', () => {
     expect(PROTOCOL_COMMANDS.SERVICE_STOP).to.equal('serviceStop')
     expect(PROTOCOL_COMMANDS.SERVICE_RESTART).to.equal('serviceRestart')
     expect(PROTOCOL_COMMANDS.SERVICE_GET_STATUS).to.equal('serviceGetStatus')
+    expect(PROTOCOL_COMMANDS.SERVICE_LIST).to.equal('serviceList')
     expect(PROTOCOL_COMMANDS.SERVICE_EXTEND).to.equal('serviceExtend')
   })
 
@@ -24,14 +25,15 @@ describe('Service on Demand client wiring', () => {
     expect(ServiceStatusNumber.Error).to.equal(99)
   })
 
-  it('ProviderInstance exposes the six service methods', () => {
+  it('ProviderInstance exposes the service methods', () => {
     for (const m of [
       'getServiceTemplates',
       'serviceStart',
       'serviceStop',
       'serviceExtend',
       'serviceRestart',
-      'getServiceStatus'
+      'getServiceStatus',
+      'getServices'
     ]) {
       assert(
         typeof (ProviderInstance as any)[m] === 'function',


### PR DESCRIPTION
# Add `SERVICE_LIST` support: `ProviderInstance.getServices()`

## What

Client-side support for the new ocean-node `SERVICE_LIST` command
(`GET /api/services/serviceList`, ocean-node commit
[`d6153a0`](https://github.com/oceanprotocol/ocean-node/commit/d6153a0a735cd83991e8dc53cb958d9e6b20f71a)):
the **node-wide service listing** for Service on Demand, exposed as
`ProviderInstance.getServices(nodeUri, signerOrAuthToken, filters?, signal?)` on both the
HTTP and P2P transports.

## Semantics (mirrors the node)

- **Authenticated but NOT owner-scoped** — any consumer identity (signature or auth
  token) sees every owner's services. The per-owner full view remains
  `getServiceStatus` (`SERVICE_GET_STATUS`).
- **Default (no filters)**: only the services **currently holding a resource
  reservation** — exactly what the engines count against the shared pools:
  Running/Restarting/Stopping, the mid-start pipeline states, paid `Error` (container
  died, restartable), and explicitly `Stopped` within the paid window. `Expired` and
  never-paid jobs hold nothing and are not listed.
- **Filters** (`ServiceListFilters`):
  - `status` — ONE specific `ServiceStatusNumber` (any, incl. `Expired`); takes
    precedence over `includeAllStatuses`
  - `includeAllStatuses` — every status, regardless of reservations
  - `fromTimestamp` — only services created at/after that moment (ISO date string, or a
    Unix timestamp in seconds or milliseconds)
- **Listing-sanitized output** (`ServiceJobListed`): on top of the always-stripped
  `userData`, the node removes `dockerCmd`, `dockerEntrypoint`, `dockerfile` and
  `additionalDockerFiles`; identity, status, resources, endpoints and payment metadata
  are kept.

## Changes

- `src/@types/Provider.ts` — `PROTOCOL_COMMANDS.SERVICE_LIST = 'serviceList'` (the
  auth-signed `command` string and P2P dispatch key; matches ocean-node verbatim).
- `src/@types/Services.ts` — new exported types `ServiceJobListed`
  (`Omit<ServiceJob, 'dockerCmd' | 'dockerEntrypoint' | 'dockerfile' | 'additionalDockerFiles'>`)
  and `ServiceListFilters`.
- `src/services/providers/HttpProvider.ts` — `getServices()`: signed
  `GET /api/services/serviceList` following the `getServiceStatus` pattern (advertised
  endpoint discovery with well-known-path fallback, signature query params or
  auth-token `Authorization` header). Filters are serialized the way the node's route
  parses them (`status` stringified, `includeAllStatuses` sent as literal `'true'` only
  when set, `fromTimestamp` passed through).
- `src/services/providers/P2pProvider.ts` — `getServices()`: the `serviceList` P2P
  command with the filters inline (native number/boolean).
- `src/services/providers/BaseProvider.ts` — façade dispatch, so the method works
  transparently over HTTP or P2P like the rest of the service surface.

## Tests

- **Unit** (`test/unit/Services.test.ts`): asserts the `serviceList` command string
  matches the node value exactly, and that `ProviderInstance.getServices` is exposed.
- **Integration** (`test/integration/Services.test.ts`): new lifecycle step after
  `getServiceStatus` exercising, against a live node: the default listing returned to a
  **different identity than the owner** (proving it is not owner-scoped), sanitization
  of all five stripped fields, the `status` filter (`Running` matches, `Expired` does
  not), and a future `fromTimestamp` excluding the service. Skips cleanly when the
  Service-on-Demand stack isn't available, like the neighboring tests.
- **Drive-by fix**: the restart test was passing `opSignal()` into the `dockerCmd`
  parameter slot (latent since dockerCmd/dockerEntrypoint were added to
  `serviceRestart` in #2114); it now lands in `signal`.

## Compatibility

`getServices()` requires an ocean-node build that includes the `SERVICE_LIST` handler —
older nodes will 404 the HTTP route / reject the P2P command. No changes to existing
methods or types; purely additive.

## Verification

- `npm run type-check` passes; ESLint clean on all touched files (only pre-existing
  `prefer-destructuring` warnings remain in the integration test).
- `test/unit/Services.test.ts` passes (4/4).
- The integration step runs on the CI barge matrix (http + p2p legs) alongside the rest
  of the Service-on-Demand lifecycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to list services across a node.
  * Supports filtering by status and start time, with an option to include all statuses.
  * Service listings protect sensitive configuration details while retaining relevant identity and payment information.
  * Available through both HTTP and peer-to-peer connections.

* **Tests**
  * Added coverage for service listing, filtering, response sanitization, and protocol integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->