### PR TITLE
add node compute job/service runTimeMetrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           bash -x start_ocean.sh 2>&1 > start-node.log &
         env:
           CONTRACTS_VERSION: '2.9.0'
-          NODE_VERSION: "pr-1408"
+          NODE_VERSION: "pr-1436"
       - name: Install deps & build
         run: npm ci && npm run build:metadata
 

--- a/src/@types/Compute.ts
+++ b/src/@types/Compute.ts
@@ -98,6 +98,8 @@ export type ComputeJobMetadata = {
   [key: string]: string | number | boolean
 }
 
+// GPU backend a device's metrics were sampled with. Only 'nvidia' (NVML) is emitted
+// today; 'amd' / 'intel' are reserved for when those backends exist.
 export type GpuVendor = 'nvidia' | 'amd' | 'intel'
 
 // Per-GPU runtime metrics. One entry per GPU resource the job/service holds. Only NVIDIA

--- a/src/@types/Compute.ts
+++ b/src/@types/Compute.ts
@@ -98,6 +98,63 @@ export type ComputeJobMetadata = {
   [key: string]: string | number | boolean
 }
 
+export type GpuVendor = 'nvidia' | 'amd' | 'intel'
+
+// Per-GPU runtime metrics. One entry per GPU resource the job/service holds. Only NVIDIA
+// is emitted today; `null` (not `0`) means the backend could not read that metric.
+export interface GpuMetricsSnapshot {
+  resourceId: string
+  vendor: GpuVendor
+  utilizationPercent: number | null
+  memoryUsedBytes: number | null
+  memoryTotalBytes: number | null
+  temperatureC?: number
+  powerWatts?: number
+  shared?: boolean // true → device-level number, may include other jobs' load
+}
+
+// Best-effort Docker/NVML runtime metrics snapshot for a compute job or service container,
+// as returned by COMPUTE_GET_STATUS / SERVICE_GET_STATUS when `includeMetrics` resolves to
+// true. Sampled on a fixed cadence (node-side `C2D_METRICS_INTERVAL_SECONDS`), so values can
+// be slightly stale — see `collectedAt`. Owner-only; never present on unauthenticated or
+// listing responses.
+export interface ContainerMetricsSnapshot {
+  collectedAt: string // ISO timestamp of the sample
+  containerState: {
+    status: string // 'running' | 'exited' | ...
+    startedAt?: string
+    finishedAt?: string
+    exitCode?: number
+    oomKilled: boolean
+    error?: string
+    restartCount: number
+    health?: string // Docker HEALTHCHECK status, when the image defines one (services)
+  }
+  cpu: {
+    usagePercent: number // % of one host CPU-second per wall-second; can exceed 100
+    allocated: number // cores requested (0 when unconstrained)
+    usagePercentOfAllocated: number // usagePercent / allocated (0 when allocated is 0)
+    cumulativeSeconds: number // total CPU-seconds consumed since start
+    throttledPeriods: number // CFS quota throttling events
+    throttledSeconds: number
+  }
+  memory: {
+    usageBytes: number
+    limitBytes: number
+    usagePercent: number
+    peakUsageBytes: number // max usageBytes observed across samples
+  }
+  disk: {
+    usedBytes: number
+    quotaBytes?: number // present only for jobs with a 'disk' resource
+    usagePercent?: number // present only when quotaBytes is known
+  }
+  network?: { rxBytes: number; txBytes: number } // absent when NetworkMode 'none'
+  blockIO: { readBytes: number; writeBytes: number }
+  pids: { current: number; limit: number }
+  gpu?: GpuMetricsSnapshot[]
+}
+
 export interface ComputeJob {
   owner: string
   did?: string
@@ -139,6 +196,9 @@ export interface NodeComputeJob extends ComputeJob {
   queueMaxWaitTime?: number
   jobIdHash?: string
   maxJobDuration?: number
+  // Best-effort Docker/NVML runtime metrics, present only when computeStatus() was called
+  // with includeMetrics resolving to true for the authenticated job owner.
+  runtimeMetrics?: ContainerMetricsSnapshot
 }
 
 export interface ComputeOutputEncryption {

--- a/src/@types/Services.ts
+++ b/src/@types/Services.ts
@@ -1,4 +1,4 @@
-import { ComputeResourceRequest } from './Compute.js'
+import { ComputeResourceRequest, ContainerMetricsSnapshot } from './Compute.js'
 
 // Service-on-Demand client types. Mirror of ocean-node
 // `src/@types/C2D/ServiceOnDemand.ts` (the API surface a client interacts with).
@@ -120,6 +120,10 @@ export interface ServiceJob {
   resources: any[] // ComputeResourceRequestWithPrice[] on the node
   payment: ServiceJobPayment // initial start payment
   extendPayments?: ServiceJobPayment[] // one entry per successful SERVICE_EXTEND
+  // Best-effort Docker/NVML runtime metrics sampled while the service container runs.
+  // Present only when getServiceStatus() resolved includeMetrics to true; never present
+  // on SERVICE_LIST (see ServiceJobListed).
+  runtimeMetrics?: ContainerMetricsSnapshot
 }
 
 // Returned by SERVICE_LIST, which is authenticated but NOT owner-scoped (any consumer
@@ -129,7 +133,11 @@ export interface ServiceJob {
 // payment metadata are kept; use the owner-scoped SERVICE_GET_STATUS for the full view.
 export type ServiceJobListed = Omit<
   ServiceJob,
-  'dockerCmd' | 'dockerEntrypoint' | 'dockerfile' | 'additionalDockerFiles'
+  | 'dockerCmd'
+  | 'dockerEntrypoint'
+  | 'dockerfile'
+  | 'additionalDockerFiles'
+  | 'runtimeMetrics'
 >
 
 // Filters for SERVICE_LIST (getServices). With no filters the node returns only the

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -539,6 +539,19 @@ export class BaseProvider {
     )
   }
 
+  /**
+   * Get compute status for a specific jobId/documentId/owner.
+   * @param {boolean} includeMetrics Owner-only runtime metrics (`runtimeMetrics`) on the
+   *   returned job(s). To receive them, the node needs owner credentials: an auth token
+   *   (`signerOrAuthToken` as a string) is ALWAYS sent, regardless of this flag; a `Signer`'s
+   *   nonce+signature is only computed and sent when this flag is `true` (skipped otherwise
+   *   to avoid an extra nonce round-trip on every plain status poll). Omitted (default): the
+   *   node attaches metrics silently if valid owner credentials made it into the request
+   *   (true automatically for token callers, false for `Signer` callers unless this flag is
+   *   set), and returns exactly today's response otherwise. `true`: metrics are required —
+   *   this method also computes the `Signer`'s signature, and the node answers 400/401 if
+   *   credentials don't verify. `false`: metrics are never attached.
+   */
   public async computeStatus(
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
@@ -915,6 +928,13 @@ export class BaseProvider {
     return services
   }
 
+  /**
+   * Returns the caller's service jobs (userData stripped). Filter by `serviceId`,
+   * or omit it to list all of the caller's services. Requires a signature.
+   * @param {boolean} includeMetrics Owner-only runtime metrics (`runtimeMetrics`) on the
+   *   returned service(s). This command is already authenticated, so metrics are included
+   *   BY DEFAULT (omitted / `undefined`); pass `false` to opt out.
+   */
   public async getServiceStatus(
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -544,14 +544,16 @@ export class BaseProvider {
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
-    signal?: AbortSignal
-  ): Promise<ComputeJob | ComputeJob[]> {
+    signal?: AbortSignal,
+    includeMetrics?: boolean
+  ): Promise<NodeComputeJob | NodeComputeJob[]> {
     return this.getImpl(nodeUri).computeStatus(
       nodeUri,
       signerOrAuthToken,
       jobId,
       agreementId,
-      signal
+      signal,
+      includeMetrics
     )
   }
 
@@ -917,13 +919,15 @@ export class BaseProvider {
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    includeMetrics?: boolean
   ): Promise<ServiceJob[]> {
     return this.getImpl(nodeUri).getServiceStatus(
       nodeUri,
       signerOrAuthToken,
       serviceId,
-      signal
+      signal,
+      includeMetrics
     )
   }
 

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -1074,25 +1074,54 @@ export class HttpProvider {
    * @param {string} jobId The ID of a compute job.
    * @param {string} agreementId The ID of the service agreement (tx id)
    * @param {AbortSignal} signal abort signal
-   * @return {Promise<ComputeJob | ComputeJob[]>}
+   * @param {boolean} includeMetrics Owner-only runtime metrics (`runtimeMetrics`) on the
+   *   returned job(s). To receive them, the node needs owner credentials: an auth token
+   *   (`signerOrAuthToken` as a string) is ALWAYS sent, regardless of this flag; a `Signer`'s
+   *   nonce+signature is only computed and sent when this flag is `true` (skipped otherwise
+   *   to avoid an extra nonce round-trip on every plain status poll). Omitted (default): the
+   *   node attaches metrics silently if valid owner credentials made it into the request
+   *   (true automatically for token callers, false for `Signer` callers unless this flag is
+   *   set), and returns exactly today's response otherwise. `true`: metrics are required —
+   *   this method also computes the `Signer`'s signature, and the node answers 400/401 if
+   *   credentials don't verify. `false`: metrics are never attached.
+   * @return {Promise<NodeComputeJob | NodeComputeJob[]>}
    */
   public async computeStatus(
     nodeUri: string,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
-    signal?: AbortSignal
-  ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
+    signal?: AbortSignal,
+    includeMetrics?: boolean
+  ): Promise<NodeComputeJob | NodeComputeJob[]> {
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const computeStatusUrl = this.getEndpointURL(serviceEndpoints, 'computeStatus')
       ? this.getEndpointURL(serviceEndpoints, 'computeStatus').urlPath
       : null
 
+    let consumerAddress: string
+    let nonce: string
+    let signature: string
+    if (includeMetrics === true) {
+      ;({ consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+        nodeUri,
+        signerOrAuthToken,
+        PROTOCOL_COMMANDS.COMPUTE_GET_STATUS,
+        signal,
+        providerEndpoints,
+        serviceEndpoints
+      ))
+    } else {
+      consumerAddress = await getConsumerAddress(signerOrAuthToken)
+    }
+
     let url = `?consumerAddress=${consumerAddress}`
     url += (agreementId && `&agreementId=${agreementId}`) || ''
     url += (jobId && `&jobId=${jobId}`) || ''
+    url += includeMetrics !== undefined ? `&includeMetrics=${includeMetrics}` : ''
+    url += nonce ? `&nonce=${nonce}` : ''
+    url += signature ? `&signature=${signature}` : ''
 
     if (!computeStatusUrl) return null
     let response
@@ -2196,13 +2225,17 @@ export class HttpProvider {
   /**
    * Returns the caller's service jobs (userData stripped). Filter by `serviceId`,
    * or omit it to list all of the caller's services. Requires a signature.
+   * @param {boolean} includeMetrics Owner-only runtime metrics (`runtimeMetrics`) on the
+   *   returned service(s). This command is already authenticated, so metrics are included
+   *   BY DEFAULT (omitted / `undefined`); pass `false` to opt out.
    * @return {Promise<ServiceJob[]>} The matching service jobs.
    */
   public async getServiceStatus(
     nodeUri: string,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    includeMetrics?: boolean
   ): Promise<ServiceJob[]> {
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
@@ -2217,7 +2250,8 @@ export class HttpProvider {
     )
     const query = this.buildQuery({
       ...authPayload,
-      ...(serviceId ? { serviceId } : {})
+      ...(serviceId ? { serviceId } : {}),
+      ...(includeMetrics !== undefined ? { includeMetrics: String(includeMetrics) } : {})
     })
     const headers: Record<string, string> = {}
     if (typeof signerOrAuthToken === 'string') headers.Authorization = signerOrAuthToken

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -1253,18 +1253,44 @@ export class P2pProvider {
 
   /**
    * Get compute status via P2P.
+   * @param {boolean} includeMetrics Owner-only runtime metrics (`runtimeMetrics`) on the
+   *   returned job(s). To receive them, the node needs owner credentials: an auth token
+   *   (`signerOrAuthToken` as a string) is ALWAYS sent, regardless of this flag; a `Signer`'s
+   *   nonce+signature is only computed and sent when this flag is `true` (skipped otherwise
+   *   to avoid an extra nonce round-trip on every plain status poll). Omitted (default): the
+   *   node attaches metrics silently if valid owner credentials made it into the request
+   *   (true automatically for token callers, false for `Signer` callers unless this flag is
+   *   set), and returns exactly today's response otherwise. `true`: metrics are required —
+   *   this method also computes the `Signer`'s signature, and the node answers 400/401 if
+   *   credentials don't verify. `false`: metrics are never attached.
    */
   public async computeStatus(
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     jobId?: string,
     agreementId?: string,
-    signal?: AbortSignal
-  ): Promise<ComputeJob | ComputeJob[]> {
-    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
+    signal?: AbortSignal,
+    includeMetrics?: boolean
+  ): Promise<NodeComputeJob | NodeComputeJob[]> {
+    let consumerAddress: string
+    let nonce: string
+    let signature: string
+    if (includeMetrics === true) {
+      ;({ consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+        nodeUri,
+        signerOrAuthToken,
+        PROTOCOL_COMMANDS.COMPUTE_GET_STATUS,
+        signal
+      ))
+    } else {
+      consumerAddress = await getConsumerAddress(signerOrAuthToken)
+    }
     const body: Record<string, any> = { consumerAddress }
     if (jobId) body.jobId = jobId
     if (agreementId) body.agreementId = agreementId
+    if (includeMetrics !== undefined) body.includeMetrics = includeMetrics
+    if (nonce) body.nonce = nonce
+    if (signature) body.signature = signature
 
     return this.sendP2pCommand(
       nodeUri,
@@ -1909,11 +1935,17 @@ export class P2pProvider {
     return Array.isArray(result) ? result : [result]
   }
 
+  /**
+   * @param {boolean} includeMetrics Owner-only runtime metrics (`runtimeMetrics`) on the
+   *   returned service(s). This command is already authenticated, so metrics are included
+   *   BY DEFAULT (omitted / `undefined`); pass `false` to opt out.
+   */
   public async getServiceStatus(
     nodeUri: OceanNode,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     serviceId?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    includeMetrics?: boolean
   ): Promise<ServiceJob[]> {
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
@@ -1924,7 +1956,11 @@ export class P2pProvider {
     const result = await this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.SERVICE_GET_STATUS,
-      { ...authPayload, ...(serviceId ? { serviceId } : {}) },
+      {
+        ...authPayload,
+        ...(serviceId ? { serviceId } : {}),
+        ...(includeMetrics !== undefined ? { includeMetrics } : {})
+      },
       signerOrAuthToken,
       signal
     )


### PR DESCRIPTION
# Add `runtimeMetrics` typings + `includeMetrics` plumbing for compute/service status

## Summary

Mirrors [ocean-node PR #1436](https://github.com/oceanprotocol/ocean-node/pull/1436) ("Feature/docker stats") on the client side: adds the typed shape of the new Docker/NVML runtime-metrics snapshot the node can attach to compute-job and service-job status responses, and teaches `computeStatus()` / `getServiceStatus()` how to request it via the new `includeMetrics` flag. No runtime behavior changes for any existing caller that doesn't pass the new parameter.

## Background

Ocean-node PR #1436 adds best-effort, owner-only runtime metrics (CPU, memory, disk, network, block I/O, PIDs, exit info, optional NVIDIA GPU stats) for C2D compute jobs and Service-on-Demand containers, sampled on a fixed interval and exposed through the existing `COMPUTE_GET_STATUS` / `SERVICE_GET_STATUS` endpoints behind a new `includeMetrics` flag. This PR brings the corresponding client-side types and opt-in wiring into `@oceanprotocol/lib` so consumers (e.g. `ocean-cli`) can request and type-check the new data once a node running that feature is available.

## What changed

### New types (`src/@types/Compute.ts`)

- `GpuVendor` — `'nvidia' | 'amd' | 'intel'`
- `GpuMetricsSnapshot` — per-GPU utilization/memory/temperature/power; `null` (not `0`) marks a metric the backend couldn't read
- `ContainerMetricsSnapshot` — the full snapshot: `containerState`, `cpu`, `memory`, `disk`, optional `network`, `blockIO`, `pids`, optional `gpu[]`. Deliberately omits the node's internal `prev` CPU-delta accumulator, which the node always strips before a snapshot reaches any client.
- `NodeComputeJob` gains an optional `runtimeMetrics?: ContainerMetricsSnapshot`.

### `src/@types/Services.ts`

- `ServiceJob` gains the same optional `runtimeMetrics?: ContainerMetricsSnapshot`.
- `ServiceJobListed`'s omitted-keys union now also excludes `'runtimeMetrics'`, matching the node's `toListedServiceJob` — `SERVICE_LIST` never returns metrics regardless of any flag.

### Provider methods — `getServiceStatus()` (`BaseProvider`, `HttpProvider`, `P2pProvider`)

- New trailing optional parameter: `includeMetrics?: boolean`.
- This command is already authenticated (owner-scoped), so metrics are included **by default**; pass `includeMetrics: false` to opt out. `HttpProvider` forwards it as a query param, `P2pProvider` forwards it in the signed command body.

### Provider methods — `computeStatus()` (`BaseProvider`, `HttpProvider`, `P2pProvider`)

- New trailing optional parameter: `includeMetrics?: boolean`.
- Return type widened from `ComputeJob | ComputeJob[]` to `NodeComputeJob | NodeComputeJob[]` — the type that actually matches this endpoint's wire payload (it already carries `environment`, `resources`, `payment`, etc.), so `runtimeMetrics` is visible on the value callers get back.
- `COMPUTE_GET_STATUS` supports unauthenticated calls, so unlike `getServiceStatus()`, metrics are opt-in here:
  - An **auth token** (`signerOrAuthToken` passed as a string) is presented to the node unconditionally, on every call, regardless of `includeMetrics` — this was already true before this change.
  - A **`Signer`**'s nonce + signature are only computed (an extra nonce round-trip) and sent when `includeMetrics === true`, to avoid paying that cost on every plain, unauthenticated status poll.
  - Net effect: `includeMetrics` omitted → node attaches metrics silently if the request already carries valid owner credentials (automatic for token callers, requires the flag for `Signer` callers) and behaves exactly as before otherwise; `includeMetrics: true` → required, node answers 400/401 if credentials don't verify; `includeMetrics: false` → never attached.

### CI (`.github/workflows/ci.yml`)

- Bumped the barge `NODE_VERSION` env from `pr-1408` to `pr-1436` so the integration suite runs against an ocean-node build that actually has this feature.

## Behavior / compatibility

- **Purely additive.** All new parameters are optional and appended after existing trailing parameters (`signal`), so no existing positional call site shifts argument meaning.
- **No change in network requests** for any caller that doesn't pass `includeMetrics` to `computeStatus()`/`getServiceStatus()` with a `Signer` — the extra nonce/signature round-trip only happens when `includeMetrics: true` is explicitly requested on `computeStatus()`.
- `computeStatus()`'s declared return type changes from `ComputeJob | ComputeJob[]` to `NodeComputeJob | NodeComputeJob[]`; since `NodeComputeJob extends ComputeJob`, this is a widening, not a narrowing, and is source-compatible with existing callers typed against `ComputeJob`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional runtime metrics for compute jobs and services, including resource, memory, disk, network, process, container, and GPU information.
  * Status requests can now explicitly include or exclude runtime metrics.
  * Detailed metrics are available only when requested, while standard status responses remain streamlined.
* **Bug Fixes**
  * Updated integration testing to use the latest Barge version.
* **Privacy**
  * Service listings continue to exclude runtime metrics and other configuration-sensitive details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->