### PR TITLE
hardcode http paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           bash -x start_ocean.sh 2>&1 > start_ocean.log &
         env:
           CONTRACTS_VERSION: '2.9.0'
-          NODE_VERSION: "pr-1408"
+          NODE_VERSION: "pr-1448"
       - name: Install deps & build
         run: npm ci && npm run build:metadata
       - name: Wait for node to be ready
@@ -157,7 +157,7 @@ jobs:
           bash -x start_ocean.sh 2>&1 > start-node.log &
         env:
           CONTRACTS_VERSION: '2.9.0'
-          NODE_VERSION: "pr-1408"
+          NODE_VERSION: "pr-1448"
       - name: Install deps & build
         run: npm ci && npm run build:metadata
 

--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -41,12 +41,6 @@ export interface ProviderComputeInitializeResults {
   payment?: ProviderComputeInitializePayment
 }
 
-export interface ServiceEndpoint {
-  serviceName: string
-  method: string
-  urlPath: string
-}
-
 export interface NodeP2P {
   nodeId: string
   multiaddress?: Multiaddr[]

--- a/src/@types/Services.ts
+++ b/src/@types/Services.ts
@@ -56,8 +56,7 @@ export interface ServiceTemplatePublic {
 
 // ── Runtime service job ────────────────────────────────────────────────
 
-// Port mapping for a running service (named ServiceJobEndpoint to avoid colliding
-// with the provider-route `ServiceEndpoint` type used for node endpoint discovery).
+// Port mapping for a running service.
 export interface ServiceJobEndpoint {
   containerPort: number
   hostPort: number

--- a/src/@types/Services.ts
+++ b/src/@types/Services.ts
@@ -56,7 +56,6 @@ export interface ServiceTemplatePublic {
 
 // ── Runtime service job ────────────────────────────────────────────────
 
-// Port mapping for a running service.
 export interface ServiceJobEndpoint {
   containerPort: number
   hostPort: number

--- a/src/services/Aquarius.ts
+++ b/src/services/Aquarius.ts
@@ -239,7 +239,7 @@ export class Aquarius {
     signal?: AbortSignal,
     authorization?: string
   ): Promise<any> {
-    const path = this.aquariusURL + '/api/aquarius/assets/query'
+    const path = this.aquariusURL + '/api/aquarius/assets/metadata/query'
 
     try {
       const response = await fetch(path, {

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -12,7 +12,6 @@ import {
   ComputeResultStream,
   ProviderInitialize,
   ProviderComputeInitializeResults,
-  ServiceEndpoint,
   UserCustomParameters,
   ComputeResourceRequest,
   ComputeJobMetadata,
@@ -154,17 +153,9 @@ export class BaseProvider {
   public async getNonce(
     nodeUri: OceanNode,
     consumerAddress: string,
-    signal?: AbortSignal,
-    providerEndpoints?: any,
-    serviceEndpoints?: ServiceEndpoint[]
+    signal?: AbortSignal
   ): Promise<number> {
-    return this.getImpl(nodeUri).getNonce(
-      nodeUri,
-      consumerAddress,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
-    )
+    return this.getImpl(nodeUri).getNonce(nodeUri, consumerAddress, signal)
   }
 
   public async encrypt(

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -83,7 +83,7 @@ export class HttpProvider {
     const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
     const signature = await getSignature(signerOrAuthToken, nonce, command)
-    if (!signature) throw new Error('Could not sign persistent storage request.')
+    if (!signature) throw new Error(`Could not sign ${command} request.`)
     return { consumerAddress, nonce, signature }
   }
 

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -10,7 +10,6 @@ import {
   ComputeEnvironment,
   ProviderInitialize,
   ProviderComputeInitializeResults,
-  ServiceEndpoint,
   UserCustomParameters,
   ComputeResourceRequest,
   ComputeJobMetadata,
@@ -56,13 +55,16 @@ export class HttpProvider {
     return getAuthorization(s)
   }
 
+  // Strips any trailing slash(es) from nodeUri so a route can just be appended to it.
+  private baseUrl(nodeUri: string): string {
+    return nodeUri.replace(/\/+$/, '')
+  }
+
   private async getSignedCommandParams(
     nodeUri: string,
     signerOrAuthToken: SignerOrAuthTokenOrSignature,
     command: string,
-    signal?: AbortSignal,
-    providerEndpoints?: any,
-    serviceEndpoints?: any
+    signal?: AbortSignal
   ): Promise<CompleteSignature> {
     if (isAgentSignature(signerOrAuthToken)) {
       return {
@@ -78,60 +80,32 @@ export class HttpProvider {
         signature: undefined
       }
     }
-    if (!providerEndpoints) providerEndpoints = await this.getEndpoints(nodeUri)
-    if (!serviceEndpoints)
-      serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-
     const consumerAddress = await getConsumerAddress(signerOrAuthToken)
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
     const signature = await getSignature(signerOrAuthToken, nonce, command)
     if (!signature) throw new Error('Could not sign persistent storage request.')
     return { consumerAddress, nonce, signature }
   }
 
-  private resolvePersistentStorageRoute(
-    nodeUri: string,
-    serviceEndpoints: ServiceEndpoint[],
-    serviceNames: string[],
-    fallbackPath: string
-  ): string {
-    for (const serviceName of serviceNames) {
-      const endpoint = this.getEndpointURL(serviceEndpoints, serviceName)
-      if (endpoint?.urlPath) return endpoint.urlPath
-    }
-    return nodeUri.replace(/\/+$/, '') + fallbackPath
-  }
-
   /**
-   * Returns the provider endpoints
+   * Returns the node's root info document (nodeId, chainIds, providerAddress, nodePublicKey, ...).
    * @param {string} nodeUri - the provider url
    * @return {Promise<any>}
    */
-  async getEndpoints(nodeUri: string, authorization?: string): Promise<any> {
+  private async getNodeInfo(nodeUri: string, authorization?: string): Promise<any> {
     try {
-      const endpoints = await this.getData(nodeUri, authorization)
-      return await endpoints.json()
+      const info = await this.getData(nodeUri, authorization)
+      return await info.json()
     } catch (e) {
-      LoggerInstance.error('Finding the service endpoints failed:', e)
+      LoggerInstance.error('Finding the node info failed:', e)
       throw new Error('HTTP request failed calling Provider')
     }
   }
 
   public async getNodeStatus(nodeUri: string, signal?: AbortSignal): Promise<NodeStatus> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const endpoint = this.getEndpointURL(serviceEndpoints, 'directCommand')
-    if (!endpoint?.urlPath) return null
+    const path = this.baseUrl(nodeUri) + '/directCommand'
     try {
-      const response = await fetch(endpoint.urlPath, {
+      const response = await fetch(path, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ command: PROTOCOL_COMMANDS.STATUS }),
@@ -150,11 +124,7 @@ export class HttpProvider {
     fromTimestamp?: number,
     signal?: AbortSignal
   ): Promise<NodeComputeJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const endpoint = this.getEndpointURL(serviceEndpoints, 'jobs')
-    if (!endpoint?.urlPath) return []
-    let url = endpoint.urlPath
+    let url = this.baseUrl(nodeUri) + '/api/services/jobs/:job'
     if (fromTimestamp) url += `?fromTimestamp=${fromTimestamp}`
     try {
       const response = await fetch(url, {
@@ -178,46 +148,8 @@ export class HttpProvider {
    * @return {string} The node public key
    */
   private async getNodePublicKey(nodeUri: string): Promise<string> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    return providerEndpoints.nodePublicKey
-  }
-
-  /**
-   * This function returns the endpoint URL for a given service name.
-   * @param {ServiceEndpoint[]} servicesEndpoints - The array of service endpoints
-   * @param {string} serviceName - The name of the service
-   * @returns {ServiceEndpoint} The endpoint URL for the given service name
-   */
-  getEndpointURL(
-    servicesEndpoints: ServiceEndpoint[],
-    serviceName: string
-  ): ServiceEndpoint {
-    if (!servicesEndpoints) return null
-    return servicesEndpoints.find(
-      (s) => s.serviceName.toLowerCase() === serviceName.toLowerCase()
-    ) as ServiceEndpoint
-  }
-
-  /**
-   * This function returns an array of service endpoints for a given provider endpoint.
-   * @param {string} providerEndpoint - The provider endpoint
-   * @param {any} endpoints - The endpoints object
-   * @returns {ServiceEndpoint[]} An array of service endpoints
-   */
-  public async getServiceEndpoints(providerEndpoint: string, endpoints: any) {
-    const serviceEndpoints: ServiceEndpoint[] = []
-    for (const i in endpoints.serviceEndpoints) {
-      const endpoint: ServiceEndpoint = {
-        serviceName: i,
-        method: endpoints.serviceEndpoints[i][0],
-        urlPath:
-          providerEndpoint.replace(/\/+$/, '') +
-          '/' +
-          endpoints.serviceEndpoints[i][1].replace(/^\/+/, '')
-      }
-      serviceEndpoints.push(endpoint)
-    }
-    return serviceEndpoints
+    const nodeInfo = await this.getNodeInfo(nodeUri)
+    return nodeInfo.nodePublicKey
   }
 
   /**
@@ -225,27 +157,14 @@ export class HttpProvider {
    * @param {string} nodeUri provider uri address
    * @param {string} consumerAddress Publisher address
    * @param {AbortSignal} signal abort signal
-   * @param {string} providerEndpoints Identifier of the asset to be registered in ocean
-   * @param {string} serviceEndpoints document description object (DDO)=
    * @return {Promise<string>} urlDetails
    */
   public async getNonce(
     nodeUri: string,
     consumerAddress: string,
-    signal?: AbortSignal,
-    providerEndpoints?: any,
-    serviceEndpoints?: ServiceEndpoint[]
+    signal?: AbortSignal
   ): Promise<number> {
-    if (!providerEndpoints) {
-      providerEndpoints = await this.getEndpoints(nodeUri)
-    }
-    if (!serviceEndpoints) {
-      serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    }
-    const path = this.getEndpointURL(serviceEndpoints, 'nonce')
-      ? this.getEndpointURL(serviceEndpoints, 'nonce').urlPath
-      : null
-    if (!path) return null
+    const path = this.baseUrl(nodeUri) + '/api/services/nonce'
     try {
       const response = await fetch(path + `?userAddress=${consumerAddress}`, {
         method: 'GET',
@@ -277,22 +196,14 @@ export class HttpProvider {
     policyServer?: any,
     signal?: AbortSignal
   ): Promise<string> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.ENCRYPT,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
 
-    let path =
-      (this.getEndpointURL(serviceEndpoints, 'encrypt')
-        ? this.getEndpointURL(serviceEndpoints, 'encrypt').urlPath
-        : null) + `?chainId=${chainId}`
-    if (!path) return null
+    let path = this.baseUrl(nodeUri) + '/api/services/encrypt' + `?chainId=${chainId}`
     if (nonce) path += `&nonce=${nonce}`
     if (consumerAddress) path += `&consumerAddress=${consumerAddress}`
     if (signature) path += `&signature=${signature}`
@@ -327,14 +238,9 @@ export class HttpProvider {
     withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const args = { did, serviceId, checksum: withChecksum }
     const files: FileInfo[] = []
-    const path = this.getEndpointURL(serviceEndpoints, 'fileinfo')
-      ? this.getEndpointURL(serviceEndpoints, 'fileinfo').urlPath
-      : null
-    if (!path) return null
+    const path = this.baseUrl(nodeUri) + '/api/services/fileInfo'
     let response
     try {
       response = await fetch(path, {
@@ -379,14 +285,9 @@ export class HttpProvider {
     withChecksum: boolean = false,
     signal?: AbortSignal
   ): Promise<FileInfo[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const args = { ...file, checksum: withChecksum }
     const files: FileInfo[] = []
-    const path = this.getEndpointURL(serviceEndpoints, 'fileinfo')
-      ? this.getEndpointURL(serviceEndpoints, 'fileinfo').urlPath
-      : null
-    if (!path) return null
+    const path = this.baseUrl(nodeUri) + '/api/services/fileInfo'
     let response
     try {
       response = await fetch(path, {
@@ -427,10 +328,7 @@ export class HttpProvider {
     nodeUri: string,
     signal?: AbortSignal
   ): Promise<ComputeEnvironment[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const path = this.getEndpointURL(serviceEndpoints, 'computeEnvironments')?.urlPath
-    if (!path) return null
+    const path = this.baseUrl(nodeUri) + '/api/services/computeEnvironments'
     let response
     try {
       response = await fetch(path, {
@@ -481,13 +379,7 @@ export class HttpProvider {
     computeEnv?: string,
     validUntil?: number
   ): Promise<ProviderInitialize> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    let initializeUrl = this.getEndpointURL(serviceEndpoints, 'initialize')
-      ? this.getEndpointURL(serviceEndpoints, 'initialize').urlPath
-      : null
-
-    if (!initializeUrl) return null
+    let initializeUrl = this.baseUrl(nodeUri) + '/api/services/initialize'
     initializeUrl += `?documentId=${did}`
     initializeUrl += `&serviceId=${serviceId}`
     initializeUrl += `&fileIndex=${fileIndex}`
@@ -553,12 +445,7 @@ export class HttpProvider {
     dockerRegistryAuthData?: dockerRegistryAuth,
     output?: ComputeOutput
   ): Promise<ProviderComputeInitializeResults> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const initializeUrl = this.getEndpointURL(serviceEndpoints, 'initializeCompute')
-      ? this.getEndpointURL(serviceEndpoints, 'initializeCompute').urlPath
-      : null
-    if (!initializeUrl) return null
+    const initializeUrl = this.baseUrl(nodeUri) + '/api/services/initializeCompute'
 
     const providerData: Record<string, any> = {
       datasets: assets,
@@ -644,19 +531,12 @@ export class HttpProvider {
     policyServer?: any,
     userCustomParameters?: UserCustomParameters
   ): Promise<any> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const downloadUrl = this.getEndpointURL(serviceEndpoints, 'download')
-      ? this.getEndpointURL(serviceEndpoints, 'download').urlPath
-      : null
-    if (!downloadUrl) return null
+    const downloadUrl = this.baseUrl(nodeUri) + '/api/services/download'
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.DOWNLOAD,
-      undefined,
-      providerEndpoints,
-      serviceEndpoints
+      undefined
     )
     let consumeUrl = downloadUrl
     consumeUrl += `?fileIndex=${fileIndex}`
@@ -713,27 +593,13 @@ export class HttpProvider {
     dockerRegistryAuth?: dockerRegistryAuth,
     outputBucketId?: string
   ): Promise<ComputeJob | ComputeJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-
-    const computeStartUrl = this.getEndpointURL(serviceEndpoints, 'computeStart')
-      ? this.getEndpointURL(serviceEndpoints, 'computeStart').urlPath
-      : null
-
-    if (!computeStartUrl) {
-      LoggerInstance.error(
-        'Compute start failed: Cannot get proper computeStart route (perhaps not implemented on provider?)'
-      )
-      return null
-    }
+    const computeStartUrl = this.baseUrl(nodeUri) + '/api/services/compute'
 
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.COMPUTE_START,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const payload = Object()
     payload.consumerAddress = consumerAddress
@@ -840,27 +706,13 @@ export class HttpProvider {
     dockerRegistryAuth?: dockerRegistryAuth,
     outputBucketId?: string
   ): Promise<ComputeJob | ComputeJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-
-    const computeStartUrl = this.getEndpointURL(serviceEndpoints, 'freeCompute')
-      ? this.getEndpointURL(serviceEndpoints, 'freeCompute').urlPath
-      : null
-
-    if (!computeStartUrl) {
-      LoggerInstance.error(
-        'Compute start failed: Cannot get proper computeStart route (perhaps not implemented on provider?)'
-      )
-      return null
-    }
+    const computeStartUrl = this.baseUrl(nodeUri) + '/api/services/freeCompute'
 
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.FREE_COMPUTE_START,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const payload = Object()
     payload.consumerAddress = consumerAddress
@@ -940,29 +792,13 @@ export class HttpProvider {
     jobId: string,
     signal?: AbortSignal
   ): Promise<any> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-
-    const computeStreamableLogs = this.getEndpointURL(
-      serviceEndpoints,
-      'computeStreamableLogs'
-    )
-      ? this.getEndpointURL(serviceEndpoints, 'computeStreamableLogs').urlPath
-      : null
-
-    if (!computeStreamableLogs) {
-      LoggerInstance.error(
-        'Compute start failed: Cannot get proper computeStreamableLogs route (perhaps not implemented on provider?)'
-      )
-      return null
-    }
+    const computeStreamableLogs =
+      this.baseUrl(nodeUri) + '/api/services/computeStreamableLogs'
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.COMPUTE_GET_STREAMABLE_LOGS,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
 
     let url = `?jobId=${jobId}`
@@ -1013,19 +849,13 @@ export class HttpProvider {
     agreementId?: string,
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const computeStopUrl = this.getEndpointURL(serviceEndpoints, 'computeStop')
-      ? this.getEndpointURL(serviceEndpoints, 'computeStop').urlPath
-      : null
+    const computeStopUrl = this.baseUrl(nodeUri) + '/api/services/compute'
 
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.COMPUTE_STOP,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const queryParams = new URLSearchParams()
     if (consumerAddress) queryParams.set('consumerAddress', consumerAddress)
@@ -1084,17 +914,12 @@ export class HttpProvider {
     signal?: AbortSignal
   ): Promise<ComputeJob | ComputeJob[]> {
     const consumerAddress = await getConsumerAddress(signerOrAuthToken)
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const computeStatusUrl = this.getEndpointURL(serviceEndpoints, 'computeStatus')
-      ? this.getEndpointURL(serviceEndpoints, 'computeStatus').urlPath
-      : null
+    const computeStatusUrl = this.baseUrl(nodeUri) + '/api/services/compute'
 
     let url = `?consumerAddress=${consumerAddress}`
     url += (agreementId && `&agreementId=${agreementId}`) || ''
     url += (jobId && `&jobId=${jobId}`) || ''
 
-    if (!computeStatusUrl) return null
     let response
     try {
       const authHeader = this.getAuthorization(signerOrAuthToken)
@@ -1148,21 +973,14 @@ export class HttpProvider {
     index: number
   ): Promise<string> {
     const isAuthToken = typeof signerOrAuthToken === 'string'
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const computeResultUrl = this.getEndpointURL(serviceEndpoints, 'computeResult')
-      ? this.getEndpointURL(serviceEndpoints, 'computeResult').urlPath
-      : null
+    const computeResultUrl = this.baseUrl(nodeUri) + '/api/services/computeResult'
 
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.COMPUTE_GET_RESULT,
-      undefined,
-      providerEndpoints,
-      serviceEndpoints
+      undefined
     )
-    if (!computeResultUrl) return null
     let resultUrl = computeResultUrl
     resultUrl += `?consumerAddress=${consumerAddress}`
     resultUrl += `&jobId=${jobId}`
@@ -1208,18 +1026,8 @@ export class HttpProvider {
     signal?: AbortSignal
   ): Promise<string> {
     const consumerAddress = await consumer.getAddress()
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const url = this.getEndpointURL(serviceEndpoints, 'generateAuthToken').urlPath || null
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const url = this.baseUrl(nodeUri) + '/api/services/auth/token'
+    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
 
     const issuerPeerId = (await this.getNodeStatus(nodeUri, signal))?.id
     if (!issuerPeerId) throw new Error('Could not resolve node peerId for signature.')
@@ -1270,19 +1078,8 @@ export class HttpProvider {
     signal?: AbortSignal
   ): Promise<{ success: boolean }> {
     const consumerAddress = await consumer.getAddress()
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const url =
-      this.getEndpointURL(serviceEndpoints, 'invalidateAuthToken').urlPath || null
-    const nonce = (
-      (await this.getNonce(
-        nodeUri,
-        consumerAddress,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
-      )) + 1
-    ).toString()
+    const url = this.baseUrl(nodeUri) + '/api/services/auth/token/invalidate'
+    const nonce = ((await this.getNonce(nodeUri, consumerAddress, signal)) + 1).toString()
 
     const signature = await getSignature(
       consumer,
@@ -1350,12 +1147,7 @@ export class HttpProvider {
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const initializeUrl = this.getEndpointURL(serviceEndpoints, 'PolicyServerPassthrough')
-      ? this.getEndpointURL(serviceEndpoints, 'PolicyServerPassthrough').urlPath
-      : null
-    if (!initializeUrl) return null
+    const initializeUrl = this.baseUrl(nodeUri) + '/api/services/PolicyServerPassthrough'
 
     let response
     try {
@@ -1401,15 +1193,7 @@ export class HttpProvider {
     request: PolicyServerInitializeCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const initializeUrl = this.getEndpointURL(
-      serviceEndpoints,
-      'initializePSVerification'
-    )
-      ? this.getEndpointURL(serviceEndpoints, 'initializePSVerification').urlPath
-      : null
-    if (!initializeUrl) return null
+    const initializeUrl = this.baseUrl(nodeUri) + '/api/services/initializePSVerification'
 
     let response
     try {
@@ -1469,26 +1253,12 @@ export class HttpProvider {
     page?: number,
     signal?: AbortSignal
   ): Promise<NodeLogEntry[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-
-    const logsUrl = this.getEndpointURL(serviceEndpoints, 'logs')
-      ? this.getEndpointURL(serviceEndpoints, 'logs').urlPath
-      : null
-
-    if (!logsUrl) {
-      LoggerInstance.error(
-        'Download node logs failed: Cannot get proper logs route (perhaps not implemented on provider?)'
-      )
-      return null
-    }
+    const logsUrl = this.baseUrl(nodeUri) + '/logs'
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.GET_LOGS,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     let url = logsUrl + `?startTime=${startTime}&endTime=${endTime}`
     if (maxLogs) url += `&maxLogs=${maxLogs}`
@@ -1635,14 +1405,7 @@ export class HttpProvider {
     accessList: PersistentStorageAccessList[]
     label?: string | null
   }> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageCreateBucket'],
-      '/api/services/persistentStorage/buckets'
-    )
+    const route = this.baseUrl(nodeUri) + '/api/services/persistentStorage/buckets'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1673,14 +1436,7 @@ export class HttpProvider {
     owner: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageBucket[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageGetBuckets'],
-      '/api/services/persistentStorage/buckets'
-    )
+    const route = this.baseUrl(nodeUri) + '/api/services/persistentStorage/buckets'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1707,14 +1463,9 @@ export class HttpProvider {
     bucketId: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const routeBase = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageListFiles'],
+    const routeBase =
+      this.baseUrl(nodeUri) +
       `/api/services/persistentStorage/buckets/${encodeURIComponent(bucketId)}/files`
-    )
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1743,16 +1494,11 @@ export class HttpProvider {
     fileName: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageObject> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const routeBase = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageGetFileObject'],
+    const routeBase =
+      this.baseUrl(nodeUri) +
       `/api/services/persistentStorage/buckets/${encodeURIComponent(
         bucketId
       )}/files/${encodeURIComponent(fileName)}/object`
-    )
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1781,16 +1527,11 @@ export class HttpProvider {
     content: P2PRequestBodyStream,
     signal?: AbortSignal
   ): Promise<PersistentStorageFileEntry> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const routeBase = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageUploadFile'],
+    const routeBase =
+      this.baseUrl(nodeUri) +
       `/api/services/persistentStorage/buckets/${encodeURIComponent(
         bucketId
       )}/files/${encodeURIComponent(fileName)}`
-    )
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1870,16 +1611,11 @@ export class HttpProvider {
     fileName: string,
     signal?: AbortSignal
   ): Promise<PersistentStorageDeleteFileResponse> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const routeBase = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageDeleteFile'],
+    const routeBase =
+      this.baseUrl(nodeUri) +
       `/api/services/persistentStorage/buckets/${encodeURIComponent(
         bucketId
       )}/files/${encodeURIComponent(fileName)}`
-    )
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1908,14 +1644,9 @@ export class HttpProvider {
     label: string | null,
     signal?: AbortSignal
   ): Promise<PersistentStorageUpdateBucketResponse> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const routeBase = this.resolvePersistentStorageRoute(
-      nodeUri,
-      serviceEndpoints,
-      ['persistentStorageUpdateBucket'],
+    const routeBase =
+      this.baseUrl(nodeUri) +
       `/api/services/persistentStorage/buckets/${encodeURIComponent(bucketId)}`
-    )
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
@@ -1939,18 +1670,6 @@ export class HttpProvider {
   }
 
   // ── Service on Demand ────────────────────────────────────────────────
-
-  // Resolves a /api/services/<route> URL: prefers the node's advertised endpoint
-  // (when present), otherwise falls back to the well-known path.
-  private resolveServiceRoute(
-    nodeUri: string,
-    serviceEndpoints: ServiceEndpoint[],
-    route: string
-  ): string {
-    const endpoint = this.getEndpointURL(serviceEndpoints, route)
-    if (endpoint?.urlPath) return endpoint.urlPath
-    return nodeUri.replace(/\/+$/, '') + `/api/services/${route}`
-  }
 
   // Encrypts userData to the node's public key (ECIES): JSON-encode then encrypt.
   private async encryptServiceUserData(
@@ -1987,9 +1706,7 @@ export class HttpProvider {
     chainId?: number,
     signal?: AbortSignal
   ): Promise<ServiceTemplatePublic[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceTemplates')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceTemplates'
     const url = chainId !== undefined ? `${route}?chainId=${chainId}` : route
     const response = await fetch(url, {
       method: 'GET',
@@ -2015,16 +1732,12 @@ export class HttpProvider {
     params: ServiceStartParams,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceStart')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceStart'
     const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_START,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const { userData, ...rest } = params
     const body: Record<string, any> = {
@@ -2059,16 +1772,12 @@ export class HttpProvider {
     serviceId: string,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceStop')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceStop'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_STOP,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const authHeader = this.getAuthorization(signerOrAuthToken)
     const response = await fetch(route, {
@@ -2097,16 +1806,12 @@ export class HttpProvider {
     payment: ServicePayment,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceExtend')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceExtend'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_EXTEND,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const authHeader = this.getAuthorization(signerOrAuthToken)
     const response = await fetch(route, {
@@ -2154,16 +1859,12 @@ export class HttpProvider {
       dockerCmd,
       dockerEntrypoint
     } = params ?? {}
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceRestart')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceRestart'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_RESTART,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const authHeader = this.getAuthorization(signerOrAuthToken)
     const response = await fetch(route, {
@@ -2204,16 +1905,12 @@ export class HttpProvider {
     serviceId?: string,
     signal?: AbortSignal
   ): Promise<ServiceJob[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceStatus')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceStatus'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_GET_STATUS,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const query = this.buildQuery({
       ...authPayload,
@@ -2244,16 +1941,12 @@ export class HttpProvider {
     filters?: ServiceListFilters,
     signal?: AbortSignal
   ): Promise<ServiceJobListed[]> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(nodeUri, serviceEndpoints, 'serviceList')
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceList'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_LIST,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const query = this.buildQuery({
       ...authPayload,
@@ -2281,20 +1974,12 @@ export class HttpProvider {
     since?: string,
     signal?: AbortSignal
   ): Promise<any> {
-    const providerEndpoints = await this.getEndpoints(nodeUri)
-    const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
-    const route = this.resolveServiceRoute(
-      nodeUri,
-      serviceEndpoints,
-      'serviceGetStreamableLogs'
-    )
+    const route = this.baseUrl(nodeUri) + '/api/services/serviceStreamableLogs'
     const authPayload = await this.getSignedCommandParams(
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.SERVICE_GET_STREAMABLE_LOGS,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     const query = this.buildQuery({
       ...authPayload,

--- a/test/integration/Provider.test.ts
+++ b/test/integration/Provider.test.ts
@@ -71,6 +71,38 @@ describe('Provider tests', async () => {
     assert(Array.isArray(jobs), 'Jobs should be an array')
   })
 
+  it('Alice tests getNodeJobs hits the real /jobs/:job route, not a 404', async function () {
+    // getNodeJobs() swallows both "no jobs" and a 404 into the same [] (see
+    // HttpProvider.getNodeJobs's catch block), so the assertion above can't tell a working
+    // route from a broken one. Hit the exact URL the SDK builds directly to prove the
+    // hardcoded '/api/services/jobs/:job' path (the node's own required, non-optional param -
+    // confirmed by running its real route handler in isolation) still resolves against a live
+    // node instead of regressing to a 404.
+    if (isP2pUri(providerUrl)) this.skip()
+    const response = await fetch(
+      `${providerUrl.replace(/\/+$/, '')}/api/services/jobs/:job`
+    )
+    assert(
+      response.ok,
+      `expected the jobs route to resolve (200), got ${response.status}`
+    )
+    const body = await response.json()
+    assert(Array.isArray(body.jobs), 'response body should contain a jobs array')
+  })
+
+  it('Alice confirms /api/services/jobs without :job 404s against a live node', async function () {
+    // The other half of the story: the node registers this route with a REQUIRED param
+    // (`/jobs/:job`, not `/jobs/:job?`), so dropping the segment entirely isn't an option -
+    // it 404s. This is why the SDK sends the literal placeholder above instead of just
+    // omitting it. Proven here against a live node, not just an isolated route probe.
+    if (isP2pUri(providerUrl)) this.skip()
+    const response = await fetch(`${providerUrl.replace(/\/+$/, '')}/api/services/jobs`)
+    assert(
+      response.status === 404,
+      `expected a 404 without the :job segment, got ${response.status}`
+    )
+  })
+
   it('Alice tests getNonce', async () => {
     const nonce = await ProviderInstance.getNonce(
       config.oceanNodeUri,

--- a/test/integration/PublishEditConsume.test.ts
+++ b/test/integration/PublishEditConsume.test.ts
@@ -13,7 +13,8 @@ import {
   sendTx,
   transfer,
   amountToUnits,
-  StorageObject
+  StorageObject,
+  isP2pUri
 } from '../../src/index.js'
 import { createAssetHelper, orderAsset, updateAssetMetadata } from './helpers.js'
 import { DDO } from '@oceanprotocol/ddo-js'
@@ -238,6 +239,27 @@ describe('Publish consume test', async () => {
     // resolvedGraphqlAssetDdo = await aquarius.waitForIndexer(grapqlAssetId)
     // assert(resolvedGraphqlAssetDdo, 'Cannot fetch graphql DDO from Aquarius')
   }).timeout(80000)
+
+  it('Finds the resolved asset via querySearch', async function () {
+    // querySearch() has no P2P routing (unlike resolve/waitForIndexer/validate) - it only
+    // ever does a raw HTTP POST, so this can't run against a peerId/multiaddr node.
+    if (isP2pUri(config.oceanNodeUri)) this.skip()
+    // Regression guard for the route fix: querySearch() used to POST to
+    // /api/aquarius/assets/query, which the node never registered (always 404). It now posts
+    // to /api/aquarius/assets/metadata/query, so this must actually find the indexed asset.
+    const result = await aquarius.querySearch({
+      query: {
+        bool: {
+          filter: [{ term: { id: urlAssetId } }]
+        }
+      }
+    })
+    const flatResults = ([] as any[]).concat(...(Array.isArray(result) ? result : []))
+    assert(
+      flatResults.some((doc: any) => doc?.id === urlAssetId),
+      'querySearch should find the just-indexed url asset by DID'
+    )
+  }).timeout(30000)
 
   it('Mint datasets datatokens to publisher', async () => {
     datatoken = new Datatoken(publisherAccount, config.chainId)

--- a/test/integration/Services.test.ts
+++ b/test/integration/Services.test.ts
@@ -276,18 +276,25 @@ describe('Service on Demand flow tests', () => {
   it('streams service logs via serviceGetStreamableLogs', async function () {
     if (skipLifecycle || !serviceId) this.skip()
     this.timeout(30000)
-    const result = await ProviderInstance.serviceGetStreamableLogs(
-      providerUrl,
-      consumerAccount,
-      serviceId
-    )
-    // A non-null result proves the route resolved (this is the route that used to 404 by
-    // requesting /api/services/serviceGetStreamableLogs instead of .../serviceStreamableLogs).
-    assert(result, 'expected a streamable logs response, not null')
-    assert(
-      typeof (result as any)[Symbol.asyncIterator] === 'function',
-      'expected an async iterable'
-    )
+    const controller = new AbortController()
+    try {
+      const result = await ProviderInstance.serviceGetStreamableLogs(
+        providerUrl,
+        consumerAccount,
+        serviceId,
+        undefined,
+        controller.signal
+      )
+      // A non-null result proves the route resolved (this is the route that used to 404 by
+      // requesting /api/services/serviceGetStreamableLogs instead of .../serviceStreamableLogs).
+      assert(result, 'expected a streamable logs response, not null')
+      assert(
+        typeof (result as any)[Symbol.asyncIterator] === 'function',
+        'expected an async iterable'
+      )
+    } finally {
+      controller.abort()
+    }
   })
 
   it('returns the service via getServiceStatus (userData stripped)', async function () {

--- a/test/integration/Services.test.ts
+++ b/test/integration/Services.test.ts
@@ -273,6 +273,23 @@ describe('Service on Demand flow tests', () => {
     assert(running.endpoints[0].url, 'endpoint url missing')
   })
 
+  it('streams service logs via serviceGetStreamableLogs', async function () {
+    if (skipLifecycle || !serviceId) this.skip()
+    this.timeout(30000)
+    const result = await ProviderInstance.serviceGetStreamableLogs(
+      providerUrl,
+      consumerAccount,
+      serviceId
+    )
+    // A non-null result proves the route resolved (this is the route that used to 404 by
+    // requesting /api/services/serviceGetStreamableLogs instead of .../serviceStreamableLogs).
+    assert(result, 'expected a streamable logs response, not null')
+    assert(
+      typeof (result as any)[Symbol.asyncIterator] === 'function',
+      'expected an async iterable'
+    )
+  })
+
   it('returns the service via getServiceStatus (userData stripped)', async function () {
     if (skipLifecycle || !serviceId) this.skip()
     const jobs = await ProviderInstance.getServiceStatus(

--- a/test/unit/HttpProviderRoutes.test.ts
+++ b/test/unit/HttpProviderRoutes.test.ts
@@ -1,0 +1,49 @@
+import { assert, expect } from 'chai'
+import { ProviderInstance } from '../../src/index.js'
+
+describe('HttpProvider.getNodeJobs request construction', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  // ocean-node registers this route as `/api/services/jobs/:job` with a REQUIRED (non-optional)
+  // param — confirmed by running the real route in isolation: a request with no segment after
+  // `/jobs/` 404s ("Cannot GET"), one with any literal segment (including the string ":job")
+  // reaches the handler. The node has never given a way to ask for "no filter" here, so the
+  // client sends the literal placeholder the node itself announces in its serviceEndpoints doc.
+  it('requests the literal :job path segment, not an interpolated value', async () => {
+    let requestedUrl: string | undefined
+    let requestedMethod: string | undefined
+    globalThis.fetch = (async (url: string, init?: any) => {
+      requestedUrl = url
+      requestedMethod = init?.method
+      return { ok: true, json: async () => ({ jobs: [] }) } as any
+    }) as any
+
+    const jobs = await ProviderInstance.getNodeJobs('http://127.0.0.1:8001')
+    assert(Array.isArray(jobs), 'should return an array')
+    expect(requestedMethod).to.equal('GET')
+    expect(requestedUrl).to.equal('http://127.0.0.1:8001/api/services/jobs/:job')
+  })
+
+  it('strips a trailing slash from nodeUri and appends fromTimestamp as a query param', async () => {
+    let requestedUrl: string | undefined
+    globalThis.fetch = (async (url: string) => {
+      requestedUrl = url
+      return { ok: true, json: async () => ({ jobs: [] }) } as any
+    }) as any
+
+    await ProviderInstance.getNodeJobs('http://127.0.0.1:8001/', 1700000000)
+    expect(requestedUrl).to.equal(
+      'http://127.0.0.1:8001/api/services/jobs/:job?fromTimestamp=1700000000'
+    )
+  })
+
+  it('returns [] instead of throwing when the node responds with a non-ok status', async () => {
+    globalThis.fetch = (async () => ({ ok: false, status: 404 })) as any
+    const jobs = await ProviderInstance.getNodeJobs('http://127.0.0.1:8001')
+    expect(jobs).to.deep.equal([])
+  })
+})

--- a/test/unit/HttpProviderRoutes.test.ts
+++ b/test/unit/HttpProviderRoutes.test.ts
@@ -8,11 +8,12 @@ describe('HttpProvider.getNodeJobs request construction', () => {
     globalThis.fetch = originalFetch
   })
 
-  // ocean-node registers this route as `/api/services/jobs/:job` with a REQUIRED (non-optional)
-  // param — confirmed by running the real route in isolation: a request with no segment after
-  // `/jobs/` 404s ("Cannot GET"), one with any literal segment (including the string ":job")
-  // reaches the handler. The node has never given a way to ask for "no filter" here, so the
-  // client sends the literal placeholder the node itself announces in its serviceEndpoints doc.
+  // ocean-node registers this route with a REQUIRED (non-optional) path param (named `:jobId`
+  // server-side as of ocean-node#1448, previously `:job`) — confirmed by running the real route
+  // in isolation: a request with no segment after `/jobs/` 404s ("Cannot GET"), one with any
+  // literal segment (including the string ":job") reaches the handler, since Express only cares
+  // that a segment is present, not its content. The node has never given a way to ask for "no
+  // filter" here, so the client sends a literal placeholder segment rather than omitting it.
   it('requests the literal :job path segment, not an interpolated value', async () => {
     let requestedUrl: string | undefined
     let requestedMethod: string | undefined


### PR DESCRIPTION
Closes #2127 
# Hardcode Ocean Node HTTP endpoints, drop root-document discovery

## Summary

Removes the runtime endpoint-discovery dance from `HttpProvider.ts` — every HTTP call used to `GET <nodeUri>/`, parse the announced `serviceEndpoints` map, then look up a path by name before doing the actual request. That "discovery" was an illusion: the announced paths come from a hand-maintained static map shipped in the same ocean-node release as this SDK, not anything that varies per deployment. This PR hardcodes each path directly inside the method that uses it — the same style `Aquarius.ts` already used for 100% of its routes — and fixes two path mismatches that were silently 404ing.

## What changed

### `src/services/providers/HttpProvider.ts`

- All 38 call sites that fetched the root document and resolved a path via `getEndpoints()` → `getServiceEndpoints()` → `getEndpointURL()` now build the literal path inline (e.g. `nodeUri.replace(/\/+$/, '') + '/api/services/nonce'`), matching exactly what the node currently announces for each route.
- Deleted `getServiceEndpoints()` and `getEndpointURL()` — no longer reachable from anywhere.
- Deleted `resolvePersistentStorageRoute()` and `resolveServiceRoute()`, the two "try the announced name, else fall back to a hardcoded path" helpers — every persistent-storage and service-on-demand route already only ever hit the fallback (the node never advertises those names), so this is now just the fallback path, un-conditionally.
- `getEndpoints()` renamed to private `getNodeInfo()`, kept alive **only** for `getNodePublicKey()`, which still needs the root document's `nodePublicKey` field (not a route). `isValidProvider()` is untouched — it already fetched the root URL directly.
- `getSignedCommandParams()` no longer takes `providerEndpoints`/`serviceEndpoints` params — they only existed to avoid double-fetching the root document, which no longer happens at all.
- **Bug fix:** `serviceGetStreamableLogs()` was resolving via the fallback helper to `/api/services/serviceGetStreamableLogs`, but the node registers `/api/services/serviceStreamableLogs` (no "Get") — this call always 404'd. Now hardcoded to the correct path.
- No shared route-table module was introduced. `P2pProvider.ts` dispatches protocol commands, not HTTP paths, so it would've been the table's only other possible consumer — and it doesn't need one.

### `src/services/providers/BaseProvider.ts`

- `getNonce()`'s trailing `providerEndpoints`/`serviceEndpoints` params deleted outright (clean removal, not deprecated-and-ignored) — this ships as part of the v9.0.0 major, so there's no reason to keep dead parameters around. No caller in this repo passed them.

### `src/@types/Provider.ts`

- Deleted the `ServiceEndpoint` interface — it only ever described the now-deleted discovery response shape. Also a clean removal, not a deprecation.

### `src/services/Aquarius.ts`

- **Bug fix:** `querySearch()` POSTed to `/api/aquarius/assets/query`, which doesn't exist on the node — only `/api/aquarius/assets/metadata/query` does. Fixed to the real path. (`Aquarius.ts` had no discovery logic to remove; every route there was already hardcoded.)

### `src/@types/Services.ts`

- Trimmed a comment on `ServiceJobEndpoint` that referenced the now-deleted `ServiceEndpoint` type.

### `test/integration/Services.test.ts`

- Added a test for `serviceGetStreamableLogs()` against a running service, asserting a non-null, async-iterable response — there was no existing coverage for this method, so the bug above had no regression guard.

## Behavior / compatibility

- **Fewer HTTP requests.** Every migrated method drops one root-document fetch (two for persistent-storage/service-on-demand calls, which previously fetched it twice via `getSignedCommandParams`). Chatty flows (compute-status polling, persistent-storage file loops) see the biggest reduction.
- **Behavior change on the error path:** a node that doesn't implement a given route now returns a 404 instead of the SDK silently resolving to `null` (the `if (!path) return null` guards are gone because a hardcoded path is never absent). This is a more honest failure mode — an unreachable node previously also produced `null`, indistinguishable from "route not supported."
- **Two breaking type/signature removals**, both clean (no `@deprecated` shim), justified by this landing in the v9.0.0 major:
  - `BaseProvider.getNonce()` no longer accepts `providerEndpoints`/`serviceEndpoints`.
  - `ServiceEndpoint` type removed from the public export surface.
- **Two behavior fixes**, both previously-404ing routes now resolve correctly:
  - `serviceGetStreamableLogs()` → `/api/services/serviceStreamableLogs`.
  - `Aquarius.querySearch()` → `/api/aquarius/assets/metadata/query`.
- P2P transport (`P2pProvider.ts`) is untouched — verified it makes zero `fetch()` calls; everything there dispatches through `PROTOCOL_COMMANDS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metadata searches to use the correct Aquarius API route.
  * Improved provider request routing for more reliable node, service, job, file, and authentication operations.
  * Corrected handling of job URLs, query parameters, trailing slashes, and unsuccessful responses.

* **Tests**
  * Added coverage for job routes, metadata searches, and streamable service logs.
  * Added validation for successful and invalid job requests, including fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->