### PR TITLE
use node 22 & 24 to test builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: ["22", "20"]
+        node: ["22", "24"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION

Changes proposed in this PR:

- test build with node 22 & 24
- remove node v20
- 