### PR TITLE
Feature/auth for policy server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           bash -x start_ocean.sh 2>&1 > start_ocean.log &
         env:
           CONTRACTS_VERSION: '2.9.0'
-          NODE_VERSION: "pr-1408"
+          NODE_VERSION: "pr-1449"
       - name: Install deps & build
         run: npm ci && npm run build:metadata
       - name: Wait for node to be ready
@@ -157,7 +157,7 @@ jobs:
           bash -x start_ocean.sh 2>&1 > start-node.log &
         env:
           CONTRACTS_VERSION: '2.9.0'
-          NODE_VERSION: "pr-1408"
+          NODE_VERSION: "pr-1449"
       - name: Install deps & build
         run: npm ci && npm run build:metadata
 

--- a/src/@types/PolicyServer.ts
+++ b/src/@types/PolicyServer.ts
@@ -1,10 +1,19 @@
 export interface PolicyServerPassthroughCommand {
   policyServerPassthrough?: any
+  // caller identity, verified by the node before anything is forwarded to the policy
+  // server. filled in from the signer / auth token, so any value set here is overwritten
+  consumerAddress?: string
+  nonce?: string
+  signature?: string
 }
 
 export interface PolicyServerInitializeCommand {
   documentId?: string
   serviceId?: string
-  consumerAddress?: string
   policyServer?: any
+  // caller identity, verified by the node before anything is forwarded to the policy
+  // server. filled in from the signer / auth token, so any value set here is overwritten
+  consumerAddress?: string
+  nonce?: string
+  signature?: string
 }

--- a/src/@types/PolicyServer.ts
+++ b/src/@types/PolicyServer.ts
@@ -1,10 +1,5 @@
 export interface PolicyServerPassthroughCommand {
   policyServerPassthrough?: any
-  // caller identity, verified by the node before anything is forwarded to the policy
-  // server. filled in from the signer / auth token, so any value set here is overwritten
-  consumerAddress?: string
-  nonce?: string
-  signature?: string
 }
 
 export interface PolicyServerInitializeCommand {

--- a/src/@types/Provider.ts
+++ b/src/@types/Provider.ts
@@ -129,6 +129,7 @@ export const PROTOCOL_COMMANDS = {
   HANDLE_INDEXING_THREAD: 'handleIndexingThread',
   COLLECT_FEES: 'collectFees',
   POLICY_SERVER_PASSTHROUGH: 'PolicyServerPassthrough',
+  POLICY_SERVER_INITIALIZE: 'PolicyServerInitialize',
   GET_P2P_PEER: 'getP2PPeer',
   GET_P2P_PEERS: 'getP2PPeers',
   GET_P2P_NETWORK_STATS: 'getP2PNetworkStats',

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -643,18 +643,30 @@ export class BaseProvider {
 
   public async PolicyServerPassthrough(
     nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    return this.getImpl(nodeUri).PolicyServerPassthrough(nodeUri, request, signal)
+    return this.getImpl(nodeUri).PolicyServerPassthrough(
+      nodeUri,
+      signerOrAuthToken,
+      request,
+      signal
+    )
   }
 
   public async initializePSVerification(
     nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerInitializeCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    return this.getImpl(nodeUri).initializePSVerification(nodeUri, request, signal)
+    return this.getImpl(nodeUri).initializePSVerification(
+      nodeUri,
+      signerOrAuthToken,
+      request,
+      signal
+    )
   }
 
   public async downloadNodeLogs(

--- a/src/services/providers/BaseProvider.ts
+++ b/src/services/providers/BaseProvider.ts
@@ -643,16 +643,10 @@ export class BaseProvider {
 
   public async PolicyServerPassthrough(
     nodeUri: OceanNode,
-    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    return this.getImpl(nodeUri).PolicyServerPassthrough(
-      nodeUri,
-      signerOrAuthToken,
-      request,
-      signal
-    )
+    return this.getImpl(nodeUri).PolicyServerPassthrough(nodeUri, request, signal)
   }
 
   public async initializePSVerification(

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -924,7 +924,6 @@ export class HttpProvider {
     signal?: AbortSignal,
     includeMetrics?: boolean
   ): Promise<NodeComputeJob | NodeComputeJob[]> {
-    const consumerAddress = await getConsumerAddress(signerOrAuthToken)
     const computeStatusUrl = this.baseUrl(nodeUri) + '/api/services/compute'
     let consumerAddress: string
     let nonce: string
@@ -934,9 +933,7 @@ export class HttpProvider {
         nodeUri,
         signerOrAuthToken,
         PROTOCOL_COMMANDS.COMPUTE_GET_STATUS,
-        signal,
-        providerEndpoints,
-        serviceEndpoints
+        signal
       ))
     } else {
       consumerAddress = await getConsumerAddress(signerOrAuthToken)

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -1341,27 +1341,15 @@ export class HttpProvider {
   }
 
   /** Sends a PolicyServer request to node to be passthrough to PS
-   *
-   * The node authenticates the caller before anything reaches the Policy Server, so a
-   * credential is mandatory: an auth token (sent as the `Authorization` header) or a
-   * signer / precomputed signature over `consumerAddress + nonce + "PolicyServerPassthrough"`.
-   * Requests without one are rejected with a 401. The verified `consumerAddress` is the one
-   * the node forwards, overwriting anything set inside `policyServerPassthrough`.
    * @param {string} nodeUri The provider URI.
-   * @param {SignerOrAuthTokenOrSignature} signerOrAuthToken The consumer signer object, auth token or signature.
    * @param {PolicyServerPassthroughCommand} request The request to be passed through to the Policy Server.
    * @param {AbortSignal} signal abort signal
    */
   public async PolicyServerPassthrough(
     nodeUri: string,
-    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    if (!signerOrAuthToken)
-      throw new Error(
-        'PolicyServerPassthrough failed: a signer, auth token or signature is required.'
-      )
     // the node injects fields into this object, so it has to be a keyed object. arrays are
     // objects too, and would be forwarded as {"0":..,"1":..} with no action
     if (
@@ -1379,29 +1367,13 @@ export class HttpProvider {
       : null
     if (!initializeUrl) return null
 
-    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
-      nodeUri,
-      signerOrAuthToken,
-      PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
-    )
-    if (!isAddress(consumerAddress))
-      throw new Error(
-        `PolicyServerPassthrough failed: could not resolve a valid web3 "consumerAddress" (got "${consumerAddress}") from the supplied credential.`
-      )
-    const body = { ...request, consumerAddress, nonce, signature }
-    const authHeader = this.getAuthorization(signerOrAuthToken)
-
     let response
     try {
       response = await fetch(initializeUrl, {
         method: 'POST',
-        body: JSON.stringify(body),
+        body: JSON.stringify(request),
         headers: {
-          'Content-Type': 'application/json',
-          ...(authHeader ? { Authorization: authHeader } : {})
+          'Content-Type': 'application/json'
         },
         signal
       })
@@ -1421,7 +1393,7 @@ export class HttpProvider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', JSON.stringify(redactSensitiveFields(body)))
+    LoggerInstance.error('Payload was:', JSON.stringify(redactSensitiveFields(request)))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -599,10 +599,6 @@ export class HttpProvider {
         },
         signal
       })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`${errorText}`)
-      }
     } catch (e) {
       LoggerInstance.error('Initialize compute failed: ')
       LoggerInstance.error(e)
@@ -1409,10 +1405,6 @@ export class HttpProvider {
         },
         signal
       })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`${errorText}`)
-      }
     } catch (e) {
       LoggerInstance.error('PolicyServerPassthrough failed: ')
       LoggerInstance.error(e)
@@ -1490,10 +1482,6 @@ export class HttpProvider {
         },
         signal
       })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`${errorText}`)
-      }
     } catch (e) {
       LoggerInstance.error('initializePSVerification failed: ')
       LoggerInstance.error(e)

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -1,5 +1,6 @@
-import { Signer } from 'ethers'
+import { Signer, isAddress } from 'ethers'
 import { LoggerInstance } from '../../utils/Logger.js'
+import { redactSensitiveFields } from '../../utils/General.js'
 import {
   StorageObject,
   FileInfo,
@@ -618,7 +619,10 @@ export class HttpProvider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', JSON.stringify(providerData))
+    LoggerInstance.error(
+      'Payload was:',
+      JSON.stringify(redactSensitiveFields(providerData))
+    )
     throw new Error(JSON.stringify(resolvedResponse))
   }
 
@@ -790,7 +794,7 @@ export class HttpProvider {
     } catch (e) {
       LoggerInstance.error('Compute start failed:')
       LoggerInstance.error(e)
-      LoggerInstance.error('Payload was:', payload)
+      LoggerInstance.error('Payload was:', redactSensitiveFields(payload))
       throw new Error('HTTP request failed calling Provider')
     }
     if (response?.ok) {
@@ -804,7 +808,7 @@ export class HttpProvider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', payload)
+    LoggerInstance.error('Payload was:', redactSensitiveFields(payload))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 
@@ -909,7 +913,7 @@ export class HttpProvider {
     } catch (e) {
       LoggerInstance.error('Compute start failed:')
       LoggerInstance.error(e)
-      LoggerInstance.error('Payload was:', payload)
+      LoggerInstance.error('Payload was:', redactSensitiveFields(payload))
       throw new Error('HTTP request failed calling Provider')
     }
     if (response?.ok) {
@@ -923,7 +927,7 @@ export class HttpProvider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', payload)
+    LoggerInstance.error('Payload was:', redactSensitiveFields(payload))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 
@@ -1341,15 +1345,37 @@ export class HttpProvider {
   }
 
   /** Sends a PolicyServer request to node to be passthrough to PS
+   *
+   * The node authenticates the caller before anything reaches the Policy Server, so a
+   * credential is mandatory: an auth token (sent as the `Authorization` header) or a
+   * signer / precomputed signature over `consumerAddress + nonce + "PolicyServerPassthrough"`.
+   * Requests without one are rejected with a 401. The verified `consumerAddress` is the one
+   * the node forwards, overwriting anything set inside `policyServerPassthrough`.
    * @param {string} nodeUri The provider URI.
+   * @param {SignerOrAuthTokenOrSignature} signerOrAuthToken The consumer signer object, auth token or signature.
    * @param {PolicyServerPassthroughCommand} request The request to be passed through to the Policy Server.
    * @param {AbortSignal} signal abort signal
    */
   public async PolicyServerPassthrough(
     nodeUri: string,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
+    if (!signerOrAuthToken)
+      throw new Error(
+        'PolicyServerPassthrough failed: a signer, auth token or signature is required.'
+      )
+    // the node injects fields into this object, so it has to be a keyed object. arrays are
+    // objects too, and would be forwarded as {"0":..,"1":..} with no action
+    if (
+      !request?.policyServerPassthrough ||
+      typeof request.policyServerPassthrough !== 'object' ||
+      Array.isArray(request.policyServerPassthrough)
+    )
+      throw new Error(
+        'PolicyServerPassthrough failed: "policyServerPassthrough" must be an object.'
+      )
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const initializeUrl = this.getEndpointURL(serviceEndpoints, 'PolicyServerPassthrough')
@@ -1357,13 +1383,29 @@ export class HttpProvider {
       : null
     if (!initializeUrl) return null
 
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
+    if (!isAddress(consumerAddress))
+      throw new Error(
+        'PolicyServerPassthrough failed: "consumerAddress" is not a valid web3 address.'
+      )
+    const body = { ...request, consumerAddress, nonce, signature }
+    const authHeader = this.getAuthorization(signerOrAuthToken)
+
     let response
     try {
       response = await fetch(initializeUrl, {
         method: 'POST',
-        body: JSON.stringify(request),
+        body: JSON.stringify(body),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -1387,20 +1429,31 @@ export class HttpProvider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', JSON.stringify(request))
+    LoggerInstance.error('Payload was:', JSON.stringify(redactSensitiveFields(body)))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 
   /** Initialize Policy Server verification
+   *
+   * Authenticated exactly like `PolicyServerPassthrough`, but it is a distinct command, so
+   * the signed message uses its own command string:
+   * `consumerAddress + nonce + "PolicyServerInitialize"`. A signature is therefore scoped to
+   * one endpoint and cannot be replayed against the other.
    * @param {string} nodeUri The provider URI.
+   * @param {SignerOrAuthTokenOrSignature} signerOrAuthToken The consumer signer object, auth token or signature.
    * @param {PolicyServerInitializeCommand} request The request to be sent to the Policy Server.
    * @param {AbortSignal} signal abort signal
    */
   public async initializePSVerification(
     nodeUri: string,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerInitializeCommand,
     signal?: AbortSignal
   ): Promise<any> {
+    if (!signerOrAuthToken)
+      throw new Error(
+        'initializePSVerification failed: a signer, auth token or signature is required.'
+      )
     const providerEndpoints = await this.getEndpoints(nodeUri)
     const serviceEndpoints = await this.getServiceEndpoints(nodeUri, providerEndpoints)
     const initializeUrl = this.getEndpointURL(
@@ -1411,13 +1464,29 @@ export class HttpProvider {
       : null
     if (!initializeUrl) return null
 
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.POLICY_SERVER_INITIALIZE,
+      signal,
+      providerEndpoints,
+      serviceEndpoints
+    )
+    if (!isAddress(consumerAddress))
+      throw new Error(
+        'initializePSVerification failed: "consumerAddress" is not a valid web3 address.'
+      )
+    const body = { ...request, consumerAddress, nonce, signature }
+    const authHeader = this.getAuthorization(signerOrAuthToken)
+
     let response
     try {
       response = await fetch(initializeUrl, {
         method: 'POST',
-        body: JSON.stringify(request),
+        body: JSON.stringify(body),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(authHeader ? { Authorization: authHeader } : {})
         },
         signal
       })
@@ -1441,7 +1510,7 @@ export class HttpProvider {
       response.statusText,
       resolvedResponse
     )
-    LoggerInstance.error('Payload was:', JSON.stringify(request))
+    LoggerInstance.error('Payload was:', JSON.stringify(redactSensitiveFields(body)))
     throw new Error(JSON.stringify(resolvedResponse))
   }
 

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -1393,7 +1393,7 @@ export class HttpProvider {
     )
     if (!isAddress(consumerAddress))
       throw new Error(
-        'PolicyServerPassthrough failed: "consumerAddress" is not a valid web3 address.'
+        `PolicyServerPassthrough failed: could not resolve a valid web3 "consumerAddress" (got "${consumerAddress}") from the supplied credential.`
       )
     const body = { ...request, consumerAddress, nonce, signature }
     const authHeader = this.getAuthorization(signerOrAuthToken)
@@ -1474,7 +1474,7 @@ export class HttpProvider {
     )
     if (!isAddress(consumerAddress))
       throw new Error(
-        'initializePSVerification failed: "consumerAddress" is not a valid web3 address.'
+        `initializePSVerification failed: could not resolve a valid web3 "consumerAddress" (got "${consumerAddress}") from the supplied credential.`
       )
     const body = { ...request, consumerAddress, nonce, signature }
     const authHeader = this.getAuthorization(signerOrAuthToken)

--- a/src/services/providers/HttpProvider.ts
+++ b/src/services/providers/HttpProvider.ts
@@ -1242,9 +1242,7 @@ export class HttpProvider {
       nodeUri,
       signerOrAuthToken,
       PROTOCOL_COMMANDS.POLICY_SERVER_INITIALIZE,
-      signal,
-      providerEndpoints,
-      serviceEndpoints
+      signal
     )
     if (!isAddress(consumerAddress))
       throw new Error(

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -11,7 +11,7 @@ import { ping } from '@libp2p/ping'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { lpStream, UnexpectedEOFError } from '@libp2p/utils'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
-import { Signer } from 'ethers'
+import { Signer, isAddress } from 'ethers'
 import { sleep } from '../../utils/General.js'
 import { LoggerInstance } from '../../utils/Logger.js'
 import { concatUint8Arrays } from '../../utils/bytes.js'
@@ -1501,34 +1501,81 @@ export class P2pProvider {
 
   /**
    * PolicyServer passthrough via P2P.
+   *
+   * The node authenticates the caller before anything reaches the Policy Server: the
+   * signed message is `consumerAddress + nonce + "PolicyServerPassthrough"`, or an auth
+   * token is sent instead. Requests without a credential are rejected with a 401.
    */
   public async PolicyServerPassthrough(
     nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
+    if (!signerOrAuthToken)
+      throw new Error(
+        'PolicyServerPassthrough failed: a signer, auth token or signature is required.'
+      )
+    // the node injects fields into this object, so it has to be a keyed object. arrays are
+    // objects too, and would be forwarded as {"0":..,"1":..} with no action
+    if (
+      !request?.policyServerPassthrough ||
+      typeof request.policyServerPassthrough !== 'object' ||
+      Array.isArray(request.policyServerPassthrough)
+    )
+      throw new Error(
+        'PolicyServerPassthrough failed: "policyServerPassthrough" must be an object.'
+      )
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
+      signal
+    )
+    if (!isAddress(consumerAddress))
+      throw new Error(
+        'PolicyServerPassthrough failed: "consumerAddress" is not a valid web3 address.'
+      )
     return this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
-      { ...request },
-      null,
+      { ...request, consumerAddress, nonce, signature },
+      signerOrAuthToken,
       signal
     )
   }
 
   /**
    * Initialize Policy Server verification via P2P.
+   *
+   * A distinct command from the passthrough, so the signed message uses its own command
+   * string: `consumerAddress + nonce + "PolicyServerInitialize"`.
    */
   public async initializePSVerification(
     nodeUri: OceanNode,
+    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerInitializeCommand,
     signal?: AbortSignal
   ): Promise<any> {
+    if (!signerOrAuthToken)
+      throw new Error(
+        'initializePSVerification failed: a signer, auth token or signature is required.'
+      )
+    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
+      nodeUri,
+      signerOrAuthToken,
+      PROTOCOL_COMMANDS.POLICY_SERVER_INITIALIZE,
+      signal
+    )
+    if (!isAddress(consumerAddress))
+      throw new Error(
+        'initializePSVerification failed: "consumerAddress" is not a valid web3 address.'
+      )
     return this.sendP2pCommand(
       nodeUri,
-      PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
-      { ...request },
-      null,
+      PROTOCOL_COMMANDS.POLICY_SERVER_INITIALIZE,
+      { ...request, consumerAddress, nonce, signature },
+      signerOrAuthToken,
       signal
     )
   }

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -1501,21 +1501,12 @@ export class P2pProvider {
 
   /**
    * PolicyServer passthrough via P2P.
-   *
-   * The node authenticates the caller before anything reaches the Policy Server: the
-   * signed message is `consumerAddress + nonce + "PolicyServerPassthrough"`, or an auth
-   * token is sent instead. Requests without a credential are rejected with a 401.
    */
   public async PolicyServerPassthrough(
     nodeUri: OceanNode,
-    signerOrAuthToken: SignerOrAuthTokenOrSignature,
     request: PolicyServerPassthroughCommand,
     signal?: AbortSignal
   ): Promise<any> {
-    if (!signerOrAuthToken)
-      throw new Error(
-        'PolicyServerPassthrough failed: a signer, auth token or signature is required.'
-      )
     // the node injects fields into this object, so it has to be a keyed object. arrays are
     // objects too, and would be forwarded as {"0":..,"1":..} with no action
     if (
@@ -1526,21 +1517,11 @@ export class P2pProvider {
       throw new Error(
         'PolicyServerPassthrough failed: "policyServerPassthrough" must be an object.'
       )
-    const { consumerAddress, nonce, signature } = await this.getSignedCommandParams(
-      nodeUri,
-      signerOrAuthToken,
-      PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
-      signal
-    )
-    if (!isAddress(consumerAddress))
-      throw new Error(
-        `PolicyServerPassthrough failed: could not resolve a valid web3 "consumerAddress" (got "${consumerAddress}") from the supplied credential.`
-      )
     return this.sendP2pCommand(
       nodeUri,
       PROTOCOL_COMMANDS.POLICY_SERVER_PASSTHROUGH,
-      { ...request, consumerAddress, nonce, signature },
-      signerOrAuthToken,
+      { ...request },
+      null,
       signal
     )
   }

--- a/src/services/providers/P2pProvider.ts
+++ b/src/services/providers/P2pProvider.ts
@@ -1534,7 +1534,7 @@ export class P2pProvider {
     )
     if (!isAddress(consumerAddress))
       throw new Error(
-        'PolicyServerPassthrough failed: "consumerAddress" is not a valid web3 address.'
+        `PolicyServerPassthrough failed: could not resolve a valid web3 "consumerAddress" (got "${consumerAddress}") from the supplied credential.`
       )
     return this.sendP2pCommand(
       nodeUri,
@@ -1569,7 +1569,7 @@ export class P2pProvider {
     )
     if (!isAddress(consumerAddress))
       throw new Error(
-        'initializePSVerification failed: "consumerAddress" is not a valid web3 address.'
+        `initializePSVerification failed: could not resolve a valid web3 "consumerAddress" (got "${consumerAddress}") from the supplied credential.`
       )
     return this.sendP2pCommand(
       nodeUri,

--- a/src/utils/General.ts
+++ b/src/utils/General.ts
@@ -13,12 +13,14 @@ export function isDefined(something: any): boolean {
 }
 
 // credentials present on (almost) any payload we send to a node. these must never reach
-// the logs, since they are what authorizes the request in the first place
+// the logs, since they are what authorizes the request in the first place.
+// lowercase: keys are matched case-insensitively, since a header-cased "Authorization" or a
+// caller's own casing inside the free-form policy server blobs leaks just as badly
 const SENSITIVE_PAYLOAD_FIELDS = [
   'authorization', // auth token (JWT), usually sent on the Authorization header
   'signature', // consumer signature authorizing this command
   'aes_encrypted_key', // download: encrypted key material
-  'encryptedDockerRegistryAuth' // compute: encrypted docker registry credentials
+  'encrypteddockerregistryauth' // compute: encrypted docker registry credentials
 ]
 
 const REDACTED = '[REDACTED]'
@@ -60,7 +62,7 @@ export function redactSensitiveFields(
   seen.add(value)
   const copy: any = {}
   for (const [key, item] of Object.entries(value)) {
-    if (SENSITIVE_PAYLOAD_FIELDS.includes(key)) {
+    if (SENSITIVE_PAYLOAD_FIELDS.includes(key.toLowerCase())) {
       copy[key] = isDefined(item) ? REDACTED : item
     } else {
       copy[key] = redactSensitiveFields(item, seen)

--- a/src/utils/General.ts
+++ b/src/utils/General.ts
@@ -11,3 +11,61 @@ export async function sleep(ms: number) {
 export function isDefined(something: any): boolean {
   return something !== undefined && something !== null
 }
+
+// credentials present on (almost) any payload we send to a node. these must never reach
+// the logs, since they are what authorizes the request in the first place
+const SENSITIVE_PAYLOAD_FIELDS = [
+  'authorization', // auth token (JWT), usually sent on the Authorization header
+  'signature', // consumer signature authorizing this command
+  'aes_encrypted_key', // download: encrypted key material
+  'encryptedDockerRegistryAuth' // compute: encrypted docker registry credentials
+]
+
+const REDACTED = '[REDACTED]'
+
+/**
+ * Returns a copy of the payload with every credential field redacted, at any depth.
+ *
+ * This must not mutate its input: the caller still needs the real credentials to send the
+ * request, and credentials also show up nested (the free-form `policyServer` /
+ * `policyServerPassthrough` blobs), so we rebuild containers instead of writing into them.
+ *
+ * Only plain objects and arrays are walked - Buffers, typed arrays, Dates, streams and the
+ * like are passed through untouched.
+ *
+ * @param {any} value - the payload to redact
+ * @param {WeakSet<object>} seen - internal cycle guard
+ * @return {any} a redacted copy, safe to log
+ */
+export function redactSensitiveFields(
+  value: any,
+  seen: WeakSet<object> = new WeakSet()
+): any {
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+  if (seen.has(value)) {
+    return '[CIRCULAR]'
+  }
+  if (Array.isArray(value)) {
+    seen.add(value)
+    const copy = value.map((item) => redactSensitiveFields(item, seen))
+    seen.delete(value)
+    return copy
+  }
+  const proto = Object.getPrototypeOf(value)
+  if (proto !== Object.prototype && proto !== null) {
+    return value
+  }
+  seen.add(value)
+  const copy: any = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (SENSITIVE_PAYLOAD_FIELDS.includes(key)) {
+      copy[key] = isDefined(item) ? REDACTED : item
+    } else {
+      copy[key] = redactSensitiveFields(item, seen)
+    }
+  }
+  seen.delete(value)
+  return copy
+}


### PR DESCRIPTION
# Authenticate the PolicyServer calls, and stop logging credentials

## What

Client-side counterpart to ocean-node
[#1449](https://github.com/oceanprotocol/ocean-node/pull/1449) ("Authenticate
`PolicyServerPassthrough` / `initializePSVerification`, and stop logging credentials").

Both PolicyServer endpoints are now authenticated by the node: a caller must supply an
`Authorization` token or a `nonce` + `signature` pair together with `consumerAddress`, or
the request is rejected with `401` and never reaches the PolicyServer. `initializePSVerification`
also became its own protocol command (`PolicyServerInitialize`) so a signature is scoped to
one endpoint and cannot be replayed against the other.

Until now `ProviderInstance.PolicyServerPassthrough()` and
`ProviderInstance.initializePSVerification()` POSTed the caller's request object verbatim,
with no `Authorization` header and no identity fields — against a node carrying #1449 **both
calls would start failing with 401**. This PR makes them carry credentials the same way every
other authenticated Provider method already does, on both the HTTP and P2P transports, and
mirrors the node's third fix (credential redaction) on the client's own log lines.

## Semantics (mirrors the node)

- Credentials are derived from a `SignerOrAuthTokenOrSignature` via the existing
  `getSignedCommandParams()`: a `Signer` fetches `getNonce()+1` and signs
  `consumerAddress + nonce + <command>`; a JWT string is sent as the `Authorization` header;
  a precomputed `CompleteSignature` is forwarded as-is.
- The signed message differs per endpoint, matching the node:
  | method | command | signed message |
  | --- | --- | --- |
  | `PolicyServerPassthrough` | `PolicyServerPassthrough` | `consumerAddress + nonce + "PolicyServerPassthrough"` |
  | `initializePSVerification` | `PolicyServerInitialize` | `consumerAddress + nonce + "PolicyServerInitialize"` |
- The derived identity always wins over anything the caller put in the request object —
  the node overwrites those fields after verification anyway, so sending a different value
  would only produce a confusing mismatch.
- The caller's auth token is relayed by the node to the PolicyServer, so `POLICY_SERVER_URL`
  should be an operator-controlled HTTPS endpoint (see the node's `docs/PolicyServer.md`).

## Changes

- `src/@types/Provider.ts` — added `POLICY_SERVER_INITIALIZE: 'PolicyServerInitialize'` to
  `PROTOCOL_COMMANDS`.
- `src/@types/PolicyServer.ts` — `PolicyServerPassthroughCommand` gains optional
  `consumerAddress`/`nonce`/`signature`; `PolicyServerInitializeCommand` gains `nonce`/
  `signature`. Documented inline as node-verified identity that the lib fills in.
- `src/services/providers/HttpProvider.ts` — both methods take `signerOrAuthToken` as the
  new 2nd argument, resolve credentials through `getSignedCommandParams()`, send them in the
  body and set the `Authorization` header when a token is used.
- `src/services/providers/P2pProvider.ts` — same signature change; credentials are added to
  the P2P payload and `signerOrAuthToken` is now passed to `sendP2pCommand` (was `null`), so
  the `authorization` field actually reaches the node.
  **Bug fix:** `initializePSVerification` was sending the `PolicyServerPassthrough` command —
  the same bug #1449 fixed on the node's HTTP route — and so hit the wrong handler. It now
  sends `PolicyServerInitialize`.
- `src/services/providers/BaseProvider.ts` — façade signatures updated to thread the new
  argument through to the HTTP/P2P implementation.
- `src/utils/General.ts` — new exported `redactSensitiveFields()`, ported from the node's
  `validateCommands.ts`: a non-mutating recursive walk over plain objects/arrays that masks
  `authorization`, `signature`, `aes_encrypted_key` and `encryptedDockerRegistryAuth` with
  `[REDACTED]`, with a `WeakSet` cycle guard (`[CIRCULAR]`) and pass-through for non-plain
  objects (Buffers, Dates, streams).
- `src/services/providers/HttpProvider.ts` — every `LoggerInstance.error('Payload was:', …)`
  site now logs the redacted copy: `initializeCompute`, `computeStart`, `freeComputeStart`
  (all of which dumped the consumer's signature and encrypted docker/registry material on
  any failure) plus the two PolicyServer methods.

### Client-side guards

Rather than round-tripping to get the node's new `400`s, the lib now throws early on:

- a missing credential — `"a signer, auth token or signature is required"`;
- a `policyServerPassthrough` that is missing, not an object, or an **array** (arrays would
  be forwarded as `{"0":…,"1":…}` with no `action`);
- a resolved `consumerAddress` that fails ethers `isAddress`.

## Compatibility

- **Breaking (client API):** `PolicyServerPassthrough(nodeUri, request, signal?)` →
  `PolicyServerPassthrough(nodeUri, signerOrAuthToken, request, signal?)`, and identically
  for `initializePSVerification`. Callers on `9.0.0-next.*` must insert the credential as the
  second argument. There are no in-repo callers outside `BaseProvider`.
  ```ts
  await ProviderInstance.PolicyServerPassthrough(
    nodeUri,
    signerOrAuthToken,                 // Signer | JWT string | CompleteSignature
    { policyServerPassthrough: { action: 'newDDO', rawDDO: {} } }
  )
  ```
- **Node requirement:** the credentials are additive on the wire, so the calls keep working
  against a pre- # 1449 node (which simply ignores the extra fields). The P2P
  `PolicyServerInitialize` command, however, only exists on nodes carrying # 1449 — against an
  older node that P2P call now hits an unsupported command instead of silently reaching the
  passthrough handler.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated Policy Server initialization and passthrough requests.
  * Added support for consumer addresses, nonces, and signatures in Policy Server commands.
  * Added a dedicated Policy Server initialization command.

* **Security**
  * Sensitive credentials are now redacted from error logs.
  * Requests validate consumer addresses and include authentication details securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->