### PR TITLE
allow dockerspecs on service restart

### DIFF
--- a/src/@types/Services.ts
+++ b/src/@types/Services.ts
@@ -152,18 +152,35 @@ export interface ServicePayment {
 // so a plaintext secret can never be forwarded unencrypted.
 export type ServiceUserData = Record<string, unknown>
 
-export interface ServiceStartParams {
-  environment: string // required: the envId to run the service on
-  image: string // base image name (or build label when dockerfile is set)
+// The container specification shared by serviceStart and serviceRestart. Every field is
+// optional here; the consuming type decides which are required (serviceStart re-declares
+// `image` as mandatory). `userData` is always ECIES-encrypted to the node before sending.
+export interface ServiceContainerSpec {
+  image?: string // base image name (or build label when dockerfile is set)
   tag?: string // pull by name:tag
   checksum?: string // pull by digest: "sha256:<64 hex>"
   dockerfile?: string // build from inline Dockerfile; requires allowImageBuild on the env
   additionalDockerFiles?: Record<string, string>
+  userData?: ServiceUserData
   dockerCmd?: string[] // exec-form CMD override (no shell)
   dockerEntrypoint?: string[]
+}
+
+// Optional container-spec overrides for serviceRestart. The node treats the restart
+// atomically ("all-or-nothing"): providing ANY of image/tag/checksum/dockerfile/
+// additionalDockerFiles switches it into RESPEC mode — the container is rebuilt entirely
+// from these values (`image` becomes mandatory, and exactly one of tag/checksum/dockerfile
+// applies) instead of being bounced on the stored spec (REUSE mode). Passing none of them
+// reuses the stored container spec unchanged. `userData`/`dockerCmd`/`dockerEntrypoint`
+// keep their replace-when-supplied semantics: an omitted value reuses the stored one, an
+// explicit value (including `[]`) REPLACES it.
+export type ServiceRestartParams = ServiceContainerSpec
+
+export interface ServiceStartParams extends ServiceContainerSpec {
+  environment: string // required: the envId to run the service on
+  image: string // required for start (base image name, or build label when dockerfile is set)
   exposedPorts?: number[]
   resources?: ComputeResourceRequest[]
   duration: number // seconds; capped by serviceOnDemand.maxDurationSeconds
-  userData?: ServiceUserData
   payment: ServicePayment
 }

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -33,9 +33,9 @@ import {
   ServiceJob,
   ServiceJobListed,
   ServiceListFilters,
+  ServiceRestartParams,
   ServiceTemplatePublic,
   ServiceStartParams,
-  ServiceUserData,
   ServicePayment,
   OceanNode,
   NodeP2P,
@@ -860,18 +860,14 @@ export class BaseProvider {
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId: string,
-    userData?: ServiceUserData,
-    dockerCmd?: string[],
-    dockerEntrypoint?: string[],
+    params?: ServiceRestartParams,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
     return this.getImpl(nodeUri).serviceRestart(
       nodeUri,
       signerOrAuthToken,
       serviceId,
-      userData,
-      dockerCmd,
-      dockerEntrypoint,
+      params,
       signal
     )
   }

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -31,6 +31,7 @@ import {
   ServiceJob,
   ServiceJobListed,
   ServiceListFilters,
+  ServiceRestartParams,
   ServiceTemplatePublic,
   ServiceStartParams,
   ServiceUserData,
@@ -2123,21 +2124,36 @@ export class HttpProvider {
   }
 
   /**
-   * Restarts a running service (recreates the container). When `userData`, `dockerCmd` or
-   * `dockerEntrypoint` is supplied it REPLACES the stored value;
-   * otherwise the stored one is reused.  Passing a new `dockerCmd` swaps the launch command
-   * (e.g. a different model) while keeping the same serviceId, host port and expiry.
+   * Restarts a running service (recreates the container) while keeping the same serviceId,
+   * payment, resources, host port(s) and expiry.
+   *
+   * The node treats the restart atomically. Passing no container-spec fields in `params`
+   * (REUSE mode) bounces the container on its stored spec unchanged. Passing ANY of
+   * `image`/`tag`/`checksum`/`dockerfile`/`additionalDockerFiles` (RESPEC mode) rebuilds the
+   * container entirely from `params`: `image` becomes mandatory, exactly one of
+   * `tag`/`checksum`/`dockerfile` applies, and a `dockerfile` requires `allowImageBuild` on
+   * the env (else the node replies 403). `userData`/`dockerCmd`/`dockerEntrypoint` are only
+   * sent when supplied — an omitted override reuses the node's stored value, whereas an
+   * explicit value (including `[]`) REPLACES it (matches ocean-node's restartService semantics).
    * @return {Promise<ServiceJob[]>} The restarted service job (single-element array).
    */
   public async serviceRestart(
     nodeUri: string,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId: string,
-    userData?: ServiceUserData,
-    dockerCmd?: string[],
-    dockerEntrypoint?: string[],
+    params?: ServiceRestartParams,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
+    const {
+      image,
+      tag,
+      checksum,
+      dockerfile,
+      additionalDockerFiles,
+      userData,
+      dockerCmd,
+      dockerEntrypoint
+    } = params ?? {}
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceRestart')
@@ -2160,8 +2176,13 @@ export class HttpProvider {
         ...authPayload,
         serviceId,
         userData: await this.encryptServiceUserData(nodeUri, userData),
-        // Only send when supplied — an omitted override reuses the node's stored value, whereas an
-        // explicit [] REPLACES it with "no override" (matches ocean-node's restartService semantics).
+        // Only send when supplied — an omitted field reuses the node's stored value, whereas an
+        // explicit value REPLACES it (matches ocean-node's restartService REUSE/RESPEC semantics).
+        ...(image !== undefined ? { image } : {}),
+        ...(tag !== undefined ? { tag } : {}),
+        ...(checksum !== undefined ? { checksum } : {}),
+        ...(dockerfile !== undefined ? { dockerfile } : {}),
+        ...(additionalDockerFiles !== undefined ? { additionalDockerFiles } : {}),
         ...(dockerCmd !== undefined ? { dockerCmd } : {}),
         ...(dockerEntrypoint !== undefined ? { dockerEntrypoint } : {})
       }),

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -46,6 +46,7 @@ import {
   ServiceJob,
   ServiceJobListed,
   ServiceListFilters,
+  ServiceRestartParams,
   ServiceTemplatePublic,
   ServiceStartParams,
   ServiceUserData,
@@ -1866,11 +1867,19 @@ export class P2pProvider {
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId: string,
-    userData?: ServiceUserData,
-    dockerCmd?: string[],
-    dockerEntrypoint?: string[],
+    params?: ServiceRestartParams,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
+    const {
+      image,
+      tag,
+      checksum,
+      dockerfile,
+      additionalDockerFiles,
+      userData,
+      dockerCmd,
+      dockerEntrypoint
+    } = params ?? {}
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1884,8 +1893,13 @@ export class P2pProvider {
         ...authPayload,
         serviceId,
         userData: await this.encryptServiceUserData(nodeUri, userData),
-        // Only send when supplied — an omitted override reuses the node's stored value, whereas an
-        // explicit [] REPLACES it with "no override" (matches ocean-node's restartService semantics).
+        // Only send when supplied — an omitted field reuses the node's stored value, whereas an
+        // explicit value REPLACES it (matches ocean-node's restartService REUSE/RESPEC semantics).
+        ...(image !== undefined ? { image } : {}),
+        ...(tag !== undefined ? { tag } : {}),
+        ...(checksum !== undefined ? { checksum } : {}),
+        ...(dockerfile !== undefined ? { dockerfile } : {}),
+        ...(additionalDockerFiles !== undefined ? { additionalDockerFiles } : {}),
         ...(dockerCmd !== undefined ? { dockerCmd } : {}),
         ...(dockerEntrypoint !== undefined ? { dockerEntrypoint } : {})
       },

--- a/test/integration/Services.test.ts
+++ b/test/integration/Services.test.ts
@@ -373,8 +373,6 @@ describe('Service on Demand flow tests', () => {
       consumerAccount,
       serviceId,
       undefined,
-      undefined,
-      undefined,
       opSignal()
     )
     const running = await pollUntil(


### PR DESCRIPTION
Closes #2120

# Allow Docker specs on `serviceRestart` (RESPEC mode)

## What

Client-side support for the extended `serviceRestart` command from ocean-node
[#1429](https://github.com/oceanprotocol/ocean-node/pull/1429) ("Allow docker specs on
service restart"): a restart can now change the container's **image specification** while
keeping the same serviceId, payment, resources, duration/expiry and host port(s). This
covers the realistic recovery workflow — start a service, hit a bug, publish a new tag,
then restart onto the new image without losing the paid window or reserved resources.

`ProviderInstance.serviceRestart` now takes a single optional `params: ServiceRestartParams`
object (replacing the previous positional `userData`/`dockerCmd`/`dockerEntrypoint` args),
consistent with how `serviceStart` takes `ServiceStartParams`. Available on both the HTTP
and P2P transports.

## Semantics (mirrors the node)

The node treats the restart **atomically** ("all-or-nothing"), so the client just forwards
the fields the caller supplies and lets the node pick the mode:

- **REUSE mode** — no container-spec fields supplied → the container is bounced on its
  stored spec, unchanged (the previous behaviour).
- **RESPEC mode** — ANY of `image`/`tag`/`checksum`/`dockerfile`/`additionalDockerFiles`
  supplied → the container is rebuilt entirely from `params`. `image` becomes mandatory,
  exactly one of `tag`/`checksum`/`dockerfile` applies, and a `dockerfile` requires
  `allowImageBuild` on the environment (the node replies `403` otherwise). Sending a
  container param without `image`, or more than one image mode, is a `400` from the node.
- `userData`/`dockerCmd`/`dockerEntrypoint` keep their **replace-when-supplied** semantics:
  an omitted field reuses the node's stored value, an explicit value (including `[]`)
  REPLACES it. As before, `userData` is ECIES-encrypted to the node's key client-side.

Each field is only put on the wire when actually supplied, so the client never
accidentally forces the node out of REUSE mode.

## Changes

- `src/@types/Services.ts` — factored the container spec shared by start and restart into
  a new exported `ServiceContainerSpec` (`image?`, `tag?`, `checksum?`, `dockerfile?`,
  `additionalDockerFiles?`, `userData?`, `dockerCmd?`, `dockerEntrypoint?`).
  `ServiceRestartParams` is that spec (all fields optional; atomic REUSE/RESPEC contract
  documented inline); `ServiceStartParams` now `extends ServiceContainerSpec`, re-declaring
  `image` as required and adding `environment`/`exposedPorts`/`resources`/`duration`/
  `payment`. No structural change to `ServiceStartParams`.
- `src/services/providers/HttpProvider.ts` — `serviceRestart()` now accepts
  `(nodeUri, signerOrAuthToken, serviceId, params?, signal?)`; unpacks `params` and adds
  each image-spec field to the request body only when defined.
- `src/services/providers/P2pProvider.ts` — same signature/body change over the
  `serviceRestart` P2P command.
- `src/services/providers/BaseProvider.ts` — façade signature updated to the new `params`
  shape (dropped the now-unused `ServiceUserData` import).

## Tests

- **Unit** (`test/unit/Services.test.ts`): unchanged — the `serviceRestart` command string
  and method exposure assertions still hold.
- **Integration** (`test/integration/Services.test.ts`): the existing REUSE restart step
  is updated to the new `params` signature (passes `undefined` for `params`).

## Compatibility

- **Breaking (client API):** `serviceRestart`'s positional `userData`/`dockerCmd`/
  `dockerEntrypoint` arguments are replaced by a single `params: ServiceRestartParams`
  object. Callers on `9.0.0-next.*` that passed those positionally must move them into the
  object. REUSE-mode restarts (no container spec) behave exactly as before.
- **Node requirement:** RESPEC mode requires an ocean-node build that includes #1429;
  older nodes ignore/na the extra fields and restart in REUSE mode. Purely additive on the
  wire — new fields are only sent when supplied.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible service restart options, including container image, build, Docker command, entrypoint, and user data overrides.
  * Restart requests now support reusing existing container settings or rebuilding with explicitly provided specifications.
  * Standardized service start and restart configuration handling across providers.

* **Bug Fixes**
  * Ensured omitted restart options preserve existing service configuration.

* **Tests**
  * Updated service restart integration coverage for the streamlined request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->